### PR TITLE
feat: custom version parsing via modifying the source code of Semver2 gem

### DIFF
--- a/lib/pact_broker/app.rb
+++ b/lib/pact_broker/app.rb
@@ -12,6 +12,12 @@ require 'rack/pact_broker/accepts_html_filter'
 require 'rack/pact_broker/ui_authentication'
 require 'rack/pact_broker/configurable_make_it_later'
 require 'rack/pact_broker/no_auth'
+require 'semver/dsl'
+require 'semver/pre_release'
+require 'semver/runner'
+require 'semver/semver'
+require 'semver/semvermissingerror'
+require 'semver/xsemver'
 require 'sucker_punch'
 
 module PactBroker

--- a/lib/pact_broker/configuration.rb
+++ b/lib/pact_broker/configuration.rb
@@ -59,7 +59,6 @@ module PactBroker
       # Not recommended to set this to true unless there is no way to
       # consistently extract an orderable object from the consumer application version number.
       config.order_versions_by_date = false
-      config.semver_formats = ["%M.%m.%p%s%d", "%M.%m", "%M"]
       config.webhook_retry_schedule = [10, 60, 120, 300, 600, 1200] #10 sec, 1 min, 2 min, 5 min, 10 min, 20 min => 38 minutes
       config.check_for_potential_duplicate_pacticipant_names = true
       config.disable_ssl_verification = false

--- a/lib/pact_broker/configuration.rb
+++ b/lib/pact_broker/configuration.rb
@@ -65,6 +65,7 @@ module PactBroker
       # Not recommended to set this to true unless there is no way to
       # consistently extract an orderable object from the consumer application version number.
       config.order_versions_by_date = false
+      config.semver_formats = ["%M.%m.%p%s%d", "%M.%m", "%M"]
       config.webhook_retry_schedule = [10, 60, 120, 300, 600, 1200] #10 sec, 1 min, 2 min, 5 min, 10 min, 20 min => 38 minutes
       config.check_for_potential_duplicate_pacticipant_names = true
       config.disable_ssl_verification = false

--- a/lib/pact_broker/versions/parse_semantic_version.rb
+++ b/lib/pact_broker/versions/parse_semantic_version.rb
@@ -1,28 +1,18 @@
-require 'semver'
-require 'pact_broker/configuration'
+require 'semver/semver'
 
 module PactBroker
   module Versions
     class ParseSemanticVersion
-
+      SEMVER_FORMAT = "%M%m%p%s%d"
 
       def self.call string_version
-        PactBroker.configuration.semver_formats.each do |semver_format|
-          parsed_version = ::SemVer.parse(string_version, semver_format)
-          return SemVerWrapper.new(parsed_version, semver_format) unless parsed_version.nil?
-        end
-        nil
+        version = ::SemVer.parse string_version
+        return SemVerWrapper.new(version) unless version.nil?
       end
 
       class SemVerWrapper < SimpleDelegator
-
-        def initialize target, semver_format
-          super target
-          @semver_format = semver_format
-        end
-
         def to_s
-          format(@semver_format)
+          format(SEMVER_FORMAT)
         end
       end
     end

--- a/lib/semver/dsl.rb
+++ b/lib/semver/dsl.rb
@@ -1,0 +1,59 @@
+module XSemVer
+  
+  module DSL
+    
+    def self.included(klass)
+      klass.extend ClassMethods
+      klass.send :include, InstanceMethods
+    end
+
+    class CommandError < StandardError
+    end    
+    
+    
+    
+    
+    module InstanceMethods
+      
+      # Calls an instance method defined via the ::command class method.
+      # Raises CommandError if the command does not exist.
+      def run_command(command)
+        method_name = "#{self.class.command_prefix}#{command}"
+        if self.class.method_defined?(method_name)
+          send method_name
+        else
+          raise CommandError, "invalid command #{command}"
+        end
+      end
+      
+    end
+
+
+
+
+    module ClassMethods
+      
+      # Defines an instance method based on the first command name.
+      # The method executes the code of the given block.
+      # Aliases methods for any subsequent command names.
+      def command(*command_names, &block)
+        method_name = "#{command_prefix}#{command_names.shift}"
+        define_method method_name, &block
+        command_names.each do |c|
+          alias_method "#{command_prefix}#{c}", method_name
+        end
+      end
+      
+      # The prefix for any instance method defined by the ::command method.
+      def command_prefix
+        :_run_
+      end
+      
+    end
+
+
+
+
+  end
+  
+end

