### PR TITLE
fix: trigger one webhook for each pact publication that the verified …

### DIFF
--- a/lib/pact_broker/api/resources/verifications.rb
+++ b/lib/pact_broker/api/resources/verifications.rb
@@ -50,7 +50,7 @@ module PactBroker
         end
 
         def from_json
-          verification = verification_service.create(next_verification_number, verification_params, pact, metadata, webhook_options)
+          verification = verification_service.create(next_verification_number, verification_params, pact, event_context, webhook_options)
           response.body = decorator_for(verification).to_json(decorator_options)
           true
         end
@@ -81,11 +81,14 @@ module PactBroker
           metadata[:wip] == 'true'
         end
 
+        def event_context
+          metadata
+        end
+
         def webhook_options
           {
             database_connector: database_connector,
             webhook_execution_configuration: webhook_execution_configuration
-                                      .with_webhook_context(metadata)
           }
         end
 

--- a/lib/pact_broker/api/resources/webhook_execution.rb
+++ b/lib/pact_broker/api/resources/webhook_execution.rb
@@ -26,7 +26,7 @@ module PactBroker
         end
 
         def process_post
-          webhook_execution_result = webhook_service.test_execution(webhook, webhook_execution_configuration)
+          webhook_execution_result = webhook_service.test_execution(webhook, webhook_execution_configuration.webhook_context, webhook_execution_configuration)
           response.headers['Content-Type'] = 'application/hal+json;charset=utf-8'
           response.body = post_response_body(webhook_execution_result)
           true

--- a/lib/pact_broker/domain/webhook.rb
+++ b/lib/pact_broker/domain/webhook.rb
@@ -52,15 +52,15 @@ module PactBroker
         request && request.description
       end
 
-      def execute pact, verification, options
-        logger.info "Executing #{self} webhook_context=#{options.fetch(:webhook_context)}"
-        webhook_request = request.build(template_parameters(pact, verification, options))
+      def execute pact, verification, event_context, options
+        logger.info "Executing #{self} event_context=#{event_context}"
+        webhook_request = request.build(template_parameters(pact, verification, event_context, options))
         http_response, error = execute_request(webhook_request)
 
         PactBroker::Webhooks::WebhookExecutionResult.new(
           webhook_request.http_request,
           http_response,
-          generate_logs(webhook_request, http_response, error, options[:webhook_context], options.fetch(:logging_options)),
+          generate_logs(webhook_request, http_response, error, event_context, options.fetch(:logging_options)),
           error
         )
       end
@@ -106,18 +106,18 @@ module PactBroker
         return http_response, error
       end
 
-      def template_parameters(pact, verification, options)
-        PactBroker::Webhooks::PactAndVerificationParameters.new(pact, verification, options.fetch(:webhook_context)).to_hash
+      def template_parameters(pact, verification, event_context, options)
+        PactBroker::Webhooks::PactAndVerificationParameters.new(pact, verification, event_context).to_hash
       end
 
-      def generate_logs(webhook_request, http_response, error, webhook_context, logging_options)
+      def generate_logs(webhook_request, http_response, error, event_context, logging_options)
         webhook_request_logger = PactBroker::Webhooks::WebhookRequestLogger.new(logging_options)
         webhook_request_logger.log(
           uuid,
           webhook_request,
           http_response,
           error,
-          webhook_context
+          event_context
         )
       end
     end

--- a/lib/pact_broker/hash_refinements.rb
+++ b/lib/pact_broker/hash_refinements.rb
@@ -30,6 +30,10 @@ module PactBroker
         keys.each_with_object(Hash.new) { |k, hash| hash[k] = self[k] if has_key?(k) }
       end
 
+      def without(*keys)
+        reject { |k,_| keys.include?(k) }
+      end
+
       def camelcase_keys
         camelcase_keys_private(self)
       end

--- a/lib/pact_broker/webhooks/pact_and_verification_parameters.rb
+++ b/lib/pact_broker/webhooks/pact_and_verification_parameters.rb
@@ -13,6 +13,7 @@ module PactBroker
       BITBUCKET_VERIFICATION_STATUS = 'pactbroker.bitbucketVerificationStatus'
       CONSUMER_LABELS = 'pactbroker.consumerLabels'
       PROVIDER_LABELS = 'pactbroker.providerLabels'
+      EVENT_NAME = 'pactbroker.eventName'
 
       ALL = [
         CONSUMER_NAME,
@@ -26,7 +27,8 @@ module PactBroker
         GITHUB_VERIFICATION_STATUS,
         BITBUCKET_VERIFICATION_STATUS,
         CONSUMER_LABELS,
-        PROVIDER_LABELS
+        PROVIDER_LABELS,
+        EVENT_NAME
       ]
 
       def initialize(pact, trigger_verification, webhook_context)
