### PR TITLE
Fixed NameError bug

### DIFF
--- a/lib/pact_broker/api/resources/version.rb
+++ b/lib/pact_broker/api/resources/version.rb
@@ -1,5 +1,6 @@
 require 'pact_broker/services'
 require 'pact_broker/api/decorators/version_decorator'
+require 'pact_broker/api/resources/base_resource'
 
 module PactBroker
   module Api


### PR DESCRIPTION
Fixed issue that caused uninitialized constant PactBroker::Api::Resources::BaseResource (NameError) when running pact_broker with passenger.