--- a/lib/semver/pre_release.rb
+++ b/lib/semver/pre_release.rb
@@ -1,0 +1,68 @@
+module XSemVer
+  
+  # Represents the pre-release portion of a SemVer string.
+  class PreRelease
+    
+    ONLY_DIGITS = /\A\d+\z/
+    
+    attr_reader :ids
+    
+    include Comparable
+    
+    
+    
+    
+    def initialize(prerelease_string)
+      @ids = prerelease_string.split(".")
+    end
+    
+    def to_s
+      ids.join "."
+    end
+    
+    def empty?
+      ids.empty?
+    end    
+    
+    
+    
+    
+    # The SemVer 2.0.0-rc2 spec uses this example for determining pre-release precedence:
+    #   1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
+    # Pre-release precedence is calculated using the following rules, which are listed above their corresponding code.
+    def <=>(other)
+      
+      # A SemVer with no prerelease data is 'greater' than a SemVer with any prerelease data.
+      # If both prereleases are empty, they are equal.
+      return  1 if  empty? && !other.empty?
+      return -1 if !empty? &&  other.empty?
+      return  0 if  empty? &&  other.empty?
+      
+      [ids.size, other.ids.size].max.times do |n|
+        id = ids[n]
+        oid = other.ids[n]
+        
+        # A pre-release with fewer ids is less than a pre-release with more ids. (1.0.0-alpha < 1.0.0-alpha.1)
+        return 1 if oid.nil?
+        return -1 if id.nil?
+        
+        # If a pre-release id consists of only numbers, it is compared numerically.
+        if id =~ ONLY_DIGITS && oid =~ ONLY_DIGITS
+          id = id.to_i
+          oid = oid.to_i
+        end
+        
+        # If a pre-release id contains one or more letters, it is compared alphabetically.
+        comparison = (id <=> oid)
+        return comparison unless comparison == 0
+      end
+      
+      0
+    end
+    
+    
+    
+    
+  end
+  
+end

--- a/lib/semver/runner.rb
+++ b/lib/semver/runner.rb
@@ -1,4 +1,4 @@
-require 'lib/semver/dsl'
+require 'semver/dsl'
 
 module XSemVer
   

--- a/lib/semver/runner.rb
+++ b/lib/semver/runner.rb
@@ -1,0 +1,121 @@
+require 'lib/semver/dsl'
+
+module XSemVer
+  
+  # Contains the logic for performing SemVer operations from the command line.
+  class Runner
+    
+    include XSemVer::DSL
+    
+    # Run a semver command. Raise a CommandError if the command does not exist.
+    # Expects an array of commands, such as ARGV.
+    def initialize(*args)
+      @args = args
+      run_command(@args.shift || :tag)
+    end
+    
+    private
+    
+    def next_param_or_error(error_message)
+      @args.shift || raise(CommandError, error_message)
+    end
+    
+    def help_text
+      <<-HELP
+semver commands
+---------------
+
+init[ialze]                        # initialize semantic version tracking
+inc[rement] major | minor | patch  # increment a specific version number
+pre[release] [STRING]              # set a pre-release version suffix
+spe[cial] [STRING]                 # set a pre-release version suffix (deprecated)
+meta[data] [STRING]                # set a metadata version suffix
+format                             # printf like format: %M, %m, %p, %s
+tag                                # equivalent to format 'v%M.%m.%p%s'
+help
+
+PLEASE READ http://semver.org
+      HELP
+    end
+    
+    
+    
+    
+    # Create a new .semver file if the file does not exist.
+    command :initialize, :init do
+      file = SemVer.file_name
+      if File.exist? file
+        puts "#{file} already exists"
+      else
+        version = SemVer.new
+        version.save file
+      end
+    end
+    
+    
+    # Increment the major, minor, or patch of the .semver file.
+    command :increment, :inc do
+      version = SemVer.find
+      dimension = next_param_or_error("required: major | minor | patch")
+      case dimension
+      when 'major'
+        version.major += 1
+        version.minor =  0
+        version.patch =  0
+      when 'minor'
+        version.minor += 1
+        version.patch =  0
+      when 'patch'
+        version.patch += 1
+      else
+        raise CommandError, "#{dimension} is invalid: major | minor | patch"
+      end
+      version.special = ''
+      version.metadata = ''
+      version.save
+    end
+    
+    
+    # Set the pre-release of the .semver file.
+    command :special, :spe, :prerelease, :pre do
+      version = SemVer.find
+      version.special = next_param_or_error("required: an arbitrary string (beta, alfa, romeo, etc)")
+      version.save
+    end
+    
+    
+    # Set the metadata of the .semver file.
+    command :metadata, :meta do
+      version = SemVer.find
+      version.metadata = next_param_or_error("required: an arbitrary string (beta, alfa, romeo, etc)")
+      version.save
+    end
+    
+        
+    # Output the semver as specified by a format string.
+    # See: SemVer#format
+    command :format do
+      version = SemVer.find
+      puts version.format(next_param_or_error("required: format string"))
+    end
+    
+    
+    # Output the semver with the default formatting.
+    # See: SemVer#to_s
+    command :tag do
+      version = SemVer.find
+      puts version.to_s
+    end
+    
+    
+    # Output instructions for using the semvar command.
+    command :help do
+      puts help_text
+    end
+    
+
+
+
+  end
+  
+end

