### PR TITLE
fix: #184 Escape username before asigning it to URI userinfo attribute

### DIFF
--- a/lib/pact_broker/domain/webhook_request.rb
+++ b/lib/pact_broker/domain/webhook_request.rb
@@ -159,7 +159,7 @@ module PactBroker
 
       def url_with_credentials pact
         u = build_uri(pact)
-        u.userinfo = "#{username}:#{display_password}" if username
+        u.userinfo = "#{CGI::escape username}:#{display_password}" if username
         u
       end
 

--- a/spec/lib/pact_broker/domain/webhook_request_spec.rb
+++ b/spec/lib/pact_broker/domain/webhook_request_spec.rb
@@ -175,10 +175,7 @@ module PactBroker
           end
         end
 
-        context "when a username and password are specified" do
-
-          let(:username) { 'username' }
-          let(:password) { 'password' }
+        describe "when a username and password are specified" do
 
           let!(:http_request_with_basic_auth) do
             stub_request(:post, "http://example.org/hook").
@@ -189,9 +186,24 @@ module PactBroker
               to_return(:status => 200, :body => "respbod", :headers => {'Content-Type' => 'text/foo, blah'})
           end
 
-          it "uses the credentials" do
-            subject.execute(pact, options)
-            expect(http_request_with_basic_auth).to have_been_made
+          context "with normal characters" do
+            let(:username) { "username" }
+            let(:password) { "password" }
+
+            it "uses the credentials" do
+              subject.execute(pact, options)
+              expect(http_request_with_basic_auth).to have_been_made
+            end
+          end
+
+          context "with special characters" do
+            let(:username) { "user_name@site.com" }
+            let(:password) { "p@$$w0rd!" }
+
+            it "uses the credentials" do
+              subject.execute(pact, options)
+              expect(http_request_with_basic_auth).to have_been_made
+            end
           end
         end
 


### PR DESCRIPTION
Fixed issue #184 by escaping the username as the URI attribute 'userinfo' doesn't like the '@' character (and potentially others...). Seemed like the most simple and effective fix so that users who have emails as usernames can authenticate webhooks - although I'm happy to discuss!