### PR TITLE
chore: remove duplicated methods in MatrixLine

### DIFF
--- a/lib/pact_broker/ui/view_models/matrix_line.rb
+++ b/lib/pact_broker/ui/view_models/matrix_line.rb
@@ -8,7 +8,6 @@ module PactBroker
   module UI
     module ViewDomain
       class MatrixLine
-
         include PactBroker::Api::PactBrokerUrls
 
         def initialize line
@@ -45,10 +44,6 @@ module PactBroker
           @line.pact_revision_number
         end
 
-        def consumer_name
-          @line.consumer_name
-        end
-
         def consumer_version_number
           @line.consumer_version_number
         end
@@ -66,20 +61,12 @@ module PactBroker
           @line.consumer_version_order
         end
 
-        def provider_name
-          @line.provider_name
-        end
-
         def provider_version_number
           @line.provider_version_number
         end
 
         def display_provider_version_number
           PactBroker::Versions::AbbreviateNumber.call(provider_version_number)
-        end
-
-        def provider_version_order
-          @line.provider_version_order
         end
 
         def provider_version_number_url

--- a/spec/lib/pact_broker/ui/view_models/matrix_line_spec.rb
+++ b/spec/lib/pact_broker/ui/view_models/matrix_line_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+require "pact_broker/matrix/quick_row"
+require "pact_broker/ui/view_models/matrix_line"
+
+module PactBroker
+  module UI
+    module ViewDomain
+      describe MatrixLine do
+        let(:line) { instance_spy(PactBroker::Matrix::QuickRow) }
+
+        subject(:matrix_line) { described_class.new(line) }
+
+        describe "#provide_version_order" do
+          subject(:provider_version_order) { matrix_line.provider_version_order }
+
+          context "verification execution time exists" do
+            let(:verification_executed_at) { Time.now }
+
+            before do
+              allow(line).to receive(:verification_executed_at)
+                .and_return(verification_executed_at)
+            end
+
+            it "returns verification execution timestamp" do
+              timestamp = verification_executed_at.to_i
+
+              expect(provider_version_order).to eq(timestamp)
+            end
+          end
+
+          context "verification execution time does not exist" do
+            before do
+              allow(line).to receive(:verification_executed_at).and_return(nil)
+            end
+
+            it { is_expected.to eq(0) }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Remove duplicated methods in `MatrixLine`.

As discovered per https://codeclimate.com/github/pact-foundation/pact_broker/lib/pact_broker/ui/view_models/matrix_line.rb
