### PR TITLE
fix(index with tags): sort pact publication by date, not string

### DIFF
--- a/lib/pact_broker/ui/views/index/show-with-tags.haml
+++ b/lib/pact_broker/ui/views/index/show-with-tags.haml
@@ -67,7 +67,7 @@
               - index_item.provider_version_latest_tag_names.each do | tag_name |
                 .tag.label.label-primary
                   = escape_html(tag_name)
-            %td
+            %td{"data-text": index_item.publication_date_of_latest_pact_order}
               = index_item.publication_date_of_latest_pact.gsub("about ", "")
             %td{ class: index_item.webhook_status }
               - if index_item.show_webhook_status?


### PR DESCRIPTION
Use data-text attribute with date converted to integer to properly sort column.

tablesorter documentation (See textAttribute under Configuration section):
https://mottie.github.io/tablesorter/docs/#Configuration