### PR TITLE
fix: do not show clipboard icon if version is blank

### DIFF
--- a/lib/pact_broker/ui/views/index/show-with-tags.haml
+++ b/lib/pact_broker/ui/views/index/show-with-tags.haml
@@ -41,8 +41,9 @@
             %td.consumer-version-number
               %div.clippable
                 = escape_html(index_item.consumer_version_number)
-                %button.clippy.invisible{ title: "Copy to clipboard" }
-                  %span.glyphicon.glyphicon-copy
+                - if index_item.consumer_version_number
+                  %button.clippy.invisible{ title: "Copy to clipboard" }
+                    %span.glyphicon.glyphicon-copy
               - if index_item.latest?
                 .tag.label.label-success
                   latest
@@ -60,8 +61,9 @@
             %td.provider-version-number
               %div.clippable
                 = escape_html(index_item.provider_version_number)
-                %button.clippy.invisible{ title: "Copy to clipboard" }
-                  %span.glyphicon.glyphicon-copy
+                - if index_item.provider_version_number
+                  %button.clippy.invisible{ title: "Copy to clipboard" }
+                    %span.glyphicon.glyphicon-copy
               - index_item.provider_version_latest_tag_names.each do | tag_name |
                 .tag.label.label-primary
                   = escape_html(tag_name)

--- a/lib/pact_broker/ui/views/matrix/show.haml
+++ b/lib/pact_broker/ui/views/matrix/show.haml
@@ -106,8 +106,9 @@
             %div.clippable
               %a{href: line.consumer_version_number_url}
                 = line.display_consumer_version_number
-              %button.clippy.invisible{ title: "Copy to clipboard" }
-                %span.glyphicon.glyphicon-copy
+              - if line.display_consumer_version_number
+                %button.clippy.invisible{ title: "Copy to clipboard" }
+                  %span.glyphicon.glyphicon-copy
             - line.latest_consumer_version_tags.each do | tag |
               .tag-parent{"title": tag.tooltip, "data-toggle": "tooltip", "data-placement": "right"}
                 %a{href: tag.url}
@@ -132,8 +133,9 @@
             %div.clippable
               %a{href: line.provider_version_number_url}
                 = line.display_provider_version_number
-              %button.clippy.invisible{ title: "Copy to clipboard" }
-                %span.glyphicon.glyphicon-copy
+              - if line.display_provider_version_number
+                %button.clippy.invisible{ title: "Copy to clipboard" }
+                  %span.glyphicon.glyphicon-copy
             - line.latest_provider_version_tags.each do | tag |
               .tag-parent{"title": tag.tooltip, "data-toggle": "tooltip", "data-placement": "right"}
                 %a{href: tag.url}


### PR DESCRIPTION
## Description
Clipboard icon is shown even when version is blank.

This PR is to make sure we only show this icon when version is not blank.