--- a/lib/semver/semver.rb
+++ b/lib/semver/semver.rb
@@ -1,0 +1,6 @@
+require 'yaml'
+require_relative './xsemver'
+require_relative './semvermissingerror'
+
+class SemVer < ::XSemVer::SemVer
+end

--- a/lib/semver/semvermissingerror.rb
+++ b/lib/semver/semvermissingerror.rb
@@ -1,0 +1,2 @@
+class SemVerMissingError < RuntimeError
+end

--- a/lib/semver/xsemver.rb
+++ b/lib/semver/xsemver.rb
@@ -1,0 +1,190 @@
+require 'yaml'
+require_relative './semvermissingerror'
+require_relative './pre_release'
+
+module XSemVer
+# sometimes a library that you are using has already put the class
+# 'SemVer' in global scope. Too Bad®. Use this symbol instead.
+  class SemVer
+    FILE_NAME = '.semver'
+    TAG_FORMAT = 'v%M%m%p%s%d'
+
+    def SemVer.file_name
+      FILE_NAME
+    end
+
+    def SemVer.find dir=nil
+      v = SemVer.new
+      f = SemVer.find_file dir
+      v.load f
+      v
+    end
+
+    def SemVer.find_file dir=nil
+      dir ||= Dir.pwd
+      raise "#{dir} is not a directory" unless File.directory? dir
+      path = File.join dir, file_name
+
+      Dir.chdir dir do
+        while !File.exists? path do
+          raise SemVerMissingError, "#{dir} is not semantic versioned", caller if File.dirname(path).match(/(\w:\/|\/)$/i)
+          path = File.join File.dirname(path), ".."
+          path = File.expand_path File.join(path, file_name)
+          puts "semver: looking at #{path}"
+        end
+        return path
+      end
+
+    end
+
+    attr_accessor :major, :minor, :patch, :special, :metadata
+
+    def initialize major=0, minor=0, patch=0, special='', metadata=''
+      major.kind_of? Integer or raise "invalid major: #{major}"
+
+      unless special.empty?
+        special =~ /[A-Za-z][0-9A-Za-z\.]+/ or raise "invalid special: #{special}"
+      end
+
+      unless metadata.empty?
+        metadata =~ /\A[A-Za-z0-9][0-9A-Za-z\.-]*\z/ or raise "invalid metadata: #{metadata}"
+      end
+
+      @major, @minor, @patch, @special, @metadata = major, minor, patch, special, metadata
+    end
+
+    def load file
+      @file = file
+      hash = YAML.load_file(file) || {}
+      @major = hash[:major] or raise "invalid semver file: #{file}"
+      @minor = hash[:minor] or raise "invalid semver file: #{file}"
+      @patch = hash[:patch] or raise "invalid semver file: #{file}"
+      @special = hash[:special] or raise "invalid semver file: #{file}"
+      @metadata = hash[:metadata] || ""
+    end
+
+    def save file=nil
+      file ||= @file
+
+      hash = {
+        :major => @major,
+        :minor => @minor,
+        :patch => @patch,
+        :special => @special,
+        :metadata => @metadata
+      }
+
+      yaml = YAML.dump hash
+      open(file, 'w') { |io| io.write yaml }
+    end
+
+    def format fmt
+      fmt = fmt.gsub '%M', @major.to_s
+      fmt = fmt.gsub('%m', @minor ? ".#{@minor}" : '')
+      fmt = fmt.gsub('%p', @patch ? ".#{@patch}" : '')
+      fmt = fmt.gsub('%s', prerelease? ? "-#{@special}" : '')
+      fmt = fmt.gsub('%d', metadata? ? "+#{@metadata}" : '')
+      fmt
+    end
+
+    def to_s
+      format TAG_FORMAT
+    end
+
+    # Compare version numbers according to SemVer 2.0.0-rc2
+    def <=> other
+      [:major, :minor, :patch].each do |method|
+        left = send(method) || 0
+        right = other.send(method) || 0
+        comparison = left <=> right
+        return comparison unless comparison == 0
+      end
+      PreRelease.new(prerelease) <=> PreRelease.new(other.prerelease)
+    end
+
+    include Comparable
+
+    # Parses a semver from a string and format.
+    def self.parse(version_string, format = nil, allow_missing = true)
+      format ||= TAG_FORMAT
+      regex_str = Regexp.escape format
+
+      # Convert all the format characters to named capture groups
+      regex_str = regex_str.
+        gsub(/^v/, 'v?').
+        gsub('%M', '(?<major>\d+)').
+        gsub('%m', '(?:\.(?<minor>\d+))?').
+        gsub('%p', '(?:\.(?<patch>\d+))?').
+        gsub('%s', '(?:-(?<special>[A-Za-z][0-9A-Za-z\.]+))?').
+        gsub('%d', '(?:\\\+(?<metadata>[0-9A-Za-z][0-9A-Za-z\.]*))?')
+
+      regex = Regexp.new(regex_str)
+      match = regex.match version_string
+      if match
+        major = minor = patch = nil
+        special = metadata = ''
+
+        # Extract out the version parts
+        major = match[:major].to_i if match.names.include? 'major'
+        minor = match[:minor].to_i if match.names.include?('minor') && match[:minor]
+        patch = match[:patch].to_i if match.names.include?('patch') && match[:patch]
+        special = match[:special] || '' if match.names.include? 'special'
+        metadata = match[:metadata] || '' if match.names.include? 'metadata'
+
+        # Failed parse if major, minor, or patch wasn't found
+        # and allow_missing is false
+        return nil if !allow_missing and !major
+
+        # Otherwise, allow them to default to zero
+        major ||= 0
+
+        SemVer.new major, minor, patch, special, metadata
+      end
+    end
+
+    # Parses a rubygems string, such as 'v2.0.5.rc.3' or '2.0.5.rc.3' to 'v2.0.5-rc.3'
+    def self.parse_rubygems version_string
+      if /v?(?<major>\d+)
+           (\.(?<minor>\d+)
+            (\.(?<patch>\d+)
+             (\.(?<pre>[A-Za-z]+\.[0-9A-Za-z]+) 
+           )?)?)?
+          /x =~ version_string
+
+        major = major.to_i
+        minor = minor.to_i if minor
+        minor ||= 0
+        patch = patch.to_i if patch
+        patch ||= 0
+        pre ||= ''
+        SemVer.new major, minor, patch, pre, ''
+      else
+        SemVer.new
+      end
+    end
+
+    # SemVer specification 2.0.0-rc2 states that anything after the '-' character is prerelease data.
+    # To be consistent with the specification verbage, #prerelease returns the same value as #special.
+    # TODO: Deprecate #special in favor of #prerelease?
+    def prerelease
+      special
+    end
+
+    # SemVer specification 2.0.0-rc2 states that anything after the '-' character is prerelease data.
+    # To be consistent with the specification verbage, #prerelease= sets the same value as #special.
+    # TODO: Deprecate #special= in favor of #prerelease=?
+    def prerelease=(pre)
+      self.special = pre
+    end
+
+    # Return true if the SemVer has a non-empty #prerelease value. Otherwise, false.
+    def prerelease?
+      !special.nil? && special.length > 0
+    end
+
+    # Return true if the SemVer has a non-empty #metadata value. Otherwise, false.
+    def metadata?
+      !metadata.nil? && metadata.length > 0
+    end
+  end
+end

