### PR TITLE
feat: Follow up for #239 + adding list of success codes to SAVABLE_SETTING_NAMES variable

### DIFF
--- a/lib/pact_broker/configuration.rb
+++ b/lib/pact_broker/configuration.rb
@@ -31,6 +31,7 @@ module PactBroker
       :webhook_http_method_whitelist,
       :webhook_scheme_whitelist,
       :webhook_host_whitelist,
+      :webhook_http_code_success,
       :base_equality_only_on_content_that_affects_verification_results,
       :seed_example_data,
       :badge_provider_mode,

--- a/lib/pact_broker/webhooks/webhook_execution_result.rb
+++ b/lib/pact_broker/webhooks/webhook_execution_result.rb
@@ -14,7 +14,10 @@ module PactBroker
       end
 
       def success?
-        !response.nil? && response.code.to_i < 300
+        unless response.nil?
+          # Response HTTP Code must be in success list otherwise it is false
+          PactBroker.configuration.webhook_http_code_success.include? response.code.to_i
+        end
       end
     end
   end

--- a/spec/lib/pact_broker/api/resources/webhook_execution_result_spec.rb
+++ b/spec/lib/pact_broker/api/resources/webhook_execution_result_spec.rb
@@ -6,7 +6,7 @@ module PactBroker
         Net::HTTP::Get.new("http://example.org?foo=bar")
       end
 
-      context "When 'webhook_http_code_success' has: [200, 201]" do
+      context "When 'webhook_http_code_success' has [200, 201]" do
         before do
           allow(PactBroker.configuration).to receive(:webhook_http_code_success).and_return([200, 201])
         end
@@ -29,7 +29,7 @@ module PactBroker
       end
 
 
-      context "When 'webhook_http_code_success' has: [400, 401]" do
+      context "When 'webhook_http_code_success' has [400, 401]" do
         before do
           allow(PactBroker.configuration).to receive(:webhook_http_code_success).and_return([400, 401])
         end

--- a/spec/lib/pact_broker/api/resources/webhook_execution_result_spec.rb
+++ b/spec/lib/pact_broker/api/resources/webhook_execution_result_spec.rb
@@ -1,0 +1,56 @@
+module PactBroker
+  module Webhooks
+    describe WebhookExecutionResult do
+      subject { WebhookExecutionResult::new(request, response, nil) }
+      let(:request) do
+        Net::HTTP::Get.new("http://example.org?foo=bar")
+      end
+
+      context "When 'webhook_http_code_success' has: [200, 201]" do
+        before do
+          allow(PactBroker.configuration).to receive(:webhook_http_code_success).and_return([200, 201])
+        end
+
+        context "and response is '200'" do
+          let(:response) { double(code: '200') }
+
+          it "then it should be success" do
+            expect(subject.success?).to be_truthy
+          end
+        end
+
+        context "and response is '400'" do
+          let(:response) { double(code: '400') }
+
+          it "then it should fail" do
+            expect(subject.success?).to be_falsey
+          end
+        end
+      end
+
+
+      context "When 'webhook_http_code_success' has: [400, 401]" do
+        before do
+          allow(PactBroker.configuration).to receive(:webhook_http_code_success).and_return([400, 401])
+        end
+
+        context "and response is '200'" do
+          let(:response) { double(code: '200') }
+
+          it "then it should fail" do
+            expect(subject.success?).to be_falsey
+          end
+        end
+
+        context "and response is '400'" do
+          let(:response) { double(code: '400') }
+
+          it "then it should be success" do
+            expect(subject.success?).to be_truthy
+          end
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
During developing for pact-broker-docker I noticed that the http-code checking is still not working, I noticed that I only fixed the "logging" part but not the real code check. 😆  It should now also be fixed and I added some test cases.

Furthermore I also added 'webhook_http_code_success' to the SAVABLE_SETTING_NAMES  so that the configured value is also printed during pact-broker-docker startup.