### PR TITLE
Add conflict guards to pact merger

### DIFF
--- a/lib/pact_broker/api/resources/pact.rb
+++ b/lib/pact_broker/api/resources/pact.rb
@@ -40,7 +40,10 @@ module PactBroker
         end
 
         def is_conflict?
-          potential_duplicate_pacticipants?(pact_params.pacticipant_names)
+          merge_conflict = request.patch? && resource_exists? &&
+            Pacts::Merger.conflict?(pact.json_content, pact_params.json_content)
+
+          potential_duplicate_pacticipants?(pact_params.pacticipant_names) || merge_conflict
         end
 
         def malformed_request?

--- a/lib/pact_broker/pacts/merger.rb
+++ b/lib/pact_broker/pacts/merger.rb
@@ -49,10 +49,9 @@ module PactBroker
       end
 
       def same_request_properties? original, additional
-        method_matches = original["method"] == additional["method"]
-        path_matches = original["path"] == additional["path"]
-
-        method_matches && path_matches && original["headers"] == additional["headers"]
+        attributes_match = %w(method path query body headers).all? do |attribute|
+          original[attribute] == additional[attribute]
+        end
       end
     end
   end

--- a/spec/features/merge_pact_spec.rb
+++ b/spec/features/merge_pact_spec.rb
@@ -25,7 +25,7 @@ describe "Merging a pact" do
   end
 
   context "when a pact for this consumer version does exist" do
-    let(:existing_pact_content) { load_fixture('a_consumer-a_provider-2.json') }
+    let(:existing_pact_content) { load_fixture('a_consumer-a_provider-3.json') }
     let(:merged_pact_content) { load_fixture('a_consumer-a_provider-merged.json') }
 
     before do
@@ -42,6 +42,14 @@ describe "Merging a pact" do
 
     it "returns the merged pact in the response body" do
       expect(response_body_json).to contain_hash JSON.parse(merged_pact_content)
+    end
+
+    context "with a conflicting request" do
+      let(:existing_pact_content) { load_fixture('a_consumer-a_provider-conflict.json') }
+
+      it "returns a 409 Conflict" do
+        expect(subject.status).to be 409
+      end
     end
   end
 