--- a/lib/semver/xsemver.rb
+++ b/lib/semver/xsemver.rb
@@ -106,6 +106,9 @@ module XSemVer
 
     # Parses a semver from a string and format.
     def self.parse(version_string, format = nil, allow_missing = true)
+      # check if git SHA
+      return nil if !version_string.include?('.') && (version_string =~ /\A[-+]?\d*\.?\d+\z/).nil?
+
       format ||= TAG_FORMAT
       regex_str = Regexp.escape format
 

--- a/lib/semver/xsemver.rb
+++ b/lib/semver/xsemver.rb
@@ -107,7 +107,7 @@ module XSemVer
     # Parses a semver from a string and format.
     def self.parse(version_string, format = nil, allow_missing = true)
       # check if git SHA
-      return nil if !version_string.include?('.') && (version_string =~ /\A[-+]?\d*\.?\d+\z/).nil?
+      return nil if !version_string.include?('.') && version_string.length >= 40
 
       format ||= TAG_FORMAT
       regex_str = Regexp.escape format

--- a/pact_broker.gemspec
+++ b/pact_broker.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'dry-validation', '~> 0.10.5'
   gem.add_runtime_dependency 'sequel', '~> 5.6'
   gem.add_runtime_dependency 'webmachine', '1.5.0'
-  gem.add_runtime_dependency 'semver2', '~> 3.4.2'
   gem.add_runtime_dependency 'rack', '~>2.0'
   gem.add_runtime_dependency 'redcarpet', '>=3.3.2', '~>3.3'
   gem.add_runtime_dependency 'pact-support'

