### PR TITLE
feat/239: Add new configuration 'webhook_http_code_whitelist'

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -26,6 +26,7 @@ app = PactBroker::App.new do | config |
   config.webhook_host_whitelist = [/.*/, "10.0.0.0/8"]
   config.webhook_scheme_whitelist = ['http', 'https']
   config.webhook_http_method_whitelist = ['GET', 'POST']
+  config.webhook_http_code_whitelist = [200, 201, 202]
   #config.base_url = ENV['PACT_BROKER_BASE_URL']
 
   database_logger = PactBroker::DB::LogQuietener.new(config.logger)

--- a/config.ru
+++ b/config.ru
@@ -26,7 +26,7 @@ app = PactBroker::App.new do | config |
   config.webhook_host_whitelist = [/.*/, "10.0.0.0/8"]
   config.webhook_scheme_whitelist = ['http', 'https']
   config.webhook_http_method_whitelist = ['GET', 'POST']
-  config.webhook_http_code_whitelist = [200, 201, 202]
+  config.webhook_http_code_success = [200, 201, 202, 203, 204, 205, 206]
   #config.base_url = ENV['PACT_BROKER_BASE_URL']
 
   database_logger = PactBroker::DB::LogQuietener.new(config.logger)

--- a/lib/pact_broker/config/space_delimited_integer_list.rb
+++ b/lib/pact_broker/config/space_delimited_integer_list.rb
@@ -1,0 +1,25 @@
+module PactBroker
+  module Config
+    class SpaceDelimitedIntegerList < Array
+      def initialize list
+        super(list)
+      end
+
+      def self.integer?(string)
+        (Integer(string) rescue nil) != nil
+      end
+
+      def self.parse(string)
+        array = (string || '')
+                    .split(' ')
+                    .filter { |word| integer?(word) }
+                    .collect(&:to_i)
+        SpaceDelimitedIntegerList.new(array)
+      end
+
+      def to_s
+        collect(&:to_s).join(' ')
+      end
+    end
+  end
+end

--- a/lib/pact_broker/config/space_delimited_integer_list.rb
+++ b/lib/pact_broker/config/space_delimited_integer_list.rb
@@ -12,7 +12,7 @@ module PactBroker
       def self.parse(string)
         array = (string || '')
                     .split(' ')
-                    .filter { |word| integer?(word) }
+                    .select { |word| integer?(word) }
                     .collect(&:to_i)
         SpaceDelimitedIntegerList.new(array)
       end

--- a/lib/pact_broker/configuration.rb
+++ b/lib/pact_broker/configuration.rb
@@ -50,7 +50,7 @@ module PactBroker
     attr_accessor :check_for_potential_duplicate_pacticipant_names
     attr_accessor :webhook_retry_schedule
     attr_accessor :user_agent
-    attr_reader :webhook_http_method_whitelist, :webhook_scheme_whitelist, :webhook_host_whitelist, :webhook_http_code_whitelist
+    attr_reader :webhook_http_method_whitelist, :webhook_scheme_whitelist, :webhook_host_whitelist, :webhook_http_code_success
     attr_accessor :semver_formats
     attr_accessor :enable_public_badge_access, :shields_io_base_url, :badge_provider_mode
     attr_accessor :disable_ssl_verification
@@ -106,7 +106,7 @@ module PactBroker
       config.check_for_potential_duplicate_pacticipant_names = true
       config.disable_ssl_verification = false
       config.webhook_http_method_whitelist = ['POST']
-      config.webhook_http_code_whitelist = [200, 201, 202]
+      config.webhook_http_code_success = [200, 201, 202, 203, 204, 205, 206]
       config.webhook_scheme_whitelist = ['https']
       config.webhook_host_whitelist = []
       # TODO get rid of unsafe-inline
@@ -242,8 +242,8 @@ module PactBroker
       @webhook_http_method_whitelist = parse_space_delimited_string_list_property('webhook_http_method_whitelist', webhook_http_method_whitelist)
     end
 