--- a/spec/fixtures/a_consumer-a_provider-3.json
+++ b/spec/fixtures/a_consumer-a_provider-3.json
@@ -7,18 +7,6 @@
   },
   "interactions": [
     {
-      "description" : "a request for something",
-      "provider_state": null,
-      "request": {
-        "method": "get",
-        "path" : "/something"
-      },
-      "response": {
-        "status": 200,
-        "body" : "something"
-      }
-    },
-    {
       "description" : "another request for something",
       "provider_state": null,
       "request": {

--- a/spec/fixtures/a_consumer-a_provider-conflict.json
+++ b/spec/fixtures/a_consumer-a_provider-conflict.json
@@ -10,20 +10,8 @@
       "description" : "a request for something",
       "provider_state": null,
       "request": {
-        "method": "get",
+        "method": "post",
         "path" : "/something"
-      },
-      "response": {
-        "status": 200,
-        "body" : "something"
-      }
-    },
-    {
-      "description" : "another request for something",
-      "provider_state": null,
-      "request": {
-        "method": "get",
-        "path" : "/something_else"
       },
       "response": {
         "status": 200,

--- a/spec/fixtures/consumer-provider.json
+++ b/spec/fixtures/consumer-provider.json
@@ -11,7 +11,10 @@
       "provider_state": null,
       "request": {
         "method": "get",
-        "path" : "/something"
+        "path" : "/something",
+        "headers" : {
+          "Content-Type" : "application/json"
+        }
       },
       "response": {
         "status": 200,

--- a/spec/lib/pact_broker/pacts/merger_spec.rb
+++ b/spec/lib/pact_broker/pacts/merger_spec.rb
@@ -98,6 +98,16 @@ module PactBroker
             expect(compare_pacts(example_pact, @pact_to_compare)).to eq false
           end
 
+          it "returns true if requests have a different query" do
+            @pact_to_compare["interactions"][0]["request"]["query"] = "foo=bar&baz=qux"
+            expect(compare_pacts(example_pact, @pact_to_compare)).to eq true
+          end
+
+          it "returns true if requests have a different body" do
+            @pact_to_compare["interactions"][0]["request"]["body"] = { "something" => { "nested" => "deeply" } }
+            expect(compare_pacts(example_pact, @pact_to_compare)).to eq true
+          end
+
           it "returns true if request method is different" do
             @pact_to_compare["interactions"][0]["request"]["method"] = "post"
             expect(compare_pacts(example_pact, @pact_to_compare)).to eq true

--- a/spec/lib/pact_broker/pacts/merger_spec.rb
+++ b/spec/lib/pact_broker/pacts/merger_spec.rb
@@ -28,86 +28,105 @@ module PactBroker
         }
       end
 
-      before :each do
-        @pact_to_merge = load_json_fixture('consumer-provider.json')
+      describe "#merge" do
+
+        before :each do
+          @pact_to_merge = load_json_fixture('consumer-provider.json')
+        end
+
+        it "merges two pacts" do
+          @pact_to_merge["interactions"] << example_interaction
+          result = merge_pacts(example_pact, @pact_to_merge)
+          expect(result["interactions"]).to match_array(example_pact["interactions"].push(example_interaction))
+        end
+
+        it "is idempotent" do
+          @pact_to_merge["interactions"] << example_interaction
+          first_result = merge_pacts(example_pact, @pact_to_merge)
+          second_result = merge_pacts(first_result, @pact_to_merge)
+          expect(first_result).to contain_hash second_result
+        end
+
+        it "overwrites identical interactions" do
+          @pact_to_merge["interactions"][0]["response"]["body"] = "changed!"
+          result = merge_pacts(example_pact, @pact_to_merge)
+
+          expect(result["interactions"].length).to eq example_pact["interactions"].length
+          expect(result["interactions"].first["response"]["body"]).to eq "changed!"
+        end
+
+        it "appends interactions with a different provider state" do
+          @pact_to_merge["interactions"][0]["provider_state"] = "upside down"
+
+          result = merge_pacts(example_pact, @pact_to_merge)
+          expect(result["interactions"].length).to eq example_pact["interactions"].length + 1
+        end
+
+        it "appends interactions with a different description" do
+          @pact_to_merge["interactions"][0]["description"] = "getting $$$"
+
+          result = merge_pacts(example_pact, @pact_to_merge)
+          expect(result["interactions"].length).to eq example_pact["interactions"].length + 1
+        end
+
+        # helper that lets these specs deal with hashes instead of JSON strings
+        def merge_pacts(a, b, return_hash = true)
+          result = PactBroker::Pacts::Merger.merge_pacts(a.to_json, b.to_json)
+
+          return_hash ? JSON.parse(result) : result
+        end
       end
 
-      it "merges two pacts" do
-        @pact_to_merge["interactions"] << example_interaction
-        result = merge_pacts(example_pact, @pact_to_merge)
-        expect(result["interactions"]).to match_array(example_pact["interactions"].push(example_interaction))
-      end
+      describe "#conflict?" do
+        before :each do
+          @pact_to_compare = load_json_fixture('consumer-provider.json')
+        end
 
-      it "is idempotent" do
-        @pact_to_merge["interactions"] << example_interaction
-        first_result = merge_pacts(example_pact, @pact_to_merge)
-        second_result = merge_pacts(first_result, @pact_to_merge)
-        expect(first_result).to contain_hash second_result
-      end
+        it "returns false if interactions have different descriptions" do
+          @pact_to_compare["interactions"][0]["description"] = "something else"
 
-      it "overwrites identical interactions" do
-        @pact_to_merge["interactions"][0]["response"]["body"] = "changed!"
-        result = merge_pacts(example_pact, @pact_to_merge)
+          expect(compare_pacts(example_pact, @pact_to_compare)).to eq false
+        end
 
-        expect(result["interactions"].length).to eq example_pact["interactions"].length
-        expect(result["interactions"].first["response"]["body"]).to eq "changed!"
-      end
+        it "returns false if interactions have different provider states" do
+          @pact_to_compare["interactions"][0]["provider_state"] = "some other thing"
+          expect(compare_pacts(example_pact, @pact_to_compare)).to eq false
+        end
 
-      it "appends interactions with a different provider state" do
-        @pact_to_merge["interactions"][0]["provider_state"] = "upside down"
+        context "when interactions have the same desc/state" do
+          it "returns false if request parameters are the same" do
+            expect(compare_pacts(example_pact, @pact_to_compare)).to eq false
+          end
 
-        result = merge_pacts(example_pact, @pact_to_merge)
-        expect(result["interactions"].length).to eq example_pact["interactions"].length + 1
-      end
+          it "returns true if request method is different" do
+            @pact_to_compare["interactions"][0]["request"]["method"] = "post"
+            expect(compare_pacts(example_pact, @pact_to_compare)).to eq true
+          end
 
-      it "appends interactions with a different description" do
-        @pact_to_merge["interactions"][0]["description"] = "getting $$$"
+          it "returns true if request path is different" do
+            @pact_to_compare["interactions"][0]["request"]["path"] = "/new_path"
+            expect(compare_pacts(example_pact, @pact_to_compare)).to eq true
+          end
 
-        result = merge_pacts(example_pact, @pact_to_merge)
-        expect(result["interactions"].length).to eq example_pact["interactions"].length + 1
-      end
+          it "returns true if request headers are different" do
+            @pact_to_compare["interactions"][0]["request"]["headers"]["Content-Type"] = "text/html"
+            expect(compare_pacts(example_pact, @pact_to_compare)).to eq true
+          end
 
-      it "appends interactions with a different request method" do
-        @pact_to_merge["interactions"][0]["request"]["method"] = "delete"
+          it "returns true if request has additional headers" do
+            @pact_to_compare["interactions"][0]["request"]["headers"]["Accept"] = "text/html"
+            expect(compare_pacts(example_pact, @pact_to_compare)).to eq true
+          end
 
-        result = merge_pacts(example_pact, @pact_to_merge)
-        expect(result["interactions"].length).to eq example_pact["interactions"].length + 1
-      end
+          it "returns true if request has missing headers" do
+            @pact_to_compare["interactions"][0]["request"]["headers"].delete("Content-Type")
+            expect(compare_pacts(example_pact, @pact_to_compare)).to eq true
+          end
+        end
 
-      it "appends interactions with a different request path" do
-        @pact_to_merge["interactions"][0]["request"]["path"] = "/decrypt_all_passwords"
-
-        result = merge_pacts(example_pact, @pact_to_merge)
-        expect(result["interactions"].length).to eq example_pact["interactions"].length + 1
-      end
-
-      it "appends interactions which have additional request headers in the new pact" do
-        @pact_to_merge["interactions"][0]["request"]["headers"] = { "Accept" => "script/javascript" }
-
-        result = merge_pacts(example_pact, @pact_to_merge)
-        expect(result["interactions"].length).to eq example_pact["interactions"].length + 1
-      end
-
-      it "appends interactions with different request headers" do
-        example_pact["interactions"][0]["request"]["headers"] = { "Content-Type" => "script/javascript" }
-        @pact_to_merge["interactions"][0]["request"]["headers"] = { "Content-Type" => "ayy/lmao" }
-
-        result = merge_pacts(example_pact, @pact_to_merge)
-        expect(result["interactions"].length).to eq example_pact["interactions"].length + 1
-      end
-
-      it "appends interactions with fewer request headers" do
-        example_pact["interactions"][0]["request"]["headers"] = { "Content-Type" => "script/javascript" }
-
-        result = merge_pacts(example_pact, @pact_to_merge)
-        expect(result["interactions"].length).to eq example_pact["interactions"].length + 1
-      end
-
-      # helper that lets these specs deal with hashes instead of JSON strings
-      def merge_pacts(a, b, return_hash = true)
-        result = PactBroker::Pacts::Merger.merge_pacts(a.to_json, b.to_json)
-
-        return_hash ? JSON.parse(result) : result
+        def compare_pacts(a, b)
+          PactBroker::Pacts::Merger.conflict?(a.to_json, b.to_json)
+        end
       end
     end
   end


### PR DESCRIPTION
Add guard that returns a `409 Conflict` whenever a pact is submitted for merging with an interaction that has an identical description and provider state to an existing interaction, but a different request specification.
