### PR TITLE
Fix performance of groupify

### DIFF
--- a/lib/pact_broker/domain/relationship.rb
+++ b/lib/pact_broker/domain/relationship.rb
@@ -35,7 +35,7 @@ module PactBroker
       end
 
       def connected? other
-        (self.to_a & other.to_a).any?
+        include?(other.consumer) || include?(other.provider)
       end
 
       def include? pacticipant

--- a/spec/lib/pact_broker/relationships/groupify_spec.rb
+++ b/spec/lib/pact_broker/relationships/groupify_spec.rb
@@ -10,18 +10,18 @@ module PactBroker
 
       describe ".call" do
 
-        let(:consumer_a) { double('consumer a', name: 'consumer a') }
-        let(:consumer_b) { double('consumer b', name: 'consumer b') }
-        let(:consumer_c) { double('consumer c', name: 'consumer c') }
+        let(:consumer_a) { double('consumer a', id: 1, name: 'consumer a') }
+        let(:consumer_b) { double('consumer b', id: 2, name: 'consumer b') }
+        let(:consumer_c) { double('consumer c', id: 3, name: 'consumer c') }
 
-        let(:consumer_l) { double('consumer l', name: 'consumer l') }
-        let(:consumer_m) { double('consumer m', name: 'consumer m') }
+        let(:consumer_l) { double('consumer l', id: 4, name: 'consumer l') }
+        let(:consumer_m) { double('consumer m', id: 5, name: 'consumer m') }
 
-        let(:provider_p) { double('provider p', name: 'provider p') }
+        let(:provider_p) { double('provider p', id: 6, name: 'provider p') }
 
-        let(:provider_x) { double('provider x', name: 'provider x') }
-        let(:provider_y) { double('provider y', name: 'provider y') }
-        let(:provider_z) { double('provider z', name: 'provider z') }
+        let(:provider_x) { double('provider x', id: 7, name: 'provider x') }
+        let(:provider_y) { double('provider y', id: 8, name: 'provider y') }
+        let(:provider_z) { double('provider z', id: 9, name: 'provider z') }
 
 
         let(:relationship_1) { Domain::Relationship.new(consumer_a, provider_x) }
@@ -34,7 +34,7 @@ module PactBroker
         let(:relationship_5) { Domain::Relationship.new(consumer_l, provider_p) }
         let(:relationship_6) { Domain::Relationship.new(consumer_m, provider_p) }
 
-        let(:relationships) { [relationship_1, relationship_2, relationship_3, relationship_4, relationship_5, relationship_6 ]}
+        let(:relationships) { [relationship_1, relationship_2, relationship_3, relationship_4, relationship_5, relationship_6] }
 
         it "separates the relationships into isolated groups" do
           groups = Groupify.call(relationships)


### PR DESCRIPTION
Hi,

We found that with 90 relationships trying to render the relationship graph in the UI was taking about 12 hours to complete. 

With 70 or so relationships it took 12 seconds. We got this down to a couple of seconds by improving the efficiency of the 'connected?' method, but it was still taking all day to groupify 90 nodes. So I removed the recursion and it seemed to fix the problem. I've attached a code profile of the recurse_group method before and after the patch.

Cheers,

[profile_post_patch.html.txt](https://github.com/bethesque/pact_broker/files/143972/profile_post_patch.html.txt)
[profile_pre_patch.html.txt](https://github.com/bethesque/pact_broker/files/143973/profile_pre_patch.html.txt)
