### PR TITLE
feat: updating pending and wip logic

### DIFF
--- a/lib/pact_broker/domain/pact.rb
+++ b/lib/pact_broker/domain/pact.rb
@@ -90,7 +90,9 @@ module PactBroker
       end
 
       def select_pending_provider_version_tags(provider_version_tags)
-        provider_version_tags - db_model.pact_version.select_provider_tags_with_successful_verifications(provider_version_tags)
+        tags_with_successful_verifications_from_that_branch = db_model.pact_version.select_provider_tags_with_successful_verifications(provider_version_tags)
+        tags_with_previous_successful_verifications_from_other_branches = db_model.pact_version.select_provider_tags_with_successful_verifications_from_another_branch_from_before_this_branch_created(provider_version_tags)
+        provider_version_tags - tags_with_successful_verifications_from_that_branch - tags_with_previous_successful_verifications_from_other_branches
       end
 
       def pending?

--- a/lib/pact_broker/domain/version.rb
+++ b/lib/pact_broker/domain/version.rb
@@ -59,6 +59,10 @@ module PactBroker
           where_pacticipant_name(pacticipant_name).where_number(version_number).single_record
         end
 
+        def first_for_pacticipant_id_and_branch(pacticipant_id, branch)
+          where(pacticipant_id: pacticipant_id, branch: branch).order(:created_at).first
+        end
+
         def latest_versions_for_pacticipant_branches(pacticipant_id, branches)
           query = Version.where(Sequel[:versions][:pacticipant_id] => pacticipant_id, Sequel[:versions][:branch] => branches)
 

--- a/lib/pact_broker/pacts/pact_publication.rb
+++ b/lib/pact_broker/pacts/pact_publication.rb
@@ -5,6 +5,7 @@ require 'pact_broker/repositories/helpers'
 require 'pact_broker/integrations/integration'
 require 'pact_broker/tags/head_pact_tags'
 require 'pact_broker/pacts/pact_publication_dataset_module'
+require 'pact_broker/pacts/pact_publication_wip_dataset_module'
 require 'pact_broker/pacts/eager_loaders'
 require 'pact_broker/pacts/lazy_loaders'
 
@@ -37,6 +38,7 @@ module PactBroker
       dataset_module do
         include PactBroker::Repositories::Helpers
         include PactPublicationDatasetModule
+        include PactPublicationWipDatasetModule
       end
 
       def self.subtract(a, b)

--- a/lib/pact_broker/pacts/pact_publication_dataset_module.rb
+++ b/lib/pact_broker/pacts/pact_publication_dataset_module.rb
@@ -168,97 +168,52 @@ module PactBroker
           .join(:environments, environments_join)
       end
 
-      def successfully_verified_by_provider_branch_when_not_wip(provider_id, provider_version_branch)
-        verifications_join = {
-          pact_version_id: :pact_version_id,
-          Sequel[:verifications][:success] => true,
-          Sequel[:verifications][:wip] => false,
-          Sequel[:verifications][:provider_id] => provider_id
-        }
-        versions_join = {
-          Sequel[:verifications][:provider_version_id] => Sequel[:provider_versions][:id],
-          Sequel[:provider_versions][:branch] => provider_version_branch,
-          Sequel[:provider_versions][:pacticipant_id] => provider_id
-        }
+      def verified_before_date(date)
+        where { Sequel[:verifications][:execution_date] < date }
+      end
 
-        from_self(alias: :pp).select(Sequel[:pp].*)
-          .join(:verifications, verifications_join)
-          .join(:versions, versions_join, { table_alias: :provider_versions } )
+      def successfully_verified_by_provider_branch_when_not_wip(provider_id, provider_version_branch)
+        from_self(alias: :pp)
+          .select(Sequel[:pp].*)
           .where(Sequel[:pp][:provider_id] => provider_id)
+          .join_successful_non_wip_verifications_for_provider_id(provider_id)
+          .join_provider_versions_for_provider_id_and_branch(provider_id, provider_version_branch)
           .distinct
       end
 
       def successfully_verified_by_provider_another_branch_before_this_branch_first_created(provider_id, provider_version_branch)
-        first_version_for_branch = PactBroker::Domain::Version.first_for_pacticipant_id_and_branch(provider_id, provider_version_branch)
-        verifications_join = {
-          pact_version_id: :pact_version_id,
-          Sequel[:verifications][:success] => true,
-          Sequel[:verifications][:wip] => false,
-          Sequel[:verifications][:provider_id] => provider_id
-        }
-        versions_join = {
-          Sequel[:verifications][:provider_version_id] => Sequel[:provider_versions][:id],
-          Sequel[:provider_versions][:pacticipant_id] => provider_id
-        }
-
-        query = from_self(alias: :pp).select(Sequel[:pp].*)
-          .join(:verifications, verifications_join)
-          .join(:versions, versions_join, { table_alias: :provider_versions } ) do
+        query = from_self(alias: :pp)
+          .select(Sequel[:pp].*)
+          .join_successful_non_wip_verifications_for_provider_id(provider_id)
+          .join_provider_versions_for_provider_id(provider_id) do
             Sequel.lit('provider_versions.branch != ?', provider_version_branch)
           end
           .where(Sequel[:pp][:provider_id] => provider_id)
 
-        if first_version_for_branch
-          query = query.where { Sequel[:verifications][:created_at] < first_version_for_branch.created_at }
-        end
-
+        first_version_for_branch = PactBroker::Domain::Version.first_for_pacticipant_id_and_branch(provider_id, provider_version_branch)
+        query = query.verified_before_date(first_version_for_branch.created_at) if first_version_for_branch
         query.distinct
       end
 
       def successfully_verified_by_provider_tag_when_not_wip(provider_id, provider_tag)
-        verifications_join = {
-          pact_version_id: :pact_version_id,
-          Sequel[:verifications][:success] => true,
-          Sequel[:verifications][:wip] => false,
-          Sequel[:verifications][:provider_id] => provider_id
-        }
-
-        tags_join = {
-          Sequel[:verifications][:provider_version_id] => Sequel[:provider_tags][:version_id],
-          Sequel[:provider_tags][:name] => provider_tag
-        }
-
         from_self(alias: :pp).select(Sequel[:pp].*)
-          .join(:verifications, verifications_join)
-          .join(:tags, tags_join, { table_alias: :provider_tags } )
+          .join_successful_non_wip_verifications_for_provider_id(provider_id)
+          .join_provider_version_tags_for_tag(provider_tag)
           .where(Sequel[:pp][:provider_id] => provider_id)
           .distinct
       end
 
       def successfully_verified_by_provider_another_tag_before_this_tag_first_created(provider_id, provider_tag)