--- a/spec/lib/pact_broker/versions/parse_semantic_version_spec.rb
+++ b/spec/lib/pact_broker/versions/parse_semantic_version_spec.rb
@@ -31,6 +31,10 @@ module PactBroker
             expect(ParseSemanticVersion.call("abc")).to be_nil
           end
 
+          it "returns nil when GIT SHA is given" do
+            expect(ParseSemanticVersion.call("21426d86b6188b98c1d34564c5cc4858b26f5af9")).to be_nil
+          end
+
           context "semver metadata" do
             it "accepts metadata" do
               expect(ParseSemanticVersion.call("1.2.3+abc.234")).not_to be_nil

--- a/spec/lib/pact_broker/versions/parse_semantic_version_spec.rb
+++ b/spec/lib/pact_broker/versions/parse_semantic_version_spec.rb
@@ -31,8 +31,14 @@ module PactBroker
             expect(ParseSemanticVersion.call("abc")).to be_nil
           end
 
-          it "accepts semver metadata" do
-            expect(ParseSemanticVersion.call("1.2.3+abc.234")).not_to be_nil
+          context "semver metadata" do
+            it "accepts metadata" do
+              expect(ParseSemanticVersion.call("1.2.3+abc.234")).not_to be_nil
+            end
+
+            it "accepts metadata short version" do
+              expect(ParseSemanticVersion.call("1+abc.234")).not_to be_nil
+            end
           end
         end
       end

--- a/spec/lib/semver/pre_release.rb
+++ b/spec/lib/semver/pre_release.rb
@@ -1,0 +1,23 @@
+require 'lib/semver/semver'
+
+
+describe XSemVer::PreRelease do
+  subject(:pre_releases) { strings.map { |s| described_class.new s } }
+
+  context 'with semver.org v2.0.0 section 10 example data' do
+    let(:strings) { ["alpha", "alpha.1", "alpha.beta", "beta", "beta.2", "beta.11", "rc.1", ""] }
+
+    it 'should remain the same after a sort' do
+      pre_releases.sort.each_with_index do |pr, i|
+        strings[i].should eq(pr.to_s)
+      end
+    end
+
+    it 'should remain the same after a reverse and sort' do
+      pre_releases.reverse.sort.each_with_index do |pr, i|
+        strings[i].should eq(pr.to_s)
+      end
+    end
+  end
+end
+

