### PR TITLE
Minor fixes and comments in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ Use the HAL browser to view documentation as you browse.
 ### To have a play around on your local machine
 
 * Install ruby 2.2.0 or later and bundler >= 1.12.0
-* Run `git clone git@github.com:pact-foundation/pact_broker.git && cd pact_broker/example`
-* Run `bundle`
+    * Windows users: get a Rails/Ruby installer from [RailsInstaller](http://railsinstaller.org/) and run it
+    * unix users just use their package manager
+* Run `git clone https://github.com:pact-foundation/pact_broker.git && cd pact_broker/example`
+* Run `bundle install`
 * Run `bundle exec rackup -p 8080`
 * Open [http://localhost:8080](http://localhost:8080) and you should see a list containing the pact between the Zoo App and the Animal Service.
 * Click on the arrow to see the generated HTML documentation.


### PR DESCRIPTION
I installed the pact_broker (thanks for that) on a local Windows system, and fixed a few minor issues in the README. I also added a hint on how Windows users get Rails/Ruby. Since Windows users aren't generally very familiar with Ruby, I believe this makes sense. You may like these edits or not, they are not spectacular, but I did not want to keep the findings for myself.
Thanks for your work with pact!