### PR TITLE
feat: allow webhooks to specify consumer version matchers for when they are triggered

### DIFF
--- a/db/migrations/20210323_add_consumer_version_matchers_to_webhook.rb
+++ b/db/migrations/20210323_add_consumer_version_matchers_to_webhook.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:webhooks) do
+      add_column(:consumer_version_matchers, String)
+    end
+  end
+end

--- a/lib/pact_broker/api/decorators/webhook_decorator.rb
+++ b/lib/pact_broker/api/decorators/webhook_decorator.rb
@@ -3,6 +3,7 @@ require 'pact_broker/api/decorators/webhook_request_template_decorator'
 require 'pact_broker/api/decorators/timestamps'
 require 'pact_broker/webhooks/webhook_request_template'
 require 'pact_broker/webhooks/webhook_event'
+require 'pact_broker/webhooks/version_matcher'
 require 'pact_broker/api/decorators/basic_pacticipant_decorator'
 require_relative 'pact_pacticipant_decorator'
 require_relative 'pacticipant_decorator'
@@ -13,6 +14,11 @@ module PactBroker
       class WebhookDecorator < BaseDecorator
         class WebhookEventDecorator < BaseDecorator
           property :name
+        end
+
+        class VersionMatcherDecorator < BaseDecorator
+          property :branch
+          property :tag
         end
 
         property :description, getter: lambda { |context| context[:represented].display_description }
@@ -29,6 +35,7 @@ module PactBroker
 
         property :request, :class => PactBroker::Webhooks::WebhookRequestTemplate, extend: WebhookRequestTemplateDecorator
         collection :events, :class => PactBroker::Webhooks::WebhookEvent, extend: WebhookEventDecorator
+        collection :consumer_version_matchers, camelize: true, :class => PactBroker::Webhooks::VersionMatcher, extend: VersionMatcherDecorator
 
         include Timestamps
 

--- a/lib/pact_broker/domain/version.rb
+++ b/lib/pact_broker/domain/version.rb
@@ -197,6 +197,18 @@ module PactBroker
       def latest_for_pacticipant?
         latest_version_for_pacticipant == self
       end
+
+      def matches_webhook_matcher?(version_matcher)
+        if version_matcher.branch && version_matcher.branch != branch
+          return false
+        end
+
+        if version_matcher.tag
+          return tags.any?{ |tag| tag.name == version_matcher.tag }
+        end
+
+        true
+      end
     end
   end
 end

--- a/lib/pact_broker/domain/webhook.rb
+++ b/lib/pact_broker/domain/webhook.rb
@@ -13,7 +13,7 @@ module PactBroker
       include Logging
 
       # request is actually a request_template
-      attr_accessor :uuid, :consumer, :provider, :request, :created_at, :updated_at, :events, :enabled, :description
+      attr_accessor :uuid, :consumer, :provider, :request, :created_at, :updated_at, :events, :enabled, :description, :consumer_version_matchers
       attr_reader :attributes
 
       def initialize attributes = {}
@@ -24,6 +24,7 @@ module PactBroker
         @consumer = attributes[:consumer]
         @provider = attributes[:provider]
         @events = attributes[:events]
+        @consumer_version_matchers = attributes[:consumer_version_matchers]
         @enabled = attributes[:enabled]
         @created_at = attributes[:created_at]
         @updated_at = attributes[:updated_at]
@@ -99,6 +100,16 @@ module PactBroker
 
       def expand_currently_deployed_provider_versions?
         request.uses_parameter?(PactBroker::Webhooks::PactAndVerificationParameters::CURRENTLY_DEPLOYED_PROVIDER_VERSION_NUMBER)
+      end
+
+      def version_matches_consumer_version_matchers?(version)
+        if consumer_version_matchers&.any?
+          consumer_version_matchers.any? do | matcher |
+            version.matches_webhook_matcher?(matcher)
+          end
+        else
+          true
+        end
       end
 
       private

--- a/lib/pact_broker/webhooks/version_matcher.rb
+++ b/lib/pact_broker/webhooks/version_matcher.rb
@@ -1,0 +1,33 @@
+require 'pact_broker/hash_refinements'
+
+module PactBroker
+  module Webhooks
+    class VersionMatcher < Hash
+      using PactBroker::HashRefinements
+
+      def initialize(options = {})
+        merge!(options)
+      end
+
+      def self.from_hash(hash)
+        new(hash.symbolize_keys)
+      end
+
+      def branch
+        self[:branch]
+      end
+
+      def branch= branch
+        self[:branch] = branch
+      end
+
+      def tag
+        self[:tag]
+      end
+
+      def tag= tag
+        self[:tag] = tag
+      end
+    end
+  end
+end

