### PR TITLE
fix(ui): Make long pacticipant versions look nice

### DIFF
--- a/public/stylesheets/index.css
+++ b/public/stylesheets/index.css
@@ -52,7 +52,10 @@ body { padding-top: 10px; }
   word-wrap: break-word;
 }
 
-.consumer-version-number, .provider-version-number {
+.consumer-version,
+.provider-version,
+.consumer-version-number,
+.provider-version-number {
   word-wrap: break-word;
 }
 

--- a/vendor/hal-browser/styles.css
+++ b/vendor/hal-browser/styles.css
@@ -50,6 +50,10 @@ body table.table {
   font-size: 11px;
 }
 
+body table.table td:nth-child(3) {
+  word-wrap: break-word;
+}
+
 .location-bar-container {
   line-height: 30px;
 }
@@ -70,7 +74,9 @@ body table.table {
 }
 .embedded-resource-title {
   font-style: italic;
+  word-wrap: break-word;
 }
+
 .embedded-resource-title:before {
   content: "\"";
 }


### PR DESCRIPTION
We happen to use base64 encoded data as pacticipant versions. It makes UI looks ugly. This PR fixes it by wrapping long version numbers.

We are setting up Pact for GQL Gateway contracts and the GQL gateway is it's code version and the version of all services it is federating. The base64 may became pretty long :smile: