### PR TITLE
fix: Latest pact published column does text sort

### DIFF
--- a/lib/pact_broker/ui/view_models/index_item.rb
+++ b/lib/pact_broker/ui/view_models/index_item.rb
@@ -131,6 +131,10 @@ module PactBroker
           PactBroker::DateHelper.distance_of_time_in_words(date, DateTime.now) + " ago"
         end
 
+        def publication_date_of_latest_pact_order
+          @relationship.latest_pact.created_at.to_time.to_i
+        end
+
         def verification_status
           case @relationship.verification_status
             when :success then "success"

--- a/lib/pact_broker/ui/views/index/show.haml
+++ b/lib/pact_broker/ui/views/index/show.haml
@@ -42,7 +42,7 @@
               %a{ href: index_item.provider_group_url }
                 = escape_html(index_item.provider_name)
             %td
-            %td
+            %td{"data-text": index_item.publication_date_of_latest_pact_order}
               = index_item.publication_date_of_latest_pact
             %td{class: index_item.webhook_status}
               %a{ href: index_item.webhook_url }


### PR DESCRIPTION
Use `data-text` attribute with date converted to integer to properly sort column.

tablesorter documentation (See `textAttribute` under `Configuration` section):
https://mottie.github.io/tablesorter/docs/#Configuration