--- a/spec/features/create_webhook_spec.rb
+++ b/spec/features/create_webhook_spec.rb
@@ -13,6 +13,7 @@ describe "Creating a webhook" do
       events: [{
         name: 'contract_content_changed'
       }],
+      consumerVersionMatchers: [{ branch: "main" }],
       request: {
         method: 'POST',
         url: 'https://example.org',

--- a/spec/lib/pact_broker/api/decorators/webhook_decorator_spec.rb
+++ b/spec/lib/pact_broker/api/decorators/webhook_decorator_spec.rb
@@ -153,8 +153,17 @@ module PactBroker
         end
 
         describe 'from_json' do
-          let(:hash) { { request: request, events: [event] } }
-          let(:event) { {name: 'something_happened'} }
+          let(:hash) do
+            {
+              request: request,
+              events: [event],
+              consumerVersionSelectors: consumer_version_selectors
+            }
+          end
+          let(:consumer_version_selectors) do
+            [{ branch: "main" }]
+          end
+          let(:event) { { name: 'something_happened' } }
           let(:json) { hash.to_json }
           let(:webhook) { Domain::Webhook.new }
           let(:parsed_object) { subject.from_json(json) }

--- a/spec/lib/pact_broker/domain/version_spec.rb
+++ b/spec/lib/pact_broker/domain/version_spec.rb
@@ -358,6 +358,63 @@ module PactBroker
           expect(all.first.associations[:current_deployed_versions].first.environment.name).to eq "prod"
         end
       end
+
+      describe "matches_webhook_matcher?" do
+        let(:version) do
+          td.create_consumer("Foo")
+            .create_consumer_version("1", branch: "right-branch", tag_names: ["right-tag"])
+            .and_return(:consumer_version)
+        end
+        let(:matcher) { PactBroker::Webhooks::VersionMatcher.new(branch: "right-branch") }
+
+        subject { version.matches_webhook_matcher?(matcher) }
+
+        context "when the matcher matches the branch" do
+          it { is_expected.to be true }
+        end
+
+        context "when the matcher does not match the branch" do
+          let(:matcher) { PactBroker::Webhooks::VersionMatcher.new(branch: "foo") }
+
+          it { is_expected.to be false }
+        end
+
+        context "when the matcher matches the tag" do
+          let(:matcher) { PactBroker::Webhooks::VersionMatcher.new(tag: "right-tag") }
+
+          it { is_expected.to be true }
+        end
+
+        context "when the matcher does not match the tag" do
+          let(:matcher) { PactBroker::Webhooks::VersionMatcher.new(tag: "bar") }
+
+          it { is_expected.to be false }
+        end
+
+        context "when the matcher matches the branch and tag" do
+          let(:matcher) { PactBroker::Webhooks::VersionMatcher.new(tag: "right-tag", branch: "right-branch") }
+
+          it { is_expected.to be true }
+        end
+
+        context "when the matcher matches the branch and not tag" do
+          let(:matcher) { PactBroker::Webhooks::VersionMatcher.new(tag: "bar", branch: "right-branch") }
+
+          it { is_expected.to be false }
+        end
+
+        context "when the matcher matches the tag and not branch" do
+          let(:matcher) { PactBroker::Webhooks::VersionMatcher.new(tag: "right-tag", branch: "wrong-branch") }
+
+          it { is_expected.to be false }
+        end
+
+        context "when the matcher has no properties" do
+          let(:matcher) { PactBroker::Webhooks::VersionMatcher.new({}) }
+
+          it { is_expected.to be true }
+        end
+      end
     end
   end
 end

--- a/spec/lib/pact_broker/webhooks/webhook_spec.rb
+++ b/spec/lib/pact_broker/webhooks/webhook_spec.rb
@@ -3,9 +3,6 @@ require 'pact_broker/webhooks/webhook'
 module PactBroker
   module Webhooks
     describe Webhook do
-
-      let(:td) { TestDataBuilder.new }
-
       before do
         td.create_consumer("Foo")
           .create_provider("Bar")


### PR DESCRIPTION
Having done the "support triggering a verification build for each deployed version of the provider when the pact changes" the other day, I realised that we only want to do that for change to the master pact. Feature branch changes are irrelevant, and will just result in tying up build nodes that could be doing better things. I've been meaning to add better support specifying when a webhook should run for years, so now I've finally done it. 

This PR adds support for `consumerVersionMatchers` in a webhook, that let you specify which branches or tags a webhook should be triggered for. One thing I'm not sure of - should they be called `consumerVersionMatchers` or `consumerVersionFilters`. I don't want to override the "matchers" term, given we already have that in the pact terminology.

I'll eventually add `providerVersionMatchers/Filters` too, but this is currently just solving my own problem 😆 Allowing both consumer version and provider version matchers will allow us to do things like "only do something when a master verification for a master pact comes in". I envisage people wanting "not" filters and regex filters too.