@@ -49,7 +51,8 @@ module PactBroker
           GITHUB_VERIFICATION_STATUS => github_verification_status,
           BITBUCKET_VERIFICATION_STATUS => bitbucket_verification_status,
           CONSUMER_LABELS => pacticipant_labels(pact && pact.consumer),
-          PROVIDER_LABELS => pacticipant_labels(pact && pact.provider)
+          PROVIDER_LABELS => pacticipant_labels(pact && pact.provider),
+          EVENT_NAME => event_name
         }
       end
 
@@ -115,6 +118,10 @@ module PactBroker
 
       def pacticipant_labels pacticipant
         pacticipant && pacticipant.labels ? pacticipant.labels.collect(&:name).join(", ") : ""
+      end
+
+      def event_name
+        webhook_context.fetch(:event_name)
       end
     end
   end

--- a/lib/pact_broker/webhooks/triggered_webhook.rb
+++ b/lib/pact_broker/webhooks/triggered_webhook.rb
@@ -1,6 +1,7 @@
 require 'sequel'
 require 'pact_broker/repositories/helpers'
 require 'pact_broker/webhooks/execution'
+require 'pact_broker/hash_refinements'
 
 # Represents the relationship between a webhook and the event and object
 # that caused it to be triggered. eg a pact publication
@@ -8,6 +9,7 @@ require 'pact_broker/webhooks/execution'
 module PactBroker
   module Webhooks
     class TriggeredWebhook < Sequel::Model(:triggered_webhooks)
+      using PactBroker::HashRefinements
       plugin :timestamps, update_on_create: true
       plugin :serialization, :json, :event_context
 
@@ -60,7 +62,7 @@ module PactBroker
         # getting a random 'no method to_domain for null' error
         # not sure on which object, so splitting this out into two lines
         pact = pact_publication.to_domain
-        webhook.to_domain.execute(pact, verification, options)
+        webhook.to_domain.execute(pact, verification, event_context.symbolize_keys, options)
       end
 
       def consumer_name

--- a/spec/lib/pact_broker/api/resources/verifications_spec.rb
+++ b/spec/lib/pact_broker/api/resources/verifications_spec.rb
@@ -81,11 +81,6 @@ module PactBroker
               expect(subject.headers['Location']).to eq("http://example.org/pacts/provider/Provider/consumer/Consumer/pact-version/1234/verification-results/2")
             end
 