-    def webhook_http_code_whitelist= webhook_http_code_whitelist
-      @webhook_http_code_whitelist = parse_space_delimited_integer_list_property('webhook_http_code_whitelist', webhook_http_code_whitelist)
+    def webhook_http_code_success= webhook_http_code_success
+      @webhook_http_code_success = parse_space_delimited_integer_list_property('webhook_http_code_success', webhook_http_code_success)
     end
 
     def webhook_scheme_whitelist= webhook_scheme_whitelist

--- a/lib/pact_broker/configuration.rb
+++ b/lib/pact_broker/configuration.rb
@@ -1,6 +1,7 @@
 require 'pact_broker/version'
 require 'pact_broker/error'
 require 'pact_broker/config/space_delimited_string_list'
+require 'pact_broker/config/space_delimited_integer_list'
 require 'semantic_logger'
 
 module PactBroker
@@ -49,7 +50,7 @@ module PactBroker
     attr_accessor :check_for_potential_duplicate_pacticipant_names
     attr_accessor :webhook_retry_schedule
     attr_accessor :user_agent
-    attr_reader :webhook_http_method_whitelist, :webhook_scheme_whitelist, :webhook_host_whitelist
+    attr_reader :webhook_http_method_whitelist, :webhook_scheme_whitelist, :webhook_host_whitelist, :webhook_http_code_whitelist
     attr_accessor :semver_formats
     attr_accessor :enable_public_badge_access, :shields_io_base_url, :badge_provider_mode
     attr_accessor :disable_ssl_verification
@@ -105,6 +106,7 @@ module PactBroker
       config.check_for_potential_duplicate_pacticipant_names = true
       config.disable_ssl_verification = false
       config.webhook_http_method_whitelist = ['POST']
+      config.webhook_http_code_whitelist = [200, 201, 202]
       config.webhook_scheme_whitelist = ['https']
       config.webhook_host_whitelist = []
       # TODO get rid of unsafe-inline
@@ -240,6 +242,10 @@ module PactBroker
       @webhook_http_method_whitelist = parse_space_delimited_string_list_property('webhook_http_method_whitelist', webhook_http_method_whitelist)
     end
 
+    def webhook_http_code_whitelist= webhook_http_code_whitelist
+      @webhook_http_code_whitelist = parse_space_delimited_integer_list_property('webhook_http_code_whitelist', webhook_http_code_whitelist)
+    end
+
     def webhook_scheme_whitelist= webhook_scheme_whitelist
       @webhook_scheme_whitelist = parse_space_delimited_string_list_property('webhook_scheme_whitelist', webhook_scheme_whitelist)
     end
@@ -269,5 +275,15 @@ module PactBroker
         raise ConfigurationError.new("Pact Broker configuration property `#{property_name}` must be a space delimited String or an Array")
       end
     end
+
+    def parse_space_delimited_integer_list_property property_name, property_value
+      case property_value
+      when String then Config::SpaceDelimitedIntegerList.parse(property_value)
+      when Array then Config::SpaceDelimitedIntegerList.new(property_value)
+      else
+        raise ConfigurationError.new("Pact Broker configuration property `#{property_name}` must be a space delimited String or an Array with Integer values")
+      end
+    end
+
   end
 end

--- a/lib/pact_broker/webhooks/webhook_request_logger.rb
+++ b/lib/pact_broker/webhooks/webhook_request_logger.rb
@@ -117,8 +117,12 @@ module PactBroker
       end
 
       def success?(response)
-        !response.nil? && response.code.to_i < 300
+        unless response.nil?
+          # Response HTTP Code must be in white list otherwise it is false
+          PactBroker.configuration.webhook_http_code_whitelist.include? response.code.to_i
+        end
       end
+
     end
   end
 end

