### PR TITLE
Add pb:latest-provider-pacts-with-tag to index.rb

### DIFF
--- a/lib/pact_broker/api/resources/index.rb
+++ b/lib/pact_broker/api/resources/index.rb
@@ -42,6 +42,12 @@ module PactBroker
                 title: 'Latest pacts by provider',
                 templated: true
               },
+              'pb:latest-provider-pacts-with-tag' =>
+              {
+                href: base_url + '/pacts/provider/{provider}/latest/{tag}',
+                title: 'Latest pacts by provider with a specified tag',
+                templated: true
+              },
               'pb:webhooks' =>
               {
                 href: base_url + '/webhooks',


### PR DESCRIPTION
In order to be able to add an option to [pact-jvm-provider](https://github.com/DiUS/pact-jvm/blob/master/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/broker/PactBrokerClient.groovy#L20-L32) to obtain all the _prod_ (or other) tagged pacts for all provider consumers.

I believe just adding it to index.rb is sufficient but I may be wrong.
@bethesque - could you please review? Thanks!