-        first_tag_with_name = PactBroker::Domain::Tag.where(pacticipant_id: provider_id, name: provider_tag).order(:created_at).first
-
-        verifications_join = {
-          pact_version_id: :pact_version_id,
-          Sequel[:verifications][:success] => true,
-          Sequel[:verifications][:wip] => false,
-          Sequel[:verifications][:provider_id] => provider_id
-        }
-        tags_join = {
-          Sequel[:verifications][:provider_version_id] => Sequel[:provider_tags][:version_id],
-        }
-
-        query = from_self(alias: :pp).select(Sequel[:pp].*)
-          .join(:verifications, verifications_join)
-          .join(:tags, tags_join, { table_alias: :provider_tags } ) do
+        query = from_self(alias: :pp)
+          .select(Sequel[:pp].*)
+          .where(Sequel[:pp][:provider_id] => provider_id)
+          .join_successful_non_wip_verifications_for_provider_id(provider_id)
+          .join_provider_version_tags do
             Sequel.lit('provider_tags.name != ?', provider_tag)
           end
-          .where(Sequel[:pp][:provider_id] => provider_id)
 
-        if first_tag_with_name
-          query = query.where { Sequel[:verifications][:created_at] < first_tag_with_name.created_at }
-        end
-
+        first_tag_with_name = PactBroker::Domain::Tag.where(pacticipant_id: provider_id, name: provider_tag).order(:created_at).first
+        query = query.verified_before_date(first_tag_with_name.created_at) if first_tag_with_name
         query.distinct
       end
 
@@ -359,6 +314,50 @@ module PactBroker
         require 'pact_broker/webhooks/triggered_webhook'
         PactBroker::Webhooks::TriggeredWebhook.where(pact_publication: self).delete
         super
+      end
+
+      protected
+
+      def join_successful_non_wip_verifications_for_provider_id(provider_id, &block)
+        verifications_join = {
+          pact_version_id: :pact_version_id,
+          Sequel[:verifications][:success] => true,
+          Sequel[:verifications][:wip] => false,
+          Sequel[:verifications][:provider_id] => provider_id
+        }
+        join(:verifications, verifications_join, {}, &block)
+      end
+
+      def join_provider_version_tags &block
+        tags_join = {
+          Sequel[:verifications][:provider_version_id] => Sequel[:provider_tags][:version_id],
+        }
+        join(:tags, tags_join, { table_alias: :provider_tags }, &block)
+      end
+
+      def join_provider_version_tags_for_tag(tag)
+        tags_join = {
+          Sequel[:verifications][:provider_version_id] => Sequel[:provider_tags][:version_id],
+          Sequel[:provider_tags][:name] => tag
+        }
+        join(:tags, tags_join, { table_alias: :provider_tags } )
+      end
+
+      def join_provider_versions_for_provider_id_and_branch(provider_id, provider_version_branch)
+        versions_join = {
+          Sequel[:verifications][:provider_version_id] => Sequel[:provider_versions][:id],
+          Sequel[:provider_versions][:branch] => provider_version_branch,
+          Sequel[:provider_versions][:pacticipant_id] => provider_id
+        }
+        join(:versions, versions_join, { table_alias: :provider_versions } )
+      end
+
+      def join_provider_versions_for_provider_id(provider_id, &block)
+        versions_join = {
+          Sequel[:verifications][:provider_version_id] => Sequel[:provider_versions][:id],
+          Sequel[:provider_versions][:pacticipant_id] => provider_id
+        }
+        join(:versions, versions_join, { table_alias: :provider_versions }, &block)
       end
 
       private

--- a/lib/pact_broker/pacts/pact_publication_dataset_module.rb
+++ b/lib/pact_broker/pacts/pact_publication_dataset_module.rb
@@ -172,51 +172,6 @@ module PactBroker
         where { Sequel[:verifications][:execution_date] < date }
       end
 
-      def successfully_verified_by_provider_branch_when_not_wip(provider_id, provider_version_branch)
-        from_self(alias: :pp)
-          .select(Sequel[:pp].*)
-          .where(Sequel[:pp][:provider_id] => provider_id)
-          .join_successful_non_wip_verifications_for_provider_id(provider_id)
-          .join_provider_versions_for_provider_id_and_branch(provider_id, provider_version_branch)
-          .distinct
-      end
-
-      def successfully_verified_by_provider_another_branch_before_this_branch_first_created(provider_id, provider_version_branch)
-        query = from_self(alias: :pp)
-          .select(Sequel[:pp].*)
-          .join_successful_non_wip_verifications_for_provider_id(provider_id)
-          .join_provider_versions_for_provider_id(provider_id) do
-            Sequel.lit('provider_versions.branch != ?', provider_version_branch)
-          end
-          .where(Sequel[:pp][:provider_id] => provider_id)
-
-        first_version_for_branch = PactBroker::Domain::Version.first_for_pacticipant_id_and_branch(provider_id, provider_version_branch)
-        query = query.verified_before_date(first_version_for_branch.created_at) if first_version_for_branch
-        query.distinct
-      end
-
-      def successfully_verified_by_provider_tag_when_not_wip(provider_id, provider_tag)
-        from_self(alias: :pp).select(Sequel[:pp].*)
-          .join_successful_non_wip_verifications_for_provider_id(provider_id)
-          .join_provider_version_tags_for_tag(provider_tag)
-          .where(Sequel[:pp][:provider_id] => provider_id)
-          .distinct
-      end
-
-      def successfully_verified_by_provider_another_tag_before_this_tag_first_created(provider_id, provider_tag)
-        query = from_self(alias: :pp)
-          .select(Sequel[:pp].*)
-          .where(Sequel[:pp][:provider_id] => provider_id)
-          .join_successful_non_wip_verifications_for_provider_id(provider_id)
-          .join_provider_version_tags do
-            Sequel.lit('provider_tags.name != ?', provider_tag)
-          end
-
-        first_tag_with_name = PactBroker::Domain::Tag.where(pacticipant_id: provider_id, name: provider_tag).order(:created_at).first
-        query = query.verified_before_date(first_tag_with_name.created_at) if first_tag_with_name
-        query.distinct
-      end
-
       def created_after date
         where(Sequel.lit("#{first_source_alias}.created_at > ?", date))
       end
@@ -314,50 +269,6 @@ module PactBroker
         require 'pact_broker/webhooks/triggered_webhook'
         PactBroker::Webhooks::TriggeredWebhook.where(pact_publication: self).delete
         super
