### PR TITLE
feat(webhooks): support ${pactbroker.currentlyDeployedProviderVersionNumber} in webhook templates

### DIFF
--- a/lib/pact_broker/deployments/deployed_version.rb
+++ b/lib/pact_broker/deployments/deployed_version.rb
@@ -47,6 +47,10 @@ module PactBroker
       def record_undeployed
         update(currently_deployed: false, undeployed_at: Sequel.datetime_class.now)
       end
+
+      def version_number
+        version.number
+      end
     end
   end
 end

--- a/lib/pact_broker/deployments/deployed_version_service.rb
+++ b/lib/pact_broker/deployments/deployed_version_service.rb
@@ -35,6 +35,15 @@ module PactBroker
           .all
       end
 
+      def self.find_currently_deployed_versions_for_pacticipant(pacticipant)
+        DeployedVersion
+          .currently_deployed
+          .where(pacticipant_id: pacticipant.id)
+          .eager(:version)
+          .eager(:environment)
+          .all
+      end
+
       def self.record_previous_version_undeployed(pacticipant, environment)
         DeployedVersion.last_deployed_version(pacticipant, environment)&.record_undeployed
       end

--- a/lib/pact_broker/domain/webhook.rb
+++ b/lib/pact_broker/domain/webhook.rb
@@ -3,6 +3,7 @@ require 'pact_broker/messages'
 require 'pact_broker/logging'
 require 'pact_broker/api/contracts/webhook_contract'
 require 'pact_broker/webhooks/http_request_with_redacted_headers'
+require 'pact_broker/webhooks/pact_and_verification_parameters'
 
 module PactBroker
   module Domain
@@ -94,6 +95,10 @@ module PactBroker
 
       def trigger_on_provider_verification_failed?
         events.any?(&:provider_verification_failed?)
+      end
+
+      def expand_currently_deployed_provider_versions?
+        request.uses_parameter?(PactBroker::Webhooks::PactAndVerificationParameters::CURRENTLY_DEPLOYED_PROVIDER_VERSION_NUMBER)
       end
 
       private

--- a/lib/pact_broker/webhooks/pact_and_verification_parameters.rb
+++ b/lib/pact_broker/webhooks/pact_and_verification_parameters.rb
@@ -14,6 +14,7 @@ module PactBroker
       CONSUMER_LABELS = 'pactbroker.consumerLabels'
       PROVIDER_LABELS = 'pactbroker.providerLabels'
       EVENT_NAME = 'pactbroker.eventName'
+      CURRENTLY_DEPLOYED_PROVIDER_VERSION_NUMBER = 'pactbroker.currentlyDeployedProviderVersionNumber'
 
       ALL = [
         CONSUMER_NAME,
@@ -28,7 +29,8 @@ module PactBroker
         BITBUCKET_VERIFICATION_STATUS,
         CONSUMER_LABELS,
         PROVIDER_LABELS,
-        EVENT_NAME
+        EVENT_NAME,
+        CURRENTLY_DEPLOYED_PROVIDER_VERSION_NUMBER
       ]
 
       def initialize(pact, trigger_verification, webhook_context)
@@ -52,7 +54,8 @@ module PactBroker
           BITBUCKET_VERIFICATION_STATUS => bitbucket_verification_status,
           CONSUMER_LABELS => pacticipant_labels(pact && pact.consumer),
           PROVIDER_LABELS => pacticipant_labels(pact && pact.provider),
-          EVENT_NAME => event_name
+          EVENT_NAME => event_name,
+          CURRENTLY_DEPLOYED_PROVIDER_VERSION_NUMBER => currently_deployed_provider_version_number
         }
       end
 
@@ -122,6 +125,10 @@ module PactBroker
 
       def event_name
         webhook_context.fetch(:event_name)
+      end
+
+      def currently_deployed_provider_version_number
+        webhook_context[:currently_deployed_provider_version_number] || ""
       end
     end
   end

--- a/lib/pact_broker/webhooks/webhook_request_template.rb
+++ b/lib/pact_broker/webhooks/webhook_request_template.rb
@@ -62,6 +62,13 @@ module PactBroker
         @headers = Rack::Utils::HeaderHash.new(headers)
       end
 
+      def uses_parameter?(parameter_name)
+        !!body_string&.include?("${" + parameter_name + "}")
+      end
+
+      def body_string
+        String === body ? body : body&.to_json
+      end
 
       def to_s
         "#{method.upcase} #{url}, username=#{username}, password=#{display_password}, headers=#{redacted_headers}, body=#{body}"

--- a/script/reproduce-issue-expand-currently-deployed.rb
+++ b/script/reproduce-issue-expand-currently-deployed.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+begin
+
+  $LOAD_PATH << "#{Dir.pwd}/lib"
+  require 'pact_broker/test/http_test_data_builder'
+  base_url = ENV['PACT_BROKER_BASE_URL'] || 'http://localhost:9292'
+
+  td = PactBroker::Test::HttpTestDataBuilder.new(base_url)
+  td.delete_integration(consumer: "Foo", provider: "Bar")
+    .delete_integration(consumer: "foo-consumer", provider: "bar-provider")
+    .create_environment(name: "test")
+    .create_environment(name: "prod", production: true)
+    .publish_pact(consumer: "foo-consumer", consumer_version: "1", provider: "bar-provider", content_id: "111", tag: "main")
+    .get_pacts_for_verification(
+      enable_pending: true,
+      provider_version_tag: "main",
+      include_wip_pacts_since: "2020-01-01",
+      consumer_version_selectors: [{ tag: "main", latest: true }])
+    .verify_pact(
+      index: 0,
+      provider_version_tag: "main",
+      provider_version: "1",
+      success: true
+    )
+    .record_deployment(pacticipant: "bar-provider", version: "1", environment_name: "test")
+    .record_deployment(pacticipant: "bar-provider", version: "1", environment_name: "prod")
+    .record_deployment(pacticipant: "foo-consumer", version: "1", environment_name: "prod")
+    .get_pacts_for_verification(
+      enable_pending: true,
+      provider_version_tag: "main",
+      include_wip_pacts_since: "2020-01-01",
+      consumer_version_selectors: [{ tag: "main", latest: true }])
+    .verify_pact(
+      index: 0,
+      provider_version_tag: "main",
+      provider_version: "2",
+      success: true
+    )
+    .record_deployment(pacticipant: "bar-provider", version: "2", environment_name: "test")
+    .create_global_webhook_for_contract_changed(uuid: "7a5da39c-8e50-4cc9-ae16-dfa5be043e8c")
+    .publish_pact(consumer: "foo-consumer", consumer_version: "2", provider: "bar-provider", content_id: "222", tag: "main")
+
+rescue StandardError => e
+  puts "#{e.class} #{e.message}"
+  puts e.backtrace
+  exit 1
+end


### PR DESCRIPTION
Yet another thing that has become possible now that we support explicit environments.

When the parameter `${pactbroker.currentlyDeployedProviderVersionNumber}` is used in a template, a triggered webhook will be created for each provider version that is currently deployed (deduplicated, so that if the same version is deployed to multiple environments, only one webhook will be triggered).