### PR TITLE
Append `charset=utf-8` to `Content-Type` header

### DIFF
--- a/lib/pact_broker/api/resources/base_resource.rb
+++ b/lib/pact_broker/api/resources/base_resource.rb
@@ -68,12 +68,12 @@ module PactBroker
         end
 
         def set_json_error_message message
-          response.headers['Content-Type'] = 'application/json'
+          response.headers['Content-Type'] = 'application/json;charset=utf-8'
           response.body = {error: message}.to_json
         end
 
         def set_json_validation_error_messages errors
-          response.headers['Content-Type'] = 'application/json'
+          response.headers['Content-Type'] = 'application/json;charset=utf-8'
           response.body = {errors: errors}.to_json
         end
 
@@ -96,7 +96,7 @@ module PactBroker
           rescue StandardError => e
             logger.error "Error parsing JSON #{e} - #{request_body}"
             set_json_error_message "Error parsing JSON - #{e.message}"
-            response.headers['Content-Type'] = 'application/json'
+            response.headers['Content-Type'] = 'application/json;charset=utf-8'
             true
           end
         end

--- a/lib/pact_broker/api/resources/base_resource.rb
+++ b/lib/pact_broker/api/resources/base_resource.rb
@@ -42,6 +42,15 @@ module PactBroker
           request.base_uri.to_s.chomp('/')
         end
 
+        def charsets_provided
+          [['utf-8', :encode]]
+        end
+
+        # We only use utf-8 so leave encoding as it is
+        def encode(body)
+          body
+        end
+
         def resource_url
           request.uri.to_s
         end

--- a/lib/pact_broker/api/resources/pact_webhooks.rb
+++ b/lib/pact_broker/api/resources/pact_webhooks.rb
@@ -36,7 +36,7 @@ module PactBroker
 
         def validation_errors? webhook
           if (errors = webhook_service.errors(webhook)).any?
-            response.headers['Content-Type'] = 'application/json'
+            response.headers['Content-Type'] = 'application/json;charset=utf-8'
             response.body = {errors: errors.full_messages }.to_json
           end
           errors.any?

--- a/lib/pact_broker/api/resources/webhook_execution.rb
+++ b/lib/pact_broker/api/resources/webhook_execution.rb
@@ -13,7 +13,7 @@ module PactBroker
 
         def process_post
           webhook_execution_result = webhook_service.execute_webhook_now webhook
-          response.headers['Content-Type'] = 'application/hal+json'
+          response.headers['Content-Type'] = 'application/hal+json;charset=utf-8'
           response.body = post_response_body webhook_execution_result
           webhook_execution_result.success? ? true : 500
         end

--- a/spec/features/create_webhook_spec.rb
+++ b/spec/features/create_webhook_spec.rb
@@ -65,7 +65,7 @@ describe "Creating a webhook" do
 
     it "returns a JSON Content Type" do
       subject
-      expect(last_response.headers['Content-Type']).to eq 'application/hal+json'
+      expect(last_response.headers['Content-Type']).to eq 'application/hal+json;charset=utf-8'
     end
 
     it "returns the newly created webhook" do

--- a/spec/features/create_webhook_spec.rb
+++ b/spec/features/create_webhook_spec.rb
@@ -24,7 +24,7 @@ describe "Creating a webhook" do
 
     it "returns a JSON content type" do
       subject
-      expect(last_response.headers['Content-Type']).to eq 'application/json'
+      expect(last_response.headers['Content-Type']).to eq 'application/json;charset=utf-8'
     end
 
     it "returns the validation errors" do

--- a/spec/features/publish_pact_spec.rb
+++ b/spec/features/publish_pact_spec.rb
@@ -12,7 +12,7 @@ describe "Publishing a pact" do
     end
 
     it "returns a json body" do
-      expect(subject.headers['Content-Type']).to eq "application/json"
+      expect(subject.headers['Content-Type']).to eq "application/json;charset=utf-8"
     end
 
     it "returns the pact in the body" do
@@ -31,7 +31,7 @@ describe "Publishing a pact" do
     end
 
     it "returns an application/json Content-Type" do
-      expect(subject.headers['Content-Type']).to eq "application/json"
+      expect(subject.headers['Content-Type']).to eq "application/json;charset=utf-8"
     end
 
     it "returns the pact in the response body" do

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -126,7 +126,7 @@ module PactBroker
 
         it "returns the CSV Content-Type" do
           expect(subject.status).to eq 200
-          expect(subject.headers['Content-Type']).to eq "text/csv"
+          expect(subject.headers['Content-Type']).to eq "text/csv;charset=utf-8"
         end
       end
 

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -15,7 +15,7 @@ module PactBroker
     let(:enable_diagnostic_endpoints) { false }
 
     let(:app) do
-      app = PactBroker::App.new do | config |
+      PactBroker::App.new do | config |
         config.auto_migrate_db = false
         config.use_hal_browser = hal_browser_enabled
         config.database_connection = ::DB::PACT_BROKER_DB

--- a/spec/lib/pact_broker/api/resources/group_spec.rb
+++ b/spec/lib/pact_broker/api/resources/group_spec.rb
@@ -52,7 +52,7 @@ module PactBroker::Api
 
           it "returns a CSV content type" do
             subject