--- a/spec/lib/semver/runner_spec.rb
+++ b/spec/lib/semver/runner_spec.rb
@@ -1,0 +1,446 @@
+require 'lib/semver/runner'
+
+describe XSemVer::Runner do
+  
+  
+  
+  
+  before :each do
+    
+    # Output to a file that doesn't conflict with the project's .semver file.
+    @test_file = 'semver_test_file'
+    XSemVer::SemVer.stub(:file_name).and_return @test_file
+    
+    # Capture the output that would typically appear in the console.
+    @original_stdout = $stdout
+    @output = StringIO.new
+    $stdout = @output
+    
+  end
+  
+  after :each do
+    
+    # Delete the semver_test_file if one was created.
+    FileUtils.rm_rf @test_file
+    
+    # Return output to its original value.
+    $stdout = @original_stdout
+    
+  end
+  
+  
+  
+  
+  #######################
+  # SEMVER INIT(IALIZE) #
+  #######################
+  
+  %w( init initialize ).each do |command|
+    
+    describe command do
+    
+      describe "when no .semver file exists" do
+      
+        it "creates a new .semver file" do
+          expect {
+            described_class.new command
+          }.to change{ File.exist?(@test_file) }.from(false).to(true)
+          v = SemVer.find
+          v.major.should eq(0)
+          v.minor.should eq(0)
+          v.patch.should eq(0)
+        end
+      
+      end
+    
+      describe "when a .semver file already exists" do
+        
+        before :each do
+          FileUtils.touch @test_file
+        end
+        
+        it "outputs a warning messagae" do
+          described_class.new command
+          @output.string.should eq("#{@test_file} already exists" + "\n")
+        end
+      
+        it "does not overwrite the existing file" do
+          expect {
+            described_class.new command
+          }.to_not change{ File.mtime(@test_file) }
+        end
+      
+      end
+    
+    end
+    
+  end
+
+
+
+
+  ######################
+  # SEMVER INC(REMENT) #
+  ######################
+  
+  %w( inc increment ).each do |command|
+    
+    describe command do
+      
+      before :each do
+        SemVer.new(5,6,7,'foo','bar').save @test_file
+      end
+    
+      describe "major" do
+      
+        it "increments the major version" do
+          expect {
+            described_class.new command, 'major'
+          }.to change{ SemVer.find.major }.by(1)
+        end
+      
+        it "sets the minor version to 0" do
+          expect {
+            described_class.new command, 'major'
+          }.to change{ SemVer.find.minor }.to(0)
+        end
+      
+        it "sets the patch vesion to 0" do
+          expect {
+            described_class.new command, 'major'
+          }.to change{ SemVer.find.patch }.to(0)
+        end
+        
+        it "sets the prerelease to an empty string" do
+          expect {
+            described_class.new command, 'major'
+          }.to change{ SemVer.find.prerelease }.to('')
+        end
+
+        it "sets the metadata to an empty string" do
+          expect {
+            described_class.new command, 'major'
+          }.to change{ SemVer.find.metadata }.to('')
+        end
+      
+      end
+    
+      describe "minor" do
+      
+        it "does not change the major version" do
+          expect {
+            described_class.new command, 'minor'
+          }.to_not change{ SemVer.find.major }
+        end
+      
+        it "increments the minor version" do
+          expect {
+            described_class.new command, 'minor'
+          }.to change{ SemVer.find.minor }.by(1)
+        end
+      
+        it "sets the patch version to 0" do
+          expect {
+            described_class.new command, 'minor'
+          }.to change{ SemVer.find.patch }.to(0)
+        end
+      
+        it "sets the prerelease to an empty string" do
+          expect {
+            described_class.new command, 'minor'
+          }.to change{ SemVer.find.prerelease }.to('')
+        end
+
+        it "sets the metadata to an empty string" do
+          expect {
+            described_class.new command, 'minor'
+          }.to change{ SemVer.find.metadata }.to('')
+        end
+      
+      end
+    
+      describe "patch" do
+      
+        it "does not change the major version" do
+          expect {
+            described_class.new command, 'patch'
+          }.to_not change{ SemVer.find.major }
+        end
+      
+        it "does not change the minor version" do
+          expect {
+            described_class.new command, 'patch'
+          }.to_not change{ SemVer.find.minor }
+        end
+      
+        it "increments the patch version" do
+          expect {
+            described_class.new command, 'patch'
+          }.to change{ SemVer.find.patch }.by(1)
+        end
+      
+        it "sets the prerelease to an empty string" do
+          expect {
+            described_class.new command, 'patch'
+          }.to change{ SemVer.find.prerelease }.to('')
+        end
+
+        it "sets the metadata to an empty string" do
+          expect {
+            described_class.new command, 'patch'
+          }.to change{ SemVer.find.metadata }.to('')
+        end
+      
+      end
+    
+      describe "without a valid subcommand" do
+        
+        before :each do
+          @invalid_command = 'invalid'
+        end
+      
+        it "raises an exception" do
+          expect {
+            described_class.new command, @invalid_command
+          }.to raise_error(
+            XSemVer::Runner::CommandError,
+            "#{@invalid_command} is invalid: major | minor | patch"
+          )
+        end
+        
+        it "does not modify the .semver file" do
+          expect {
+            begin
+              described_class.new command, @invalid_command
+            rescue
+            end
+          }.to_not change{ File.mtime(@test_file) }
+        end
+      
+      end
+      
+      describe "without a subcommand" do
+      
+        it "raises an exception" do
+          expect {
+            described_class.new command
+          }.to raise_error(
+            XSemVer::Runner::CommandError,
+            "required: major | minor | patch"
+          )
+        end
+        
+        it "does not modify the .semver file" do
+          expect {
+            begin
+              described_class.new command
+            rescue
+            end
+          }.to_not change{ File.mtime(@test_file) }
+        end
+      
+      end
+    
+    end
+  
+  end
+  
+  
+  
+
+  #######################
+  # SEMVER PRE(RELEASE) #
+  #######################
+    
+  %w( spe special pre prerelease ).each do |command|
+    
+    describe command do
+      
+      before :each do
+        SemVer.new.save @test_file
+      end
+    
+      describe "when a string argument is provided" do
+      
+        it "sets the pre-release of the SemVer" do
+          prerelease = 'alpha'
+          expect {
+            described_class.new command, prerelease
+          }.to change{ SemVer.find.prerelease }.to(prerelease)
+        end
+      
+      end
+    
+      describe "without a string argument" do
+      
+        it "raises an exception" do
+          expect {
+            described_class.new command
+          }.to raise_error(
+            XSemVer::Runner::CommandError,
+            "required: an arbitrary string (beta, alfa, romeo, etc)"
+          )
+        end
+        
+        it "does not modify the .semver file" do
+          expect {
+            begin
+              described_class.new command
+            rescue
+            end
+          }.to_not change{ File.mtime(@test_file) }
+        end
+
+      end
+    
+    end
+  
+  end
+  
+  
+  
+  
+  #####################
+  # SEMVER META(DATA) #
+  #####################
+    
+  %w( meta metadata ).each do |command|
+    
+    describe command do
+      
+      before :each do
+        SemVer.new.save @test_file
+      end
+    
+      describe "when a string argument is provided" do
+      
+        it "sets the metadata of the SemVer" do
+          metadata = 'md5:q1w2e3r4t5'
+          expect {
+            described_class.new command, metadata
+          }.to change{ SemVer.find.metadata }.to(metadata)
+        end
+      
+      end
+    
+      describe "without a string argument" do
+      
+        it "raises an exception" do
+          expect {
+            described_class.new command
+          }.to raise_error(
+            XSemVer::Runner::CommandError,
+            "required: an arbitrary string (beta, alfa, romeo, etc)"
+          )
+        end
+        
+        it "does not modify the .semver file" do
+          expect {
+            begin
+              described_class.new command
+            rescue
+            end
+          }.to_not change{ File.mtime(@test_file) }
+        end
+
+      end
+    
+    end
+  
+  end
+  
+  
+  
+
+  #################
+  # SEMVER FORMAT #
+  #################
+
+  describe "format" do
+    
+    describe "without a format argument" do
+      
+      it "raises an exception" do
+        SemVer.new.save @test_file
+        expect {
+          described_class.new 'format'
+        }.to raise_error(
+          XSemVer::Runner::CommandError,
+          "required: format string"
+        )
+      end
+      
+    end
+    
+  end
+  
+  
+  
+  
+  ##############
+  # SEMVER TAG #
+  ##############
+
+  describe "tag" do
+    
+    it "outputs the SemVer with default formatting" do
+      SemVer.new(5,6,7,'foo','bar').save @test_file
+      described_class.new 'tag'
+      @output.string.should eq("v5.6.7-foo+bar" + "\n")
+    end
+    
+  end
+  
+  describe "with no command" do
+    
+    it "outputs the SemVer with default formatting" do
+      SemVer.new(5,6,7,'foo','bar').save @test_file
+      described_class.new
+      @output.string.should eq("v5.6.7-foo+bar" + "\n")
+    end
+    
+  end
+  
+  
+  
+  
+  ###############
+  # SEMVER HELP #
+  ###############
+
+  describe "help" do
+    
+    it "outputs instructions for using the semvar commands" do
+      stubbed_help_text = 'stubbed help text'
+      described_class.any_instance.stub(:help_text).and_return(stubbed_help_text)
+      described_class.new 'help'
+      @output.string.should eq(stubbed_help_text + "\n")
+    end
+    
+  end
+  
+  
+  
+  
+  ####################
+  # INVALID COMMANDS #
+  ####################
+
+  describe "invalid commands" do
+    
+    it "raises an exception" do
+      invalid_command = 'foo'
+      expect {
+        described_class.new invalid_command
+      }.to raise_error(
+        XSemVer::Runner::CommandError,
+        "invalid command #{invalid_command}"
+      )
+    end
+    
+  end
+  
+  
+  
+  
+end

