### PR TITLE
feat: correct provider state matching for merging

### DIFF
--- a/lib/pact_broker/pacts/merger.rb
+++ b/lib/pact_broker/pacts/merger.rb
@@ -48,7 +48,11 @@ module PactBroker
 
       def same_description_and_state? original, additional
         original["description"] == additional["description"] &&
-          original["provider_state"] == additional["provider_state"]
+          normalized_provider_states(original) == normalized_provider_states(additional)
+      end
+
+      def normalized_provider_states(interaction)
+        interaction.values_at("provider_state", "providerState", "providerStates").compact.first
       end
 
       def same_request_properties? original, additional

--- a/spec/lib/pact_broker/pacts/merger_spec.rb
+++ b/spec/lib/pact_broker/pacts/merger_spec.rb
@@ -66,6 +66,39 @@ module PactBroker
           expect(result["interactions"].length).to eq example_pact["interactions"].length + 1
         end
 
+        it "matches same provider state when is in v2 format" do
+          example_pact["interactions"][0]["providerState"] = "something in the way"
+          pact_to_merge["interactions"][0]["providerState"] = "something in the way"
+          pact_to_merge["interactions"][0]["response"]["body"] = "changed!"
+
+          result = merge_pacts(example_pact, pact_to_merge)
+
+          expect(result["interactions"].length).to eq example_pact["interactions"].length
+          expect(result["interactions"].first["response"]["body"]).to eq "changed!"
+        end
+
+        it "supports merging when provider state is in either v2 or v1 format" do
+          example_pact["interactions"][0]["provider_state"] = "system must resist"
+          pact_to_merge["interactions"][0]["providerState"] = "system must resist"
+          pact_to_merge["interactions"][0]["response"]["body"] = "changed!"
+
+          result = merge_pacts(example_pact, pact_to_merge)
+
+          expect(result["interactions"].length).to eq example_pact["interactions"].length
+          expect(result["interactions"].first["response"]["body"]).to eq "changed!"
+        end
+
+        it "supports merging when provider state is in v3 format with providerStates" do
+          example_pact["interactions"][0]["providerStates"] = [{ name: "a state" }]
+          pact_to_merge["interactions"][0]["providerStates"] = [{ name: "a state" }]
+          pact_to_merge["interactions"][0]["response"]["body"] = "changed!"
+
+          result = merge_pacts(example_pact, pact_to_merge)
+
+          expect(result["interactions"].length).to eq example_pact["interactions"].length
+          expect(result["interactions"].first["response"]["body"]).to eq "changed!"
+        end
+
         # helper that lets these specs deal with hashes instead of JSON strings
         def merge_pacts(a, b, return_hash = true)
           result = PactBroker::Pacts::Merger.merge_pacts(a.to_json, b.to_json)


### PR DESCRIPTION
Correct dealing with various forms of provider state. There are 3 options:

- provider_state (was supported until now) but it is part of v1 specification
- providerState wasn't supported, which is part of v2 specification
- providerStates with array of objects containing at least name attribute. This is part of specification v3 and also is used by pact-message-ruby extensively.

Without this submission any submit of two contracts with merge-mode and same version when the description is same but provider state vary would fail.