-            expect(last_response.headers['Content-Type']).to eq 'text/csv'
+            expect(last_response.headers['Content-Type']).to eq 'text/csv;charset=utf-8'
           end
 
           it "returns a CSV of pacticipants that are in the same group as the given pacticipant" do

--- a/spec/lib/pact_broker/api/resources/latest_pact_spec.rb
+++ b/spec/lib/pact_broker/api/resources/latest_pact_spec.rb
@@ -45,7 +45,7 @@ module PactBroker::Api
 
           it "returns a content type of HTML" do
             subject
-            expect(last_response.headers['Content-Type']).to eq 'text/html'
+            expect(last_response.headers['Content-Type']).to eq 'text/html;charset=utf-8'
           end
 
         end

--- a/spec/lib/pact_broker/api/resources/pact_spec.rb
+++ b/spec/lib/pact_broker/api/resources/pact_spec.rb
@@ -28,7 +28,7 @@ module PactBroker::Api
           end
 
           it "returns a JSON content type" do
-            expect(response.headers['Content-Type']).to eq "application/json"
+            expect(response.headers['Content-Type']).to eq "application/json;charset=utf-8"
           end
 
           it "returns an error message" do

--- a/spec/lib/pact_broker/api/resources/pact_webhooks_spec.rb
+++ b/spec/lib/pact_broker/api/resources/pact_webhooks_spec.rb
@@ -165,7 +165,7 @@ module PactBroker::Api
 
           it "returns a JSON content type" do
             subject
-            expect(last_response.headers['Content-Type']).to eq 'application/hal+json'
+            expect(last_response.headers['Content-Type']).to eq 'application/hal+json;charset=utf-8'
           end
 
           it "generates the JSON response body" do

--- a/spec/lib/pact_broker/api/resources/pact_webhooks_spec.rb
+++ b/spec/lib/pact_broker/api/resources/pact_webhooks_spec.rb
@@ -90,7 +90,7 @@ module PactBroker::Api
 
           it "returns a JSON content type" do
             subject
-            expect(last_response.headers['Content-Type']).to eq 'application/json'
+            expect(last_response.headers['Content-Type']).to eq 'application/json;charset=utf-8'
           end
 
           it "returns an error message" do
@@ -108,7 +108,7 @@ module PactBroker::Api
 
           it "returns a JSON content type" do
             subject
-            expect(last_response.headers['Content-Type']).to eq 'application/json'
+            expect(last_response.headers['Content-Type']).to eq 'application/json;charset=utf-8'
           end
 
           it "returns an error message" do
@@ -129,7 +129,7 @@ module PactBroker::Api
 
           it "returns a JSON content type" do
             subject
-            expect(last_response.headers['Content-Type']).to eq 'application/json'
+            expect(last_response.headers['Content-Type']).to eq 'application/json;charset=utf-8'
           end
 
           it "returns the validation errors" do

--- a/spec/lib/pact_broker/api/resources/pacticipants_spec.rb
+++ b/spec/lib/pact_broker/api/resources/pacticipants_spec.rb
@@ -63,7 +63,7 @@ module PactBroker
 
             it "returns a Content-Type of application/hal+json" do
               subject
-              expect(last_response.headers['Content-Type']).to eq 'application/hal+json'
+              expect(last_response.headers['Content-Type']).to eq 'application/hal+json;charset=utf-8'
             end
 
             it "creates a JSON representation of the new pacticipant" do

--- a/spec/support/shared_examples_for_responses.rb
+++ b/spec/support/shared_examples_for_responses.rb
@@ -14,7 +14,7 @@ require 'rspec/expectations'
 RSpec::Matchers.define :be_a_hal_json_success_response do
   match do | actual |
     expect(actual.status).to be 200
-    expect(actual.headers['Content-Type']).to eq 'application/hal+json'
+    expect(actual.headers['Content-Type']).to eq 'application/hal+json;charset=utf-8'
   end
 end
 

--- a/spec/support/shared_examples_for_responses.rb
+++ b/spec/support/shared_examples_for_responses.rb
@@ -20,14 +20,14 @@ end
 
 RSpec::Matchers.define :be_a_json_response do
   match do | actual |
-    expect(actual.headers['Content-Type']).to eq 'application/json'
+    expect(actual.headers['Content-Type']).to eq 'application/json;charset=utf-8'
   end
 end
 
 RSpec::Matchers.define :be_a_json_error_response do | message |
   match do | actual |
     expect(actual.status).to be 400
-    expect(actual.headers['Content-Type']).to eq 'application/json'
+    expect(actual.headers['Content-Type']).to eq 'application/json;charset=utf-8'
     expect(actual.body).to include message
   end
 end


### PR DESCRIPTION
Pact reads pact file with open-uri's `Kernel#open` which refers charset
value of HTTP response and set responded body's encoding by that.

Without charset in response, `Kernel#open` sets responded body's
encoding as ASCII-8BIT even if the responsed body is encoded with UTF-8.
This behavior causes `Encoding::UndefinedConversionError` in
`Pact::Provider::Help::Write#write`.

In this situation, we have 2 plans. A. pact_broker responds charset, B.
the client (`Pact::PactFile`) reads as ASCII-8BIT and force encoding
with UTF-8. For those who don't use Ruby pact library, I suggest plan A
which corrects the pact_broker behavior.

By this changes pact_broker responds Content-Type as
`application/json;charset=utf-8`.
