### PR TITLE
fix(frontend): remove 'v' prefix on versions during render

### DIFF
--- a/lib/pact_broker/domain/pact.rb
+++ b/lib/pact_broker/domain/pact.rb
@@ -47,7 +47,7 @@ module PactBroker
       end
 
       def name
-        "Pact between #{consumer.name} (v#{consumer_version_number}) and #{provider.name}"
+        "Pact between #{consumer.name} (#{consumer_version_number}) and #{provider.name}"
       end
 
       def version_and_updated_date

--- a/lib/pact_broker/matrix/row.rb
+++ b/lib/pact_broker/matrix/row.rb
@@ -215,7 +215,7 @@ module PactBroker
       end
 
       def to_s
-        "#{consumer_name} v#{consumer_version_number} #{provider_name} #{provider_version_number} #{success}"
+        "#{consumer_name} #{consumer_version_number} #{provider_name} #{provider_version_number} #{success}"
       end
 
       def compare_number_desc number1, number2

--- a/lib/pact_broker/ui/view_models/index_item.rb
+++ b/lib/pact_broker/ui/view_models/index_item.rb
@@ -151,11 +151,11 @@ module PactBroker
         def verification_tooltip
           case @relationship.pseudo_branch_verification_status
           when :success
-            "Successfully verified by #{provider_name} (v#{short_version_number(@relationship.latest_verification_provider_version_number)})"
+            "Successfully verified by #{provider_name} (#{short_version_number(@relationship.latest_verification_provider_version_number)})"
           when :stale
-            "Pact has changed since last successful verification by #{provider_name} (v#{short_version_number(@relationship.latest_verification_provider_version_number)})"
+            "Pact has changed since last successful verification by #{provider_name} (#{short_version_number(@relationship.latest_verification_provider_version_number)})"
           when :failed
-            "Verification by #{provider_name} (v#{short_version_number(@relationship.latest_verification_provider_version_number)}) failed"
+            "Verification by #{provider_name} (#{short_version_number(@relationship.latest_verification_provider_version_number)}) failed"
           else
             nil
           end

--- a/spec/lib/pact_broker/pacts/diff_spec.rb
+++ b/spec/lib/pact_broker/pacts/diff_spec.rb
@@ -59,8 +59,8 @@ module PactBroker
           subject { Diff.new.process(pact_params.merge(base_url: 'http://example.org'), comparison_pact_params) }
 
           it "compares the two pacts" do
-            expect(subject).to include "Pact between Consumer (v3) and Provider"
-            expect(subject).to include "Pact between Consumer (v4) and Provider"
+            expect(subject).to include "Pact between Consumer (3) and Provider"
+            expect(subject).to include "Pact between Consumer (4) and Provider"
           end
 
           it "includes a link to the comparison pact", pending: true do

--- a/spec/lib/pact_broker/ui/view_models/index_item_spec.rb
+++ b/spec/lib/pact_broker/ui/view_models/index_item_spec.rb
@@ -52,21 +52,21 @@ module PactBroker
             let(:pseudo_branch_verification_status) { :stale }
             its(:pseudo_branch_verification_status) { is_expected.to eq "warning" }
             its(:warning?) { is_expected.to be true }
-            its(:verification_tooltip) { is_expected.to eq "Pact has changed since last successful verification by Foo (v4.5.6)" }
+            its(:verification_tooltip) { is_expected.to eq "Pact has changed since last successful verification by Foo (4.5.6)" }
           end
 
           context "when the pact has not changed since the last successful verification" do
             let(:pseudo_branch_verification_status) { :success }
             its(:pseudo_branch_verification_status) { is_expected.to eq "success" }
             its(:warning?) { is_expected.to be false }
-            its(:verification_tooltip) { is_expected.to eq "Successfully verified by Foo (v4.5.6)" }
+            its(:verification_tooltip) { is_expected.to eq "Successfully verified by Foo (4.5.6)" }
           end
 
           context "when the pact verification failed" do
             let(:pseudo_branch_verification_status) { :failed }
             its(:pseudo_branch_verification_status) { is_expected.to eq "danger" }
             its(:warning?) { is_expected.to be false }
-            its(:verification_tooltip) { is_expected.to eq "Verification by Foo (v4.5.6) failed" }
+            its(:verification_tooltip) { is_expected.to eq "Verification by Foo (4.5.6) failed" }
           end
         end
 


### PR DESCRIPTION
This prevents confusion when looking at versions in the frontend,
and seeing things like `vv1.0.0` or `vfd1245b` where the first 'v'
is artificially added.

### HAL Response
Before:
![2019-10-21-191914_grim](https://user-images.githubusercontent.com/2515325/67227925-81878900-f438-11e9-9803-69ddf4404872.png)
After: 
![2019-10-21-191801_grim](https://user-images.githubusercontent.com/2515325/67227922-80eef280-f438-11e9-84f3-aa33bcb160e6.png)

### Tooltips
Before:
![2019-10-21-191856_grim](https://user-images.githubusercontent.com/2515325/67227924-81878900-f438-11e9-8295-7802339d2dd1.png)
After:
![2019-10-21-191813_grim](https://user-images.githubusercontent.com/2515325/67227923-80eef280-f438-11e9-8774-7729d3c46e64.png)