--- a/spec/lib/semver/semver_spec.rb
+++ b/spec/lib/semver/semver_spec.rb
@@ -1,0 +1,179 @@
+require 'tempfile'
+require 'lib/semver/semver'
+
+describe SemVer do
+
+  it "should compare against another version versions" do
+    semvers = [
+      SemVer.new(0, 1, 0),
+      SemVer.new(0, 1, 1),
+      SemVer.new(0, 2, 0),
+      SemVer.new(1, 0, 0)
+    ]
+    (semvers.size - 1).times do |n|
+      semvers[n].should < semvers[n+1]
+    end
+  end
+
+  it "should serialize to and from a file" do
+    tf = Tempfile.new 'semver.spec'
+    path = tf.path
+    tf.close!
+
+    v1 = SemVer.new 1,10,33
+    v1.save path
+    v2 = SemVer.new
+    v2.load path
+
+    v1.should == v2
+  end
+
+  API = %W[special patch minor major load save format to_s <=>].collect(&:to_sym)
+  API.each { |x|
+    it "should quack like a SemVer class" do
+      sv = SemVer.new
+      sv.should respond_to(x)
+    end
+  }
+  
+  # Semantic Versioning 2.0.0-rc.1
+
+  it "should to_s with dash" do
+    v = SemVer.new 4,5,63, 'alpha.45'
+    v.to_s.should == 'v4.5.63-alpha.45'
+  end
+  
+  it "should not to_s with dash if no special" do
+    v = SemVer.new 2,5,11
+    v.to_s.should == "v2.5.11"
+  end
+  
+  it "should behave like the readme says" do
+    v = SemVer.new(0,0,0)
+    v.major                     # => "0"
+    v.major += 1
+    v.major                     # => "1"
+    v.special = 'alpha.46'
+    v.format "%M.%m.%p%s"       # => "1.1.0-alpha.46"
+    v.to_s                      # => "v1.1.0"
+  end
+
+
+  # Semantic Versioning 2.0.0-rc2
+  
+  it "aliases #prerelease to #special" do
+    v1 = SemVer.new
+    v1.special = 'foo'
+    v1.prerelease.should == 'foo'
+    v2 = SemVer.new
+    v2.prerelease = 'bar'
+    v2.special.should == 'bar'
+  end
+  
+  it "compares again another SemVer by prerelease" do
+    pres = %w( alpha alpha.1 beta.2 beta.3 beta.11 rc.1 )
+    semvers = pres.map do |pre|
+      SemVer.new 1, 0, 0, pre
+    end
+    (semvers.size - 1).times do |n|
+      semvers[n].should < semvers[n+1]
+    end
+    semvers.reverse!
+    (semvers.size - 1).times do |n|
+      semvers[n].should > semvers[n+1]
+    end
+  end
+  
+  it "compares a SemVer with prerelease against a SemVer without prerelease" do
+    v1 = SemVer.new(1, 0, 0, 'foo')
+    v2 = SemVer.new(1, 0, 0)
+    v1.should < v2
+    v2.should > v1
+    v1.should == v1
+  end
+  
+  describe "metadata" do
+  
+    it "is an empty string by default" do
+      SemVer.new.metadata.should == ''
+    end
+    
+    it "can be set when a SemVer is initialized" do
+      SemVer.new(1, 2, 3, 'foo', 'bar').metadata.should == 'bar'
+    end
+    
+    it "does not affect the comparison of two SemVers" do
+      v1 = SemVer.new
+      v1.metadata = 'foo.123'
+      v2 = SemVer.new
+      v2.metadata = 'bar.456.789'
+      v1.should == v2
+    end
+    
+    it "is parsed from a string" do
+      tests = {
+        'bar.234.567'     => ['v1.2.3-foo.123.456+bar.234.567'],
+        'SHA.q1w2e3r4t5'  => ['v1.2.3+SHA.q1w2e3r4t5'],
+      }
+      tests.each do |result, args|
+        SemVer.parse(*args).metadata.should == result
+      end
+    end
+    
+    it "is included in the return value from #to_s" do
+      SemVer.new(1, 2, 3, 'foo', 'bar').to_s.should == "v1.2.3-foo+bar"      
+    end
+    
+    it "replaces '%d' in the #format return value" do
+      SemVer.new(1, 2, 3, 'foo', 'bar').format('%d').should == '+bar'
+      SemVer.new.format('%d').should == ''
+    end
+    
+    it "must consist of only alphanumeric characters, hypens, and dots" do
+      invalid_metadatas = %w( $123 alpha+beta foo_ ~ sha:q1w2r4t5u7i8 exp[dsf] a\b\c 234(rc1) foo#bar .231 -abc )
+      valid_metadatas = %w( 123-abc. sha-12345 a 5 b- 4. 1....2---foo )
+      invalid_metadatas.each do |meta|
+        expect {
+          SemVer.new(1, 0, 0, 'foo', meta)
+        }.to raise_error(RuntimeError, "invalid metadata: #{meta}")
+      end
+      valid_metadatas.each do |meta|
+        SemVer.new(1, 0, 0, 'foo', meta)
+      end      
+    end
+    
+    it "is serialised to and from a file" do
+      tf = Tempfile.new 'semver.spec'
+      path = tf.path
+      tf.close!
+      v1 = SemVer.new
+      v1.metadata = "foo.123.456"
+      v1.save path
+      v2 = SemVer.new
+      v2.load path
+      v1.metadata.should == v2.metadata
+      v3 = SemVer.new
+      v3.save path
+      v4 = SemVer.new
+      v4.load path
+      v4.metadata.should == ''
+    end
+  end
+
+  describe 'rubygems format' do
+    { 'v2.3.1.rc.56' => SemVer.new(2, 3, 1, 'rc.56'),
+      'v2.3.1'       => SemVer.new(2, 3, 1),
+      'v2.3'         => SemVer.new(2, 3),
+      'v2'           => SemVer.new(2),
+      '2.3.1.rc.56'  => SemVer.new(2, 3, 1, 'rc.56'),
+      '2.3.1'        => SemVer.new(2, 3, 1),
+      '2.3'          => SemVer.new(2, 3),
+      '2'            => SemVer.new(2) }.
+      each do |input, expected|
+        it "should parse #{input}" do
+          ::SemVer.parse_rubygems(input).should eq(expected)
+        end
+      end
+  end
+
+end


### PR DESCRIPTION
Fixes #175:

Introduced modified version of [semver2](https://github.com/haf/semver) gem with more lenient version requirements:
(**2.1.1+b111.cef58a**, **2.1+b111.cef58a** and **2+b111.cef58**a will parse correctly)