### PR TITLE
fix issue with pact document link not displaying #94

### DIFF
--- a/lib/pact_broker/ui/views/relationships/show.haml
+++ b/lib/pact_broker/ui/views/relationships/show.haml
@@ -50,6 +50,6 @@
     $("#relationships").tablesorter();
   });
 
-  $(document).load(function(){
+  $(document).ready(function(){
     $("span.pact").load("/images/doc-text.svg");
   });


### PR DESCRIPTION
I'm not quite sure _why_, but this seems to fix the display issue with the icon not appearing.