-      end
-
-      protected
-
-      def join_successful_non_wip_verifications_for_provider_id(provider_id, &block)
-        verifications_join = {
-          pact_version_id: :pact_version_id,
-          Sequel[:verifications][:success] => true,
-          Sequel[:verifications][:wip] => false,
-          Sequel[:verifications][:provider_id] => provider_id
-        }
-        join(:verifications, verifications_join, {}, &block)
-      end
-
-      def join_provider_version_tags &block
-        tags_join = {
-          Sequel[:verifications][:provider_version_id] => Sequel[:provider_tags][:version_id],
-        }
-        join(:tags, tags_join, { table_alias: :provider_tags }, &block)
-      end
-
-      def join_provider_version_tags_for_tag(tag)
-        tags_join = {
-          Sequel[:verifications][:provider_version_id] => Sequel[:provider_tags][:version_id],
-          Sequel[:provider_tags][:name] => tag
-        }
-        join(:tags, tags_join, { table_alias: :provider_tags } )
-      end
-
-      def join_provider_versions_for_provider_id_and_branch(provider_id, provider_version_branch)
-        versions_join = {
-          Sequel[:verifications][:provider_version_id] => Sequel[:provider_versions][:id],
-          Sequel[:provider_versions][:branch] => provider_version_branch,
-          Sequel[:provider_versions][:pacticipant_id] => provider_id
-        }
-        join(:versions, versions_join, { table_alias: :provider_versions } )
-      end
-
-      def join_provider_versions_for_provider_id(provider_id, &block)
-        versions_join = {
-          Sequel[:verifications][:provider_version_id] => Sequel[:provider_versions][:id],
-          Sequel[:provider_versions][:pacticipant_id] => provider_id
-        }
-        join(:versions, versions_join, { table_alias: :provider_versions }, &block)
       end
 
       private

--- a/lib/pact_broker/pacts/pact_publication_wip_dataset_module.rb
+++ b/lib/pact_broker/pacts/pact_publication_wip_dataset_module.rb
@@ -11,39 +11,39 @@ module PactBroker
       end
 
       def successfully_verified_by_provider_another_branch_before_this_branch_first_created(provider_id, provider_version_branch)
-        query = from_self(alias: :pp)
+        first_version_for_branch = PactBroker::Domain::Version.first_for_pacticipant_id_and_branch(provider_id, provider_version_branch)
+
+        from_self(alias: :pp)
           .select(Sequel[:pp].*)
           .join_successful_non_wip_verifications_for_provider_id(provider_id)
           .join_provider_versions_for_provider_id(provider_id) do
             Sequel.lit('provider_versions.branch != ?', provider_version_branch)
           end
           .where(Sequel[:pp][:provider_id] => provider_id)
-
-        first_version_for_branch = PactBroker::Domain::Version.first_for_pacticipant_id_and_branch(provider_id, provider_version_branch)
-        query = query.verified_before_date(first_version_for_branch.created_at) if first_version_for_branch
-        query.distinct
+          .verified_before_creation_date_of(first_version_for_branch)
+          .distinct
       end
 
       def successfully_verified_by_provider_tag_when_not_wip(provider_id, provider_tag)
-        from_self(alias: :pp).select(Sequel[:pp].*)
+        from_self(alias: :pp)
+          .select(Sequel[:pp].*)
+          .where(Sequel[:pp][:provider_id] => provider_id)
           .join_successful_non_wip_verifications_for_provider_id(provider_id)
           .join_provider_version_tags_for_tag(provider_tag)
-          .where(Sequel[:pp][:provider_id] => provider_id)
           .distinct
       end
 
       def successfully_verified_by_provider_another_tag_before_this_tag_first_created(provider_id, provider_tag)
-        query = from_self(alias: :pp)
+        first_tag_with_name = PactBroker::Domain::Tag.where(pacticipant_id: provider_id, name: provider_tag).order(:created_at).first
+        from_self(alias: :pp)
           .select(Sequel[:pp].*)
           .where(Sequel[:pp][:provider_id] => provider_id)
           .join_successful_non_wip_verifications_for_provider_id(provider_id)
           .join_provider_version_tags do
             Sequel.lit('provider_tags.name != ?', provider_tag)
           end
-
-        first_tag_with_name = PactBroker::Domain::Tag.where(pacticipant_id: provider_id, name: provider_tag).order(:created_at).first
-        query = query.verified_before_date(first_tag_with_name.created_at) if first_tag_with_name
-        query.distinct
+          .verified_before_creation_date_of(first_tag_with_name)
+          .distinct
       end
 
       protected
@@ -92,6 +92,14 @@ module PactBroker
           Sequel[:provider_versions][:pacticipant_id] => provider_id
         }
         join(:versions, versions_join, { table_alias: :provider_versions }, &block)
+      end
+
+      def verified_before_creation_date_of(record)
+        if record
+          verified_before_date(record.created_at)
+        else
+          self
+        end
       end
     end
   end