-            it "merges the upstream verification metdata into the webhook context" do
-              expect(webhook_execution_configuration).to receive(:with_webhook_context).with(parsed_metadata)
-              subject
-            end
-
             it "stores the verification in the database" do
               expect(PactBroker::Verifications::Service).to receive(:create).with(
                 next_verification_number,

--- a/spec/lib/pact_broker/api/resources/webhook_execution_spec.rb
+++ b/spec/lib/pact_broker/api/resources/webhook_execution_spec.rb
@@ -30,7 +30,8 @@ module PactBroker
             let(:pact) { instance_double("PactBroker::Domain::Pact") }
             let(:consumer_name) { "foo" }
             let(:provider_name) { "bar" }
-            let(:webhook_execution_configuration) { instance_double(PactBroker::Webhooks::ExecutionConfiguration) }
+            let(:webhook_execution_configuration) { instance_double(PactBroker::Webhooks::ExecutionConfiguration, webhook_context: event_context) }
+            let(:event_context) { { some: "data" } }
 
             before do
               allow(PactBroker::Webhooks::Service).to receive(:test_execution).and_return(execution_result)
@@ -39,7 +40,7 @@ module PactBroker
             end
 
             it "executes the webhook" do
-              expect(PactBroker::Webhooks::Service).to receive(:test_execution).with(webhook, webhook_execution_configuration)
+              expect(PactBroker::Webhooks::Service).to receive(:test_execution).with(webhook, event_context, webhook_execution_configuration)
               subject
             end
 

--- a/spec/lib/pact_broker/domain/webhook_spec.rb
+++ b/spec/lib/pact_broker/domain/webhook_spec.rb
@@ -12,9 +12,9 @@ module PactBroker
       let(:webhook_template_parameters_hash) { { 'foo' => 'bar' } }
       let(:http_request) { double('http request') }
       let(:http_response) { double('http response') }
-      let(:webhook_context) { { some: 'things' } }
+      let(:event_context) { { some: 'things' } }
       let(:logging_options) { { other: 'options' } }
-      let(:options) { { webhook_context: webhook_context, logging_options: logging_options } }
+      let(:options) { { logging_options: logging_options } }
       let(:pact) { double('pact') }
       let(:verification) { double('verification') }
       let(:logger) { double('logger').as_null_object }
@@ -61,11 +61,11 @@ module PactBroker
 
         let(:webhook_request_logger) { instance_double(PactBroker::Webhooks::WebhookRequestLogger, log: "logs") }
 
-        let(:execute) { subject.execute pact, verification, options }
+        let(:execute) { subject.execute(pact, verification, event_context, options) }
 
         it "creates the template parameters" do
           expect(PactBroker::Webhooks::PactAndVerificationParameters).to receive(:new).with(
-            pact, verification, webhook_context
+            pact, verification, event_context
           )
           execute
         end
@@ -81,7 +81,7 @@ module PactBroker
         end
 
         it "generates the execution logs" do
-          expect(webhook_request_logger).to receive(:log).with(uuid, webhook_request, http_response, nil, webhook_context)
+          expect(webhook_request_logger).to receive(:log).with(uuid, webhook_request, http_response, nil, event_context)
           execute
         end
 
@@ -106,7 +106,7 @@ module PactBroker
           end
 
           it "generates the execution logs" do
-            expect(webhook_request_logger).to receive(:log).with(uuid, webhook_request, nil, instance_of(error_class), webhook_context)
+            expect(webhook_request_logger).to receive(:log).with(uuid, webhook_request, nil, instance_of(error_class), event_context)
             execute
           end
 

--- a/spec/lib/pact_broker/webhooks/render_spec.rb
+++ b/spec/lib/pact_broker/webhooks/render_spec.rb
@@ -94,7 +94,7 @@ module PactBroker
           [ double("label", name: "foo"), double("label", name: "bar") ]
         end
 
-        let(:webhook_context) { { base_url: base_url } }
+        let(:webhook_context) { { base_url: base_url, event_name: "something" } }
 
         let(:nil_pact) { nil }
         let(:nil_verification) { nil }
@@ -158,7 +158,8 @@ module PactBroker
             {
               consumer_version_number: "webhook-version-number",
               consumer_version_tags: %w[webhook tags],
-              base_url: base_url
+              base_url: base_url,
+              event_name: "something"
 
             }
           end
@@ -186,16 +187,16 @@ module PactBroker
         let(:base_url) { "http://broker" }
 
         let(:template_parameters) do
-          PactAndVerificationParameters.new(placeholder_pact, nil, { base_url: base_url }).to_hash
+          PactAndVerificationParameters.new(placeholder_pact, nil, { base_url: base_url, event_name: "something" }).to_hash
         end
 
         it "does not blow up with a placeholder pact" do
-          template_parameters = PactAndVerificationParameters.new(placeholder_pact, nil, { base_url: base_url }).to_hash
+          template_parameters = PactAndVerificationParameters.new(placeholder_pact, nil, { base_url: base_url, event_name: "something" }).to_hash
           Render.call("", template_parameters)
         end
 
         it "does not blow up with a placeholder verification" do
-          template_parameters = PactAndVerificationParameters.new(placeholder_pact, placeholder_verification, { base_url: base_url }).to_hash
+          template_parameters = PactAndVerificationParameters.new(placeholder_pact, placeholder_verification, { base_url: base_url, event_name: "something" }).to_hash
           Render.call("", template_parameters)
         end
       end

--- a/spec/lib/pact_broker/webhooks/service_spec.rb
+++ b/spec/lib/pact_broker/webhooks/service_spec.rb
@@ -181,8 +181,9 @@ module PactBroker
         let(:webhooks) { [instance_double(PactBroker::Domain::Webhook, description: 'description', uuid: '1244')]}
         let(:triggered_webhook) { instance_double(PactBroker::Webhooks::TriggeredWebhook) }
         let(:webhook_execution_configuration) { double('webhook_execution_configuration', webhook_context: webhook_context) }
-        let(:webhook_context) { double('webhook_context') }
+        let(:webhook_context) { { base_url: "http://example.org" } }
         let(:event_context) { { some: "data" } }
+        let(:expected_event_context) { { some: "data", event_name: PactBroker::Webhooks::WebhookEvent::CONTRACT_CONTENT_CHANGED, base_url: "http://example.org" } }
         let(:options) do
           { database_connector: double('database_connector'),
             webhook_execution_configuration: webhook_execution_configuration,
@@ -197,7 +198,7 @@ module PactBroker
           allow(Job).to receive(:perform_in)
         end
 
-        subject { Service.trigger_webhooks pact, verification, PactBroker::Webhooks::WebhookEvent::CONTRACT_CONTENT_CHANGED, event_context, options }
+        subject { Service.trigger_webhooks(pact, verification, PactBroker::Webhooks::WebhookEvent::CONTRACT_CONTENT_CHANGED, event_context, options) }
 
         it "finds the webhooks" do
           expect_any_instance_of(PactBroker::Webhooks::Repository).to receive(:find_by_consumer_and_or_provider_and_event_name).with(consumer, provider, PactBroker::Webhooks::WebhookEvent::DEFAULT_EVENT_NAME)
@@ -206,7 +207,7 @@ module PactBroker
 
         context "when webhooks are found" do
           it "executes the webhook" do
-            expect(Service).to receive(:run_later).with(webhooks, pact, verification, PactBroker::Webhooks::WebhookEvent::CONTRACT_CONTENT_CHANGED, options)
+            expect(Service).to receive(:run_later).with(webhooks, pact, verification, PactBroker::Webhooks::WebhookEvent::CONTRACT_CONTENT_CHANGED, expected_event_context, options)
             subject
           end
 
@@ -259,6 +260,7 @@ module PactBroker
           instance_double(PactBroker::Webhooks::ExecutionConfiguration, to_hash: execution_configuration_hash)
         end
         let(:execution_configuration_hash) { { the: 'options' } }
+        let(:event_context) { { some: "data" } }
 
         before do
           allow(PactBroker::Pacts::Service).to receive(:search_for_latest_pact).and_return(pact)
@@ -267,7 +269,7 @@ module PactBroker
           allow(execution_configuration).to receive(:with_failure_log_message).and_return(execution_configuration)
         end
 
-        subject { Service.test_execution(webhook, execution_configuration) }
+        subject { Service.test_execution(webhook, event_context, execution_configuration) }
 
         it "searches for the latest matching pact" do
           expect(PactBroker::Pacts::Service).to receive(:search_for_latest_pact).with(consumer_name: 'consumer', provider_name: 'provider')
@@ -280,7 +282,7 @@ module PactBroker
 
         context "when the trigger is not for a verification" do
           it "executes the webhook with the pact" do
-            expect(webhook).to receive(:execute).with(pact, nil, execution_configuration_hash)
+            expect(webhook).to receive(:execute).with(pact, nil, event_context.merge(event_name: "test"), execution_configuration_hash)
             subject
           end
         end
@@ -289,7 +291,7 @@ module PactBroker
           let(:pact) { nil }
 
           it "executes the webhook with a placeholder pact" do
-            expect(webhook).to receive(:execute).with(an_instance_of(PactBroker::Pacts::PlaceholderPact), anything, anything)
+            expect(webhook).to receive(:execute).with(an_instance_of(PactBroker::Pacts::PlaceholderPact), anything, anything, anything)
             subject
           end
         end
@@ -303,7 +305,7 @@ module PactBroker
           end
 
           it "executes the webhook with the pact and the verification" do
-            expect(webhook).to receive(:execute).with(pact, verification, execution_configuration_hash)
+            expect(webhook).to receive(:execute).with(pact, verification, event_context.merge(event_name: "test"), execution_configuration_hash)
             subject
           end
 
@@ -311,7 +313,7 @@ module PactBroker
             let(:verification) { nil }
 
             it "executes the webhook with a placeholder verification" do
-              expect(webhook).to receive(:execute).with(anything, an_instance_of(PactBroker::Verifications::PlaceholderVerification), anything)
+              expect(webhook).to receive(:execute).with(anything, an_instance_of(PactBroker::Verifications::PlaceholderVerification), anything, anything)
               subject
             end
           end
@@ -330,7 +332,7 @@ module PactBroker
             .with_webhook_context(base_url: 'http://example.org')
             .with_show_response(true)
         end
-        let(:event_context) { { some: "data" }}
+        let(:event_context) { { some: "data", base_url: "http://example.org" }}
         let(:options) do
           {
             database_connector: database_connector,
@@ -349,7 +351,7 @@ module PactBroker
             .and_return(:pact)
         end
 
-        subject { PactBroker::Webhooks::Service.trigger_webhooks pact, td.verification, PactBroker::Webhooks::WebhookEvent::CONTRACT_CONTENT_CHANGED, event_context, options }
+        subject { PactBroker::Webhooks::Service.trigger_webhooks(pact, td.verification, PactBroker::Webhooks::WebhookEvent::CONTRACT_CONTENT_CHANGED, event_context, options) }
 
         it "executes the HTTP request of the webhook" do
           subject


### PR DESCRIPTION
…content belongs to when using the 'pacts for verification' API

Fixes https://github.com/pact-foundation/pact_broker/issues/362
