### PR TITLE
Require dependent BaseResource

### DIFF
--- a/lib/pact_broker/api/resources/verification_triggered_webhooks.rb
+++ b/lib/pact_broker/api/resources/verification_triggered_webhooks.rb
@@ -1,3 +1,4 @@
+require 'pact_broker/api/resources/base_resource'
 require 'pact_broker/api/decorators/triggered_webhooks_decorator'
 
 module PactBroker


### PR DESCRIPTION
The pact broker doesn't run without this and, in turn, is breaking brokers that are pulling the latest deps instead of pinning.
Brought from here: https://github.com/DiUS/pact_broker-docker/issues/53#issuecomment-400343171