--- a/lib/pact_broker/pacts/pact_publication_wip_dataset_module.rb
+++ b/lib/pact_broker/pacts/pact_publication_wip_dataset_module.rb
@@ -1,0 +1,98 @@
+module PactBroker
+  module Pacts
+    module PactPublicationWipDatasetModule
+      def successfully_verified_by_provider_branch_when_not_wip(provider_id, provider_version_branch)
+        from_self(alias: :pp)
+          .select(Sequel[:pp].*)
+          .where(Sequel[:pp][:provider_id] => provider_id)
+          .join_successful_non_wip_verifications_for_provider_id(provider_id)
+          .join_provider_versions_for_provider_id_and_branch(provider_id, provider_version_branch)
+          .distinct
+      end
+
+      def successfully_verified_by_provider_another_branch_before_this_branch_first_created(provider_id, provider_version_branch)
+        query = from_self(alias: :pp)
+          .select(Sequel[:pp].*)
+          .join_successful_non_wip_verifications_for_provider_id(provider_id)
+          .join_provider_versions_for_provider_id(provider_id) do
+            Sequel.lit('provider_versions.branch != ?', provider_version_branch)
+          end
+          .where(Sequel[:pp][:provider_id] => provider_id)
+
+        first_version_for_branch = PactBroker::Domain::Version.first_for_pacticipant_id_and_branch(provider_id, provider_version_branch)
+        query = query.verified_before_date(first_version_for_branch.created_at) if first_version_for_branch
+        query.distinct
+      end
+
+      def successfully_verified_by_provider_tag_when_not_wip(provider_id, provider_tag)
+        from_self(alias: :pp).select(Sequel[:pp].*)
+          .join_successful_non_wip_verifications_for_provider_id(provider_id)
+          .join_provider_version_tags_for_tag(provider_tag)
+          .where(Sequel[:pp][:provider_id] => provider_id)
+          .distinct
+      end
+
+      def successfully_verified_by_provider_another_tag_before_this_tag_first_created(provider_id, provider_tag)
+        query = from_self(alias: :pp)
+          .select(Sequel[:pp].*)
+          .where(Sequel[:pp][:provider_id] => provider_id)
+          .join_successful_non_wip_verifications_for_provider_id(provider_id)
+          .join_provider_version_tags do
+            Sequel.lit('provider_tags.name != ?', provider_tag)
+          end
+
+        first_tag_with_name = PactBroker::Domain::Tag.where(pacticipant_id: provider_id, name: provider_tag).order(:created_at).first
+        query = query.verified_before_date(first_tag_with_name.created_at) if first_tag_with_name
+        query.distinct
+      end
+
+      protected
+
+      def verified_before_date(date)
+        where { Sequel[:verifications][:execution_date] < date }
+      end
+
+      def join_successful_non_wip_verifications_for_provider_id(provider_id, &block)
+        verifications_join = {
+          pact_version_id: :pact_version_id,
+          Sequel[:verifications][:success] => true,
+          Sequel[:verifications][:wip] => false,
+          Sequel[:verifications][:provider_id] => provider_id
+        }
+        join(:verifications, verifications_join, {}, &block)
+      end
+
+      def join_provider_version_tags &block
+        tags_join = {
+          Sequel[:verifications][:provider_version_id] => Sequel[:provider_tags][:version_id],
+        }
+        join(:tags, tags_join, { table_alias: :provider_tags }, &block)
+      end
+
+      def join_provider_version_tags_for_tag(tag)
+        tags_join = {
+          Sequel[:verifications][:provider_version_id] => Sequel[:provider_tags][:version_id],
+          Sequel[:provider_tags][:name] => tag
+        }
+        join(:tags, tags_join, { table_alias: :provider_tags } )
+      end
+
+      def join_provider_versions_for_provider_id_and_branch(provider_id, provider_version_branch)
+        versions_join = {
+          Sequel[:verifications][:provider_version_id] => Sequel[:provider_versions][:id],
+          Sequel[:provider_versions][:branch] => provider_version_branch,
+          Sequel[:provider_versions][:pacticipant_id] => provider_id
+        }
+        join(:versions, versions_join, { table_alias: :provider_versions } )
+      end
+
+      def join_provider_versions_for_provider_id(provider_id, &block)
+        versions_join = {
+          Sequel[:verifications][:provider_version_id] => Sequel[:provider_versions][:id],
+          Sequel[:provider_versions][:pacticipant_id] => provider_id
+        }
+        join(:versions, versions_join, { table_alias: :provider_versions }, &block)
+      end
+    end
+  end
+end

--- a/lib/pact_broker/pacts/pacts_for_verification_repository.rb
+++ b/lib/pact_broker/pacts/pacts_for_verification_repository.rb
@@ -186,12 +186,13 @@ module PactBroker
           .all
       end
 
+      # TODO ? find the WIP pacts by consumer branch
       def find_wip_pact_versions_for_provider_by_provider_tags(provider, provider_tags_names, provider_tags, wip_start_date, pact_publication_scope)
         potential_wip_pacts_by_consumer_tag_query = PactPublication.for_provider(provider).created_after(wip_start_date).send(pact_publication_scope)
         potential_wip_pacts_by_consumer_tag = potential_wip_pacts_by_consumer_tag_query.all
 
         tag_to_pact_publications = provider_tags_names.each_with_object({}) do | provider_tag_name, tag_to_pact_publications |