--- a/lib/pact_broker/webhooks/webhook_request_logger.rb
+++ b/lib/pact_broker/webhooks/webhook_request_logger.rb
@@ -118,8 +118,8 @@ module PactBroker
 
       def success?(response)
         unless response.nil?
-          # Response HTTP Code must be in white list otherwise it is false
-          PactBroker.configuration.webhook_http_code_whitelist.include? response.code.to_i
+          # Response HTTP Code must be in success list otherwise it is false
+          PactBroker.configuration.webhook_http_code_success.include? response.code.to_i
         end
       end
 

--- a/spec/lib/pact_broker/config/space_delimited_integer_list_spec.rb
+++ b/spec/lib/pact_broker/config/space_delimited_integer_list_spec.rb
@@ -1,0 +1,47 @@
+require 'pact_broker/config/space_delimited_integer_list'
+
+module PactBroker
+  module Config
+    describe SpaceDelimitedIntegerList do
+      describe "parse" do
+        subject { SpaceDelimitedIntegerList.parse(input) }
+
+        context "when input is ''" do
+          let(:input) { "" }
+
+          it { is_expected.to eq [] }
+          it { is_expected.to be_a SpaceDelimitedIntegerList }
+
+          its(:to_s) { is_expected.to eq input }
+        end
+
+        context "when input is 'off'" do
+          let(:input) { "off" }
+
+          it { is_expected.to eq [] }
+          it { is_expected.to be_a SpaceDelimitedIntegerList }
+
+          its(:to_s) { is_expected.to eq "" }
+        end
+
+        context "when input is '0 1 1 2 3 5 8 13 21 34'" do
+          let(:input) { "0 1 1 2 3 5 8 13 21 34" }
+
+          it { is_expected.to eq [0, 1, 1, 2, 3, 5, 8, 13, 21, 34] }
+          it { is_expected.to be_a SpaceDelimitedIntegerList }
+
+          its(:to_s) { is_expected.to eq input }
+        end
+
+        context "when input is '13 17 foo 19'" do
+          let(:input) { "13 17 foo 19" }
+
+          it { is_expected.to eq [13, 17, 19] }
+          it { is_expected.to be_a SpaceDelimitedIntegerList }
+
+          its(:to_s) { is_expected.to eq "13 17 19" }
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/pact_broker/configuration_spec.rb
+++ b/spec/lib/pact_broker/configuration_spec.rb
@@ -60,15 +60,15 @@ module PactBroker
         end
       end
 
-      describe "webhook_http_code_whitelist" do
-        it "allows setting the 'webhook_http_code_whitelist' by a space-delimited string" do
-          PactBroker.configuration.webhook_http_code_whitelist = "200 201 202"
-          expect(PactBroker.configuration.webhook_http_code_whitelist).to be_a Config::SpaceDelimitedIntegerList
+      describe "webhook_http_code_success" do
+        it "allows setting the 'webhook_http_code_success' by a space-delimited string" do
+          PactBroker.configuration.webhook_http_code_success = "200 201 202"
+          expect(PactBroker.configuration.webhook_http_code_success).to be_a Config::SpaceDelimitedIntegerList
         end
 
-        it "allows setting the 'webhook_http_code_whitelist' by an array" do
-          PactBroker.configuration.webhook_http_code_whitelist = [200, 201, 202]
-          expect(PactBroker.configuration.webhook_http_code_whitelist).to be_a Config::SpaceDelimitedIntegerList
+        it "allows setting the 'webhook_http_code_success' by an array" do
+          PactBroker.configuration.webhook_http_code_success = [200, 201, 202]
+          expect(PactBroker.configuration.webhook_http_code_success).to be_a Config::SpaceDelimitedIntegerList
         end
       end
 

--- a/spec/lib/pact_broker/configuration_spec.rb
+++ b/spec/lib/pact_broker/configuration_spec.rb
@@ -60,6 +60,18 @@ module PactBroker
         end
       end
 