-          tag_to_pact_publications[provider_tag_name] = remove_already_verified_by_tag(
+          tag_to_pact_publications[provider_tag_name] = remove_non_wip_for_tag(
             potential_wip_pacts_by_consumer_tag,
             potential_wip_pacts_by_consumer_tag_query,
             provider,
@@ -219,13 +220,13 @@ module PactBroker
         provider = pacticipant_repository.find_by_name(provider_name)
         wip_start_date = options.fetch(:include_wip_pacts_since)
 
-        wip_pact_publications_by_branch = remove_already_verified_by_branch(
+        wip_pact_publications_by_branch = remove_non_wip_for_branch(
           PactPublication.for_provider(provider).created_after(wip_start_date).latest_by_consumer_branch,
           provider,
           provider_version_branch
         )
 
-        wip_pact_publications_by_tag = remove_already_verified_by_branch(
+        wip_pact_publications_by_tag = remove_non_wip_for_branch(
           PactPublication.for_provider(provider).created_after(wip_start_date).latest_by_consumer_tag,
           provider,
           provider_version_branch
@@ -265,12 +266,12 @@ module PactBroker
           end
       end
 
-      def remove_already_verified_by_branch(pact_publications, provider, provider_version_branch)
+      def remove_non_wip_for_branch(pact_publications, provider, provider_version_branch)
         remaining_pact_publications = PactPublication.subtract(pact_publications.all, pact_publications.successfully_verified_by_provider_branch_when_not_wip(provider.id, provider_version_branch).all)
         PactPublication.subtract(remaining_pact_publications, pact_publications.successfully_verified_by_provider_another_branch_before_this_branch_first_created(provider.id, provider_version_branch).all)
       end
 
-      def remove_already_verified_by_tag(pact_publications, query, provider, tag)
+      def remove_non_wip_for_tag(pact_publications, query, provider, tag)
         pact_publications = PactPublication.subtract(pact_publications, query.successfully_verified_by_provider_tag_when_not_wip(provider.id, tag).all)
         PactPublication.subtract(pact_publications, query.successfully_verified_by_provider_another_tag_before_this_tag_first_created(provider.id, tag).all)
       end

--- a/lib/pact_broker/pacts/pacts_for_verification_repository.rb
+++ b/lib/pact_broker/pacts/pacts_for_verification_repository.rb
@@ -199,18 +199,10 @@ module PactBroker
           )
         end
 
-        provider_has_no_versions = !provider.any_versions?
-
         tag_to_pact_publications.flat_map do | provider_tag_name, pact_publications |
           pact_publications.collect do | pact_publication |
-            force_include = PactBroker.feature_enabled?(:experimental_no_provider_versions_makes_all_head_pacts_wip) && provider_has_no_versions
-
-            pending_tag_names_to_use = [provider_tag_name]
-
-            if pending_tag_names_to_use.any?
-              selectors = create_selectors_for_wip_pact(pact_publication)
-              VerifiablePact.create_for_wip_for_provider_tags(pact_publication.to_domain, selectors, pending_tag_names_to_use)
-            end
+            selectors = create_selectors_for_wip_pact(pact_publication)
+            VerifiablePact.create_for_wip_for_provider_tags(pact_publication.to_domain, selectors, [provider_tag_name])
           end
         end.compact
       end
@@ -274,12 +266,13 @@ module PactBroker
       end
 
       def remove_already_verified_by_branch(pact_publications, provider, provider_version_branch)
-        PactPublication.subtract(pact_publications.all, pact_publications.successfully_verified_by_provider_branch(provider.id, provider_version_branch).all)
+        remaining_pact_publications = PactPublication.subtract(pact_publications.all, pact_publications.successfully_verified_by_provider_branch_when_not_wip(provider.id, provider_version_branch).all)
+        PactPublication.subtract(remaining_pact_publications, pact_publications.successfully_verified_by_provider_another_branch_before_this_branch_first_created(provider.id, provider_version_branch).all)
       end
 
       def remove_already_verified_by_tag(pact_publications, query, provider, tag)
         pact_publications = PactPublication.subtract(pact_publications, query.successfully_verified_by_provider_tag_when_not_wip(provider.id, tag).all)
-        PactPublication.subtract(pact_publications, query.successfully_verified_by_provider_another_tag_before_branch_created(provider.id, tag).all)
+        PactPublication.subtract(pact_publications, query.successfully_verified_by_provider_another_tag_before_this_tag_first_created(provider.id, tag).all)
       end
 
       def scope_for(scope)

--- a/lib/pact_broker/test/http_test_data_builder.rb
+++ b/lib/pact_broker/test/http_test_data_builder.rb
@@ -33,6 +33,13 @@ module PactBroker
         puts "\n=============================================================\n\n"
       end
 
+      def comment string
+        puts "**********************************************************"
+        puts string
+        puts "**********************************************************\n\n"
+        self
+      end
+
       def create_tagged_pacticipant_version(pacticipant:, version:, tag:)
         [*tag].each do | tag |
           create_tag(pacticipant: pacticipant, version: version, tag: tag)
@@ -51,6 +58,7 @@ module PactBroker
           branch: branch
         }
         client.put("pacticipants/#{encode(pacticipant)}/versions/#{encode(version)}", request_body).tap { |response| check_for_error(response) }
+        self
       end
 
       def deploy_to_prod(pacticipant:, version:)

--- a/script/reproduce-issue-starting-up.rb
+++ b/script/reproduce-issue-starting-up.rb
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 
-begin
+# To show issue on master, need to set RACK_ENV=production to turn off feature toggle
 
+begin
   $LOAD_PATH << "#{Dir.pwd}/lib"
   require 'pact_broker/test/http_test_data_builder'
   base_url = ENV['PACT_BROKER_BASE_URL'] || 'http://localhost:9292'
@@ -11,13 +12,17 @@ begin
     .delete_integration(consumer: "foo-consumer", provider: "bar-provider")
     .create_pacticipant("foo-consumer")
     .create_pacticipant("foo-provider")
-    .create_global_webhook_for_verification_published(uuid: "ba8feb17-558a-4b3f-a078-f52c6fafd014", url: "http://webhook-server:9393")
+    .create_version(pacticipant: "foo-provider", version: "0", branch: nil)
     .publish_pact(consumer: "foo-consumer", consumer_version: "1", provider: "bar-provider", content_id: "111", tag: "main")
-    .publish_pact(consumer: "foo-consumer", consumer_version: "2", provider: "bar-provider", content_id: "111", tag: ["feat/x", "feat/y"])
-    .sleep(10)
+    .publish_pact(consumer: "foo-consumer", consumer_version: "2", provider: "bar-provider", content_id: "222", tag: ["feat/x", "feat/y"])
+    .sleep(1)
     .get_pacts_for_verification(
       provider_version_tag: "main",
-      consumer_version_selectors: [{ tag: "main", latest: true }, { tag: "feat/x", latest: true }, { tag: "feat/y", latest: true }])
+      consumer_version_selectors: [{ tag: "main", latest: true }],
+      include_wip_pacts_since: "2020-01-01",
+      enable_pending: true
+    )
+    .comment("There should have been 2 pacts to verify here")
     .verify_pact(
       index: 0,
       provider_version_tag: "main",

--- a/spec/features/pending_pacts_with_tags_spec.rb
+++ b/spec/features/pending_pacts_with_tags_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "the pending lifecycle of a pact (with no tags)" do
+RSpec.describe "the pending lifecycle of a pact (with tags)" do
   let(:pact_content_1) { { some: "interactions" }.to_json }
   let(:pact_content_2) { { some: "other interactions" }.to_json }
   let(:request_headers) { { "CONTENT_TYPE" => "application/json", "HTTP_ACCEPT" => "application/hal+json"} }

--- a/spec/features/pending_pacts_with_tags_spec.rb
+++ b/spec/features/pending_pacts_with_tags_spec.rb
@@ -1,0 +1,138 @@
+RSpec.describe "the pending lifecycle of a pact (with no tags)" do
+  let(:pact_content_1) { { some: "interactions" }.to_json }
+  let(:pact_content_2) { { some: "other interactions" }.to_json }
+  let(:request_headers) { { "CONTENT_TYPE" => "application/json", "HTTP_ACCEPT" => "application/hal+json"} }
+  let(:failed_verification_results) do
+    {
+      providerApplicationVersion: "2",
+      success: false
+    }.to_json
+  end
+  let(:successful_verification_results) do
+    {
+      providerApplicationVersion: "2",
+      success: true
+    }.to_json
+  end
+
+  def publish_pact
+    put("/pacts/provider/Bar/consumer/Foo/version/1", pact_content_1, request_headers)
+  end
+
+  def get_pacts_for_verification(provider_version_tag = "main")
+    post("/pacts/provider/Bar/for-verification", { includePendingStatus: true, providerVersionTags: [*provider_version_tag] }.to_json, request_headers)
+  end
+
+  def pact_url_from(pacts_for_verification_response)
+    JSON.parse(pacts_for_verification_response.body)["_embedded"]["pacts"][0]["_links"]["self"]["href"]
+  end
+
+  def get_pact(pact_url)
+    get pact_url, nil, request_headers
+  end
+
+  def verification_results_url_from(pact_response)
+    JSON.parse(pact_response.body)["_links"]["pb:publish-verification-results"]["href"]
+  end
+
+  def publish_verification_results(verification_results_url, results)
+    put("/pacticipants/Bar/versions/#{JSON.parse(results)["providerApplicationVersion"]}/tags/main", nil, { "CONTENT_TYPE" => "application/json" })
+    post(verification_results_url, results, request_headers)
+  end
+
+  def pending_status_from(pacts_for_verification_response)
+    JSON.parse(pacts_for_verification_response.body)["_embedded"]["pacts"][0]["verificationProperties"]["pending"]
+  end
+
+
+  context "a pact" do
+    describe "when it is first published" do
+      it "is pending" do
+        publish_pact
+        pacts_for_verification_response = get_pacts_for_verification
+        expect(pending_status_from(pacts_for_verification_response)).to be true
+      end
+    end
+
+    describe "when it is verified unsuccessfully" do
+      it "is still pending" do
+        # CONSUMER BUILD
+        # publish pact
+        publish_pact
+
+        # PROVIDER BUILD
+        # fetch pacts to verify
+        pacts_for_verification_response = get_pacts_for_verification
+        pact_url = pact_url_from(pacts_for_verification_response)
+        pact_response = get_pact(pact_url)
+
+        # verify pact... failure...
+
+        # publish failure verification results
+        verification_results_url = verification_results_url_from(pact_response)
+        publish_verification_results(verification_results_url, failed_verification_results)
+
+        # ANOTHER PROVIDER BUILD
+        # get pacts for verification
+        pacts_for_verification_response = get_pacts_for_verification
+        # still pending
+        expect(pending_status_from(pacts_for_verification_response)).to be true
+      end
+    end
+
+    describe "when it is verified successfully" do
+      it "is no longer pending" do
+        # CONSUMER BUILD
+        publish_pact
+
+        # PROVIDER BUILD
+        pacts_for_verification_response = get_pacts_for_verification
+
+        # fetch pact
+        pact_url = pact_url_from(pacts_for_verification_response)
+        pact_response = get_pact(pact_url)
+
+        # verify pact... success!
+
+        # publish failure verification results
+        verification_results_url = verification_results_url_from(pact_response)
+        publish_verification_results(verification_results_url, successful_verification_results)
+
+        # ANOTHER PROVIDER BUILD 2
+        # get pacts for verification
+        # publish successful verification results
+        pacts_for_verification_response = get_pacts_for_verification
+        # not pending any more
+        expect(pending_status_from(pacts_for_verification_response)).to be false
+      end
+    end
+
+
+    describe "when it is verified successfully by one branch, and then another branch of the provider is created" do
+      it "is not pending for the new branch" do
+        # CONSUMER BUILD
+        publish_pact
+
+        # PROVIDER BUILD
+        pacts_for_verification_response = get_pacts_for_verification
+
+        # fetch pact
+        pact_url = pact_url_from(pacts_for_verification_response)
+        pact_response = get_pact(pact_url)
+
+        # verify pact... success!
+
+        # publish failure verification results
+        verification_results_url = verification_results_url_from(pact_response)
+        publish_verification_results(verification_results_url, successful_verification_results)
+
+        # ANOTHER PROVIDER BUILD 2 from another branch
+        # get pacts for verification
+        # publish successful verification results
+        pacts_for_verification_response = get_pacts_for_verification("feat/foo")
+        # not pending
+        expect(pending_status_from(pacts_for_verification_response)).to be false
+      end
+    end
+  end
+end

--- a/spec/lib/pact_broker/pacts/pact_publication_dataset_module_spec.rb
+++ b/spec/lib/pact_broker/pacts/pact_publication_dataset_module_spec.rb
@@ -268,10 +268,10 @@ module PactBroker
         end
       end
 
-      describe "#successfully_verified_by_provider_branch" do
+      describe "#successfully_verified_by_provider_branch_when_not_wip" do
         let(:bar) { td.find_pacticipant("Bar") }
 
-        subject { PactPublication.successfully_verified_by_provider_branch(bar.id, "main").all }
+        subject { PactPublication.successfully_verified_by_provider_branch_when_not_wip(bar.id, "main").all }
 
         context "PactPublication" do
           before do
@@ -295,7 +295,7 @@ module PactBroker
 
 
         context "with chained scopes" do
-          subject { PactPublication.latest_by_consumer_branch.successfully_verified_by_provider_branch(bar.id, "provider-main").all }
+          subject { PactPublication.latest_by_consumer_branch.successfully_verified_by_provider_branch_when_not_wip(bar.id, "provider-main").all }
 
           context "when there are no latest branch pacts that have been successfully verified by the specified provider branch" do
             before do
@@ -348,7 +348,7 @@ module PactBroker
                 .create_verification(provider_version: "2", success: true, branch: "provider-main", number: "2")
             end
 
-            subject { PactPublication.latest_by_consumer_tag.successfully_verified_by_provider_branch(bar.id, "provider-main").all }
+            subject { PactPublication.latest_by_consumer_tag.successfully_verified_by_provider_branch_when_not_wip(bar.id, "provider-main").all }
 
             its(:size) { is_expected.to eq 1 }
 
@@ -376,7 +376,7 @@ module PactBroker
 
             it "with branches" do
               potential = PactPublication.for_provider(bar).latest_by_consumer_branch
-              already_verified = potential.successfully_verified_by_provider_branch(bar.id, "provider-main")
+              already_verified = potential.successfully_verified_by_provider_branch_when_not_wip(bar.id, "provider-main")
               not_verified = PactPublication.subtract(potential.all, already_verified.all)
 
               expect(not_verified.size).to eq 1
@@ -385,7 +385,7 @@ module PactBroker
 
             it "with tags" do
               potential = PactPublication.for_provider(bar).latest_by_consumer_tag
-              already_verified = potential.successfully_verified_by_provider_branch(bar.id, "provider-main")
+              already_verified = potential.successfully_verified_by_provider_branch_when_not_wip(bar.id, "provider-main")
               not_verified = PactPublication.subtract(potential.all, already_verified.all)
 
               expect(not_verified.size).to eq 1

--- a/spec/lib/pact_broker/pacts/pact_publication_spec.rb
+++ b/spec/lib/pact_broker/pacts/pact_publication_spec.rb
@@ -432,10 +432,10 @@ module PactBroker
         end
       end
 
-      describe "#successfully_verified_by_provider_branch" do
+      describe "#successfully_verified_by_provider_branch_when_not_wip" do
         let(:bar) { td.find_pacticipant("Bar") }
 
-        subject { PactPublication.successfully_verified_by_provider_branch(bar.id, "main").all }
+        subject { PactPublication.successfully_verified_by_provider_branch_when_not_wip(bar.id, "main").all }
 
         context "PactPublication" do
           before do
@@ -455,7 +455,7 @@ module PactBroker
 
 
         context "with chained scopes" do
-          subject { PactPublication.latest_by_consumer_branch.successfully_verified_by_provider_branch(bar.id, "provider-main").all }
+          subject { PactPublication.latest_by_consumer_branch.successfully_verified_by_provider_branch_when_not_wip(bar.id, "provider-main").all }
 
           context "when there are no latest branch pacts that have been successfully verified by the specified provider branch" do
             before do
@@ -508,7 +508,7 @@ module PactBroker
                 .create_verification(provider_version: "2", success: true, branch: "provider-main", number: "2")
             end
 
-            subject { PactPublication.latest_by_consumer_tag.successfully_verified_by_provider_branch(bar.id, "provider-main").all }
+            subject { PactPublication.latest_by_consumer_tag.successfully_verified_by_provider_branch_when_not_wip(bar.id, "provider-main").all }
 
             its(:size) { is_expected.to eq 1 }
 
@@ -536,7 +536,7 @@ module PactBroker
 
             it "with branches" do
               potential = PactPublication.for_provider(bar).latest_by_consumer_branch
-              already_verified = potential.successfully_verified_by_provider_branch(bar.id, "provider-main")
+              already_verified = potential.successfully_verified_by_provider_branch_when_not_wip(bar.id, "provider-main")
               not_verified = potential.all - already_verified.all
 
               expect(not_verified.size).to eq 1
@@ -545,7 +545,7 @@ module PactBroker
 
             it "with tags" do
               potential = PactPublication.for_provider(bar).latest_by_consumer_tag
-              already_verified = potential.successfully_verified_by_provider_branch(bar.id, "provider-main")
+              already_verified = potential.successfully_verified_by_provider_branch_when_not_wip(bar.id, "provider-main")
               not_verified = potential.all - already_verified.all
 
               expect(not_verified.size).to eq 1

--- a/spec/lib/pact_broker/pacts/repository_find_wip_pact_versions_for_provider_spec.rb
+++ b/spec/lib/pact_broker/pacts/repository_find_wip_pact_versions_for_provider_spec.rb
@@ -253,20 +253,6 @@ module PactBroker
           end
         end
 
-        context "when the first provider tag with a given name was created after the head pact was created" do
-          before do
-            td.create_pact_with_hierarchy("foo", "1", "bar")
-              .create_consumer_version_tag("feat-x")
-              .add_day
-              .create_provider_version("5")
-              .create_provider_version_tag(provider_tags.first)
-          end
-
-          it "doesn't return any pacts" do
-            expect(subject.size).to be 0
-          end
-        end
-
         context "when the provider tag does not exist yet and there are no provider versions" do
           before do
             td.create_pact_with_hierarchy("foo", "1", "bar")
@@ -285,11 +271,10 @@ module PactBroker
               .create_provider_version("1")
           end
 
-          it "doesn't return any pacts" do
-            expect(subject.size).to be 0
+          it "is included" do
+            expect(subject.size).to be 1
           end
         end
-
 
         context "when a pact was already successfully verified by another branch before the first creation of one tag but not the other" do
           let(:provider_tags) { %w[dev feat-1] }
@@ -327,66 +312,61 @@ module PactBroker
           end
         end
 
-        context "bethtest" do
-          let(:include_wip_pacts_since) { (Date.today - 100).to_datetime }
-          describe "select_provider_tags_with_successful_verifications_from_another_branch_from_before_this_branch_created" do
-            context "when the provider version tag specified does not exist yet and there are previous successful verifications from another branch" do
-              before do
-                td.create_pact_with_hierarchy("foo", "1", "bar")
-                  .create_consumer_version_tag("main")
-                  .create_verification(provider_version: "20", tag_names: ['dev'], success: true)
-                  .create_verification(provider_version: "21", number: 2)
-              end
+        context "when the provider version tag specified does not exist yet and there are previous successful verifications from another branch" do
+          before do
+            td.create_pact_with_hierarchy("foo", "1", "bar")
+              .create_consumer_version_tag("main")
+              .create_verification(provider_version: "20", tag_names: ['dev'], success: true)
+              .create_verification(provider_version: "21", number: 2)
+          end
 
-              let(:provider_tags) { %w[feat-new-branch] }
+          let(:provider_tags) { %w[feat-new-branch] }
 
-              it { is_expected.to be_empty }
-            end
+          it { is_expected.to be_empty }
+        end
 
-            context "when the provider version tag specified does not exist yet and there are previous failed verifications from another branch" do
-              before do
-                td.create_pact_with_hierarchy("foo", "1", "bar")
-                  .create_consumer_version_tag("main")
-                  .create_verification(provider_version: "20", tag_names: ['dev'], success: false)
-                  .create_verification(provider_version: "21", number: 2)
-              end
+        context "when the provider version tag specified does not exist yet and there are previous failed verifications from another branch" do
+          before do
+            td.create_pact_with_hierarchy("foo", "1", "bar")
+              .create_consumer_version_tag("main")
+              .create_verification(provider_version: "20", tag_names: ['dev'], success: false)
+              .create_verification(provider_version: "21", number: 2)
+          end
 
-              let(:provider_tags) { %w[feat-new-branch] }
+          let(:provider_tags) { %w[feat-new-branch] }
 
-              it "is included" do
-                expect(subject.first.pending_provider_tags).to eq [provider_tags.first]
-              end
-            end
+          it "is included" do
+            expect(subject.first.pending_provider_tags).to eq [provider_tags.first]
+          end
+        end
 
-            context "when there is a successful verification from before the first provider version with the specified tag was created" do
-              before do
-                td.create_pact_with_hierarchy("foo", "1", "bar")
-                  .create_consumer_version_tag("main")
-                  .create_verification(provider_version: "20", tag_names: ['dev'], success: true)
-                  .add_day
-                  .create_verification(provider_version: "21", tag_names: ['feat-new-branch'], number: 2, success: false)
-              end
+        context "when there is a successful verification from before the first provider version with the specified tag was created" do
+          before do
+            td.create_pact_with_hierarchy("foo", "1", "bar")
+              .create_consumer_version_tag("main")
+              .create_verification(provider_version: "20", tag_names: ['dev'], success: true)
+              .add_day
+              .create_verification(provider_version: "21", tag_names: ['feat-new-branch'], number: 2, success: false)
+          end
 
-              let(:provider_tags) { %w[feat-new-branch] }
+          let(:provider_tags) { %w[feat-new-branch] }
 
-              it { is_expected.to be_empty }
-            end
+          it { is_expected.to be_empty }
+        end
 
-            context "when there is a successful verification from after the first provider version with the specified tag was created" do
-              before do
-                td.create_pact_with_hierarchy("foo", "1", "bar")
-                  .create_consumer_version_tag("main")
-                  .create_verification(provider_version: "21", tag_names: ['feat-new-branch'], number: 2, success: false)
-                  .add_day
-                  .create_verification(provider_version: "20", tag_names: ['dev'], success: true)
-              end
+        context "when there is a successful verification from after the first provider version with the specified tag was created" do
+          before do
+            td.create_pact_with_hierarchy("foo", "1", "bar")
+              .create_consumer_version_tag("main")
+              .create_verification(provider_version: "21", tag_names: ['feat-new-branch'], number: 2, success: false)
+              .add_day
+              .create_verification(provider_version: "20", tag_names: ['dev'], success: true)
+          end
 
-              let(:provider_tags) { %w[feat-new-branch] }
+          let(:provider_tags) { %w[feat-new-branch] }
 
-              it "is included" do
-                expect(subject.first.pending_provider_tags).to eq [provider_tags.first]
-              end
-            end
+          it "is included" do
+            expect(subject.first.pending_provider_tags).to eq [provider_tags.first]
           end
         end
       end

--- a/spec/lib/pact_broker/pacts/repository_find_wip_pact_versions_for_provider_spec.rb
+++ b/spec/lib/pact_broker/pacts/repository_find_wip_pact_versions_for_provider_spec.rb
@@ -291,23 +291,102 @@ module PactBroker
         end
 
 
-        context "when a pact was published between the first creation date of two provider tags" do
+        context "when a pact was already successfully verified by another branch before the first creation of one tag but not the other" do
           let(:provider_tags) { %w[dev feat-1] }
 
           before do
-            td.create_provider("bar")
-              .create_provider_version("4")
-              .create_provider_version_tag(provider_tags.first)
-              .add_day
-              .create_pact_with_hierarchy("foo", "1", "bar")
+            td.create_pact_with_hierarchy("foo", "1", "bar")
               .create_consumer_version_tag("feat-x")
               .add_day
-              .create_provider_version("5")
-              .create_provider_version_tag(provider_tags.last)
+              .create_verification(provider_version: "1", success: false, number: 1, tag_names: %w[dev])
+              .add_day
+              .create_verification(provider_version: "2", success: true, number: 2, tag_names: %w[blah])
+              .add_day
+              .create_verification(provider_version: "3", success: false, number: 3, tag_names: %w[feat-1])
           end
 
           it "is wip for the first tag but not the second" do
-            expect(subject.first.pending_provider_tags).to eq [provider_tags.first]
+            expect(subject.first.pending_provider_tags).to eq %w[dev]
+          end
+        end
+
+        context "when a pact was already successfully verified by another branch before the first creation of one tag but not the other" do
+          let(:provider_tags) { %w[dev feat-1] }
+
+          before do
+            td.create_pact_with_hierarchy("foo", "1", "bar")
+              .create_consumer_version_tag("feat-x")
+              .add_day
+              .create_verification(provider_version: "1", success: true, number: 1, tag_names: %w[dev])
+              .add_day
+              .create_verification(provider_version: "3", success: false, number: 3, tag_names: %w[feat-1])
+          end
+
+          it "this should be WIP, as it hasn't been successfully verified by both dev AND feat-1 - need to update logic to exclude previous verifications from other specified tags. But two tags doesn't make sense anyway. Will leave it for now.", pending: true do
+            expect(subject).to_not be_empty
+          end
+        end
+
+        context "bethtest" do
+          let(:include_wip_pacts_since) { (Date.today - 100).to_datetime }
+          describe "select_provider_tags_with_successful_verifications_from_another_branch_from_before_this_branch_created" do
+            context "when the provider version tag specified does not exist yet and there are previous successful verifications from another branch" do
+              before do
+                td.create_pact_with_hierarchy("foo", "1", "bar")
+                  .create_consumer_version_tag("main")
+                  .create_verification(provider_version: "20", tag_names: ['dev'], success: true)
+                  .create_verification(provider_version: "21", number: 2)
+              end
+
+              let(:provider_tags) { %w[feat-new-branch] }
+
+              it { is_expected.to be_empty }
+            end
+
+            context "when the provider version tag specified does not exist yet and there are previous failed verifications from another branch" do
+              before do
+                td.create_pact_with_hierarchy("foo", "1", "bar")
+                  .create_consumer_version_tag("main")
+                  .create_verification(provider_version: "20", tag_names: ['dev'], success: false)
+                  .create_verification(provider_version: "21", number: 2)
+              end
+
+              let(:provider_tags) { %w[feat-new-branch] }
+
+              it "is included" do
+                expect(subject.first.pending_provider_tags).to eq [provider_tags.first]
+              end
+            end
+
+            context "when there is a successful verification from before the first provider version with the specified tag was created" do
+              before do
+                td.create_pact_with_hierarchy("foo", "1", "bar")
+                  .create_consumer_version_tag("main")
+                  .create_verification(provider_version: "20", tag_names: ['dev'], success: true)
+                  .add_day
+                  .create_verification(provider_version: "21", tag_names: ['feat-new-branch'], number: 2, success: false)
+              end
+
+              let(:provider_tags) { %w[feat-new-branch] }
+
+              it { is_expected.to be_empty }
+            end
+
+            context "when there is a successful verification from after the first provider version with the specified tag was created" do
+              before do
+                td.create_pact_with_hierarchy("foo", "1", "bar")
+                  .create_consumer_version_tag("main")
+                  .create_verification(provider_version: "21", tag_names: ['feat-new-branch'], number: 2, success: false)
+                  .add_day
+                  .create_verification(provider_version: "20", tag_names: ['dev'], success: true)
+              end
+
+              let(:provider_tags) { %w[feat-new-branch] }
+
+              it "is included" do
+                expect(subject.first.pending_provider_tags).to eq [provider_tags.first]
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Current logic for determining the WIP pacts list ends with:
 
> 5. Discard all the pacts that were published before the first instance of this provider tag (this is so that if you create a brand new provider branch, you don't get EVERY head pact included in the WIP pacts list).

The problem with this is that feature pacts created before a provider's feature branch is created don't get included.

See https://github.com/pact-foundation/pact_broker/issues/427 and https://github.com/pact-foundation/pact_broker/blob/a59f19b27f1d01a48ff62e55b81e9c27cbdde2fe/script/reproduce-issue-starting-up.rb

This PR changes the last condition to:

> 5. Discard all the pacts that were explicitly selected and successfully verified by another branch of the provider before this branch was created (this is so that if you create a brand new provider branch, you don't get EVERY head pact included in the WIP pacts list).