+      describe "webhook_http_code_whitelist" do
+        it "allows setting the 'webhook_http_code_whitelist' by a space-delimited string" do
+          PactBroker.configuration.webhook_http_code_whitelist = "200 201 202"
+          expect(PactBroker.configuration.webhook_http_code_whitelist).to be_a Config::SpaceDelimitedIntegerList
+        end
+
+        it "allows setting the 'webhook_http_code_whitelist' by an array" do
+          PactBroker.configuration.webhook_http_code_whitelist = [200, 201, 202]
+          expect(PactBroker.configuration.webhook_http_code_whitelist).to be_a Config::SpaceDelimitedIntegerList
+        end
+      end
+
       describe "webhook_scheme_whitelist" do
         it "allows setting the whitelist by a string" do
           PactBroker.configuration.webhook_scheme_whitelist = "foo"

--- a/spec/lib/pact_broker/webhooks/webhook_request_logger_spec.rb
+++ b/spec/lib/pact_broker/webhooks/webhook_request_logger_spec.rb
@@ -123,26 +123,24 @@ module PactBroker
           end
         end
 
-        context "when the response code '200' is in 'webhook_http_code_whitelist'" do
-          let(:status) { 200 }
-
-          it "successful, code '200' is in 'webhook_http_code_whitelist'" do
+        context "when the response code is a success" do
+          it "does not log the failure_log_message" do
             expect(logs).to_not include "oops"
           end
         end
 
-        context "when the response code '100' is not in 'webhook_http_code_whitelist'" do
+        context "when the response code '100' is not in 'webhook_http_code_success'" do
           let(:status) { 100 }
 
-          it "not successful, code '100' not in 'webhook_http_code_whitelist'" do
+          it "not successful, code '100' not in 'webhook_http_code_success'" do
             expect(logs).to include "oops"
           end
         end
 
-        context "when the response code '400' is not in 'webhook_http_code_whitelist'" do
+        context "when the response code is not successful" do
           let(:status) { 400 }
 
-          it "not successful, code '100' not in 'webhook_http_code_whitelist'" do
+          it "logs the failure_log_message" do
             expect(logs).to include "oops"
           end
         end

--- a/spec/lib/pact_broker/webhooks/webhook_request_logger_spec.rb
+++ b/spec/lib/pact_broker/webhooks/webhook_request_logger_spec.rb
@@ -123,16 +123,26 @@ module PactBroker
           end
         end
 
-        context "when the response code is a success" do
-          it "does not log the failure_log_message" do
+        context "when the response code '200' is in 'webhook_http_code_whitelist'" do
+          let(:status) { 200 }
+
+          it "successful, code '200' is in 'webhook_http_code_whitelist'" do
             expect(logs).to_not include "oops"
           end
         end
 
-        context "when the response code is not successful" do
+        context "when the response code '100' is not in 'webhook_http_code_whitelist'" do
+          let(:status) { 100 }
+
+          it "not successful, code '100' not in 'webhook_http_code_whitelist'" do
+            expect(logs).to include "oops"
+          end
+        end
+
+        context "when the response code '400' is not in 'webhook_http_code_whitelist'" do
           let(:status) { 400 }
 
-          it "logs the failure_log_message" do
+          it "not successful, code '100' not in 'webhook_http_code_whitelist'" do
             expect(logs).to include "oops"
           end
         end


### PR DESCRIPTION
feat/239: Add new configuration 'webhook_http_code_whitelist' to allow webhook to be successful on defined HTTP codes. Default are: 200 (OK), 201 (CREATED) and 202 (ACCEPTED)

There are three failing test suites:
* Pact::Doc::Markdown::ConsumerContractRenderer
* Pact::Doc::Markdown::IndexRenderer
* changing from integer to timestamp migrations uses pact_broker v 2.6.0

Far as I see it is not related to my changes, so it could be rather my local development (I am using Ruby 2.7 instead of 2.6)
