### PR TITLE
feat:fix triggered webhook urls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "bump", "~> 0.5"
 group :development do
   gem "pry-byebug"
   gem "rubocop", "~>1.1"
-  gem "rubocop-performance"
+  gem "rubocop-performance", "~> 1.11"
   gem "sequel-annotate", "~>1.3"
 end
 

--- a/db/migrations/20210608_add_uuid_to_webhook.rb
+++ b/db/migrations/20210608_add_uuid_to_webhook.rb
@@ -2,7 +2,7 @@ Sequel.migration do
   up do
     alter_table(:triggered_webhooks) do
       add_column(:uuid, String)
-      add_index [:uuid], name: 'triggered_webhooks_uuid', unique: true
+      add_index [:uuid], name: "triggered_webhooks_uuid", unique: true
     end
   end
 

--- a/db/migrations/20210608_add_uuid_to_webhook.rb
+++ b/db/migrations/20210608_add_uuid_to_webhook.rb
@@ -1,0 +1,14 @@
+Sequel.migration do
+  up do
+    alter_table(:triggered_webhooks) do
+      add_column(:uuid, String)
+      add_index [:uuid], name: 'triggered_webhooks_uuid', unique: true
+    end
+  end
+
+  down do
+    alter_table(:triggered_webhooks) do
+      drop_column(:uuid)
+    end
+  end
+end

--- a/db/migrations/20210609_set_webhook_uuid.rb
+++ b/db/migrations/20210609_set_webhook_uuid.rb
@@ -1,0 +1,11 @@
+require 'pact_broker/db/data_migrations/set_webhook_uuid'
+
+Sequel.migration do
+  up do
+    PactBroker::DB::DataMigrations::SetWebhookUuid.call(self)
+  end
+
+  down do
+
+  end
+end

--- a/db/migrations/20210609_set_webhook_uuid.rb
+++ b/db/migrations/20210609_set_webhook_uuid.rb
@@ -1,4 +1,4 @@
-require 'pact_broker/db/data_migrations/set_webhook_uuid'
+require "pact_broker/db/data_migrations/set_webhook_uuid"
 
 Sequel.migration do
   up do

--- a/lib/pact_broker/api.rb
+++ b/lib/pact_broker/api.rb
@@ -99,8 +99,7 @@ module PactBroker
 
         add ["webhooks", "execute" ], Api::Resources::WebhookExecution, {resource_name: "execute_unsaved_webhook"}
         add ["webhooks", :uuid ], Api::Resources::Webhook, {resource_name: "webhook"}
-        add ["webhooks", :uuid, "trigger", :trigger_uuid, "logs" ], Api::Resources::TriggeredWebhookLogs, { resource_name: "triggered_webhook_logs" }
-        add ["triggered-webhooks", :trigger_uuid, "logs" ], Api::Resources::TriggeredWebhookLogs, { resource_name: "triggered_webhook_logs" }
+        add ["triggered-webhooks", :uuid, "logs" ], Api::Resources::TriggeredWebhookLogs, { resource_name: "triggered_webhook_logs" }
         add ["webhooks", :uuid, "execute" ], Api::Resources::WebhookExecution, {resource_name: "execute_webhook"}
         add ["webhooks"], Api::Resources::AllWebhooks, {resource_name: "webhooks"}
 

--- a/lib/pact_broker/api/pact_broker_urls.rb
+++ b/lib/pact_broker/api/pact_broker_urls.rb
@@ -264,7 +264,7 @@ module PactBroker
       end
 
       def triggered_webhook_logs_url triggered_webhook, base_url
-        "#{base_url}/triggered-webhooks/#{triggered_webhook.trigger_uuid}/logs"
+        "#{base_url}/triggered-webhooks/#{triggered_webhook.uuid}/logs"
       end
 
       def badge_url_for_latest_pact pact, base_url = ""

--- a/lib/pact_broker/api/resources/triggered_webhook_logs.rb
+++ b/lib/pact_broker/api/resources/triggered_webhook_logs.rb
@@ -20,8 +20,8 @@ module PactBroker
 
         def to_text
           # Too simple to bother putting into a service
-          if triggered_webhook.webhook_executions.any?
-            triggered_webhook.webhook_executions.collect(&:logs).join("\n")
+          if webhook_executions.any?
+            webhook_executions.collect(&:logs).join("\n")
           else
             "Webhook has not executed yet. Please retry in a few seconds."
           end
@@ -37,11 +37,12 @@ module PactBroker
 
         private
 
+        def webhook_executions
+          @webhook_executions ||= triggered_webhook.webhook_executions
+        end
+
         def triggered_webhook
-          @triggered_webhook ||= begin
-            criteria = { webhook_uuid: identifier_from_path[:uuid], trigger_uuid: identifier_from_path[:trigger_uuid] }.compact
-            PactBroker::Webhooks::TriggeredWebhook.where(criteria).single_record
-          end
+          @triggered_webhook ||= PactBroker::Webhooks::TriggeredWebhook.find(uuid: identifier_from_path[:uuid])
         end
       end
     end

--- a/lib/pact_broker/db/data_migrations/set_webhook_uuid.rb
+++ b/lib/pact_broker/db/data_migrations/set_webhook_uuid.rb
@@ -1,0 +1,24 @@
+require 'pact_broker/db/data_migrations/helpers'
+require 'sequel/extensions/core_refinements'
+require 'securerandom'
+
+module PactBroker
+  module DB
+    module DataMigrations
+      class SetWebhookUuid
+        using Sequel::CoreRefinements
+        extend Helpers
+
+        def self.call(connection, _options = {})
+          if required_columns_exist?(connection)
+            connection[:triggered_webhooks].where(uuid: nil).update(uuid: [SecureRandom.uuid, "-", :id].sql_string_join)
+          end
+        end
+
+        def self.required_columns_exist?(connection)
+          columns_exist?(connection, :triggered_webhooks, [:uuid])
+        end
+      end
+    end
+  end
+end

--- a/lib/pact_broker/db/data_migrations/set_webhook_uuid.rb
+++ b/lib/pact_broker/db/data_migrations/set_webhook_uuid.rb
@@ -1,6 +1,6 @@
-require 'pact_broker/db/data_migrations/helpers'
-require 'sequel/extensions/core_refinements'
-require 'securerandom'
+require "pact_broker/db/data_migrations/helpers"
+require "sequel/extensions/core_refinements"
+require "securerandom"
 
 module PactBroker
   module DB

--- a/lib/pact_broker/db/migrate_data.rb
+++ b/lib/pact_broker/db/migrate_data.rb
@@ -24,6 +24,7 @@ module PactBroker
         DataMigrations::SetExtraColumnsForTags.call(database_connection)
         DataMigrations::SetPacticipantDisplayName.call(database_connection)
         DataMigrations::SetPacticipantMainBranch.call(database_connection)
+        DataMigrations::SetWebhookUuid.call(database_connection)
       end
     end
   end

--- a/lib/pact_broker/test/test_data_builder.rb
+++ b/lib/pact_broker/test/test_data_builder.rb
@@ -341,11 +341,11 @@ module PactBroker
 
       def create_triggered_webhook params = {}
         params.delete(:comment)
-        trigger_uuid = params[:trigger_uuid] || webhook_service.next_uuid
+        uuid = params[:uuid] || webhook_service.next_uuid
         event_name = params.key?(:event_name) ? params[:event_name] : @webhook.events.first.name # could be nil, for backwards compatibility
         verification = @webhook.trigger_on_provider_verification_published? ? @verification : nil
         event_context = params[:event_context]
-        @triggered_webhook = webhook_repository.create_triggered_webhook(trigger_uuid, @webhook, @pact, verification, PactBroker::Webhooks::TriggerService::RESOURCE_CREATION, event_name, event_context)
+        @triggered_webhook = webhook_repository.create_triggered_webhook(uuid, @webhook, @pact, verification, PactBroker::Webhooks::TriggerService::RESOURCE_CREATION, event_name, event_context)
         @triggered_webhook.update(status: params[:status]) if params[:status]
         set_created_at_if_set params[:created_at], :triggered_webhooks, { id: @triggered_webhook.id }
         self

--- a/lib/pact_broker/webhooks/event_listener.rb
+++ b/lib/pact_broker/webhooks/event_listener.rb
@@ -50,7 +50,7 @@ module PactBroker
         event = detected_events.last
         logger.info "Event detected", payload: { event_name: event.name, event_comment: event.comment }
         if event.triggered_webhooks&.any?
-          triggered_webhook_descriptions = event.triggered_webhooks.collect{ |tw| { webhook_uuid: tw.webhook_uuid, triggered_webhook_uuid: tw.trigger_uuid, webhook_description: tw.webhook.description } }
+          triggered_webhook_descriptions = event.triggered_webhooks.collect{ |tw| { webhook_uuid: tw.webhook_uuid, triggered_webhook_uuid: tw.uuid, webhook_description: tw.webhook.description } }
           logger.info "Triggered webhooks for #{event.name}", payload: { triggered_webhooks: triggered_webhook_descriptions }
         else
           logger.info "No enabled webhooks found for event #{event.name}"

--- a/lib/pact_broker/webhooks/latest_triggered_webhook.rb
+++ b/lib/pact_broker/webhooks/latest_triggered_webhook.rb
@@ -3,7 +3,22 @@ require "pact_broker/webhooks/triggered_webhook"
 module PactBroker
   module Webhooks
     class LatestTriggeredWebhook < TriggeredWebhook
-      set_dataset(:latest_triggered_webhooks)
+      SELF_JOIN = {
+        Sequel[:triggered_webhooks][:webhook_uuid] => Sequel[:triggered_webhooks_2][:webhook_uuid],
+        Sequel[:triggered_webhooks][:consumer_id] => Sequel[:triggered_webhooks_2][:consumer_id],
+        Sequel[:triggered_webhooks][:provider_id] => Sequel[:triggered_webhooks_2][:provider_id],
+        Sequel[:triggered_webhooks][:event_name] => Sequel[:triggered_webhooks_2][:event_name]
+      }
+
+      set_dataset(
+        Sequel::Model.db[:triggered_webhooks]
+          .select(Sequel[:triggered_webhooks].*)
+          .exclude(Sequel[:triggered_webhooks][:event_name] => nil)
+          .left_join(:triggered_webhooks, SELF_JOIN, { table_alias: :triggered_webhooks_2 }) do
+            Sequel[:triggered_webhooks_2][:id] > Sequel[:triggered_webhooks][:id]
+          end
+          .where(Sequel[:triggered_webhooks_2][:id] => nil)
+      )
     end
   end
 end

--- a/lib/pact_broker/webhooks/repository.rb
+++ b/lib/pact_broker/webhooks/repository.rb
@@ -97,15 +97,19 @@ module PactBroker
       end
 
       # rubocop: disable Metrics/ParameterLists
-      def create_triggered_webhook trigger_uuid, webhook, pact, verification, trigger_type, event_name, event_context
+      def create_triggered_webhook uuid, webhook, pact, verification, trigger_type, event_name, event_context
         db_webhook = deliberately_unscoped(Webhook).where(uuid: webhook.uuid).single_record
+        # trigger_uuid was meant to be one per *event*, not one per triggered webhook, but its intent got lost over time.
+        # Retiring it now in favour of uuid, but can't leave it empty because
+        # it has a not-null and unique webhook_uuid/trigger_uuid constraint on it.
         TriggeredWebhook.create(
+          uuid: uuid,
           status: TriggeredWebhook::STATUS_NOT_RUN,
           pact_publication_id: pact.id,
           verification: verification,
           webhook: db_webhook,
           webhook_uuid: db_webhook.uuid,
-          trigger_uuid: trigger_uuid,
+          trigger_uuid: uuid,
           trigger_type: trigger_type,
           consumer: pact.consumer,
           provider: pact.provider,

--- a/lib/pact_broker/webhooks/triggered_webhook.rb
+++ b/lib/pact_broker/webhooks/triggered_webhook.rb
@@ -125,8 +125,10 @@ end
 #  verification_id     | integer                     |
 #  event_name          | text                        |
 #  event_context       | text                        |
+#  uuid                | text                        |
 # Indexes:
 #  triggered_webhooks_pkey                      | PRIMARY KEY btree (id)
+#  triggered_webhooks_uuid                      | UNIQUE btree (uuid)
 #  uq_triggered_webhook_ppi_wi                  | UNIQUE btree (pact_publication_id, webhook_id, trigger_uuid)
 #  uq_triggered_webhook_wi                      | UNIQUE btree (webhook_id, trigger_uuid)
 #  triggered_webhooks_consumer_id_index         | btree (consumer_id)

--- a/spec/lib/pact_broker/api/decorators/pact_webhooks_status_decorator_spec.rb
+++ b/spec/lib/pact_broker/api/decorators/pact_webhooks_status_decorator_spec.rb
@@ -15,7 +15,7 @@ module PactBroker
             status: status,
             failure?: failure,
             retrying?: retrying,
-            trigger_uuid: "1234",
+            uuid: "1234",
             webhook_uuid: "4321",
             request_description: "GET http://foo",
             pact_publication: pact,

--- a/spec/lib/pact_broker/api/decorators/triggered_webhook_decorator_spec.rb
+++ b/spec/lib/pact_broker/api/decorators/triggered_webhook_decorator_spec.rb
@@ -11,7 +11,7 @@ module PactBroker
             status: status,
             failure?: failure,
             retrying?: retrying,
-            trigger_uuid: "1234",
+            uuid: "1234",
             webhook_uuid: "4321",
             request_description: "GET http://foo",
             pact_publication: pact,

--- a/spec/lib/pact_broker/api/resources/triggered_webhook_logs_spec.rb
+++ b/spec/lib/pact_broker/api/resources/triggered_webhook_logs_spec.rb
@@ -4,20 +4,23 @@ module PactBroker
   module Api
     module Resources
       describe TriggeredWebhookLogs do
-
-        let(:td) { TestDataBuilder.new }
-
         before do
           td.create_pact_with_hierarchy
             .create_webhook(uuid: "5432")
-            .create_triggered_webhook(trigger_uuid: "1234")
+            .create_triggered_webhook(uuid: "1234")
             .create_webhook_execution(logs: "foo")
             .create_webhook_execution(logs: "bar")
+            .create_webhook(uuid: "5555")
+            .create_triggered_webhook(uuid: "4321")
+            .create_webhook_execution(logs: "waffle")
         end
 
         let(:path) { "/webhooks/5432/trigger/1234/logs" }
 
-        subject { get path; last_response }
+        subject { get(path) }
+
+        let(:triggered_webhook_uuid) { PactBroker::Webhooks::TriggeredWebhook.first.uuid }
+        let(:path) { "/triggered-webhooks/#{triggered_webhook_uuid}/logs" }
 
         it "returns the concatenated webhook execution logs" do
           expect(subject.body).to eq "foo\nbar"

--- a/spec/lib/pact_broker/webhooks/repository_spec.rb
+++ b/spec/lib/pact_broker/webhooks/repository_spec.rb
@@ -486,7 +486,7 @@ module PactBroker
           expect(subject.consumer).to eq td.consumer
           expect(subject.provider).to eq td.provider
           expect(subject.verification).to eq td.verification
-          expect(subject.trigger_uuid).to eq "1234"
+          expect(subject.uuid).to eq "1234"
           expect(subject.trigger_type).to eq "publication"
           expect(subject.event_name).to eq "some_event"
           expect(subject.event_context).to eq event_context
@@ -573,51 +573,53 @@ module PactBroker
             .create_webhook_execution
             .create_pact_with_hierarchy
             .create_webhook(uuid: "123")
-            .create_triggered_webhook(trigger_uuid: "256", created_at: DateTime.new(2016))
+            .create_triggered_webhook(uuid: "256", created_at: DateTime.new(2016))
             .create_webhook_execution
-            .create_triggered_webhook(trigger_uuid: "332", created_at: DateTime.new(2017))
+            .create_triggered_webhook(uuid: "332", created_at: DateTime.new(2017))
             .create_webhook_execution
             .create_webhook(uuid: "987")
-            .create_triggered_webhook(trigger_uuid: "876", created_at: DateTime.new(2017))
+            .create_triggered_webhook(uuid: "876", created_at: DateTime.new(2017))
             .create_webhook_execution
-            .create_triggered_webhook(trigger_uuid: "638", created_at: DateTime.new(2018))
+            .create_triggered_webhook(uuid: "638", created_at: DateTime.new(2018))
             .create_webhook_execution
         end
 
         subject { Repository.new.find_latest_triggered_webhooks(td.consumer, td.provider) }
 
         it "finds the latest triggered webhooks" do
-          expect(subject.collect(&:trigger_uuid).sort).to eq ["332", "638"]
+          expect(subject.collect(&:uuid).sort).to eq ["332", "638"]
         end
 
         context "when a webhook has been triggered by different events" do
           before do
             td.create_pact_with_hierarchy("Foo2", "1.0.0", "Bar2")
               .create_webhook
-              .create_triggered_webhook(trigger_uuid: "333", event_name: "foo")
-              .create_triggered_webhook(trigger_uuid: "555", event_name: "foo")
+              .create_triggered_webhook(uuid: "333", event_name: "foo")
+              .create_triggered_webhook(uuid: "555", event_name: "foo")
               .create_webhook_execution
-              .create_triggered_webhook(trigger_uuid: "444", event_name: "bar")
-              .create_triggered_webhook(trigger_uuid: "777", event_name: "bar")
+              .create_triggered_webhook(uuid: "444", event_name: "bar")
+              .create_triggered_webhook(uuid: "777", event_name: "bar")
               .create_webhook_execution
-              .create_triggered_webhook(trigger_uuid: "111", event_name: nil)
-              .create_triggered_webhook(trigger_uuid: "888", event_name: nil)
+              .create_triggered_webhook(uuid: "111", event_name: nil)
+              .create_triggered_webhook(uuid: "888", event_name: nil)
               .create_webhook_execution
           end
 
           it "returns one for each event" do
-            expect(subject.collect(&:trigger_uuid).sort).to eq ["555", "777", "888"]
+            # ignoring the ones with nil event_names because they're old data, and shouldn't be
+            # considered as a separate "group"
+            expect(subject.collect(&:uuid).sort).to eq ["555", "777"]
           end
         end
 
         context "when there are two 'latest' triggered webhooks at the same time" do
           before do
-            td.create_triggered_webhook(trigger_uuid: "888", created_at: DateTime.new(2018))
+            td.create_triggered_webhook(uuid: "888", created_at: DateTime.new(2018))
               .create_webhook_execution
           end
 
           it "returns the one with the bigger ID" do
-            expect(subject.collect(&:trigger_uuid).sort).to eq ["332", "888"]
+            expect(subject.collect(&:uuid).sort).to eq ["332", "888"]
           end
         end
 
@@ -642,26 +644,26 @@ module PactBroker
             .create_webhook_execution
             .create_pact_with_hierarchy
             .create_webhook
-            .create_triggered_webhook(trigger_uuid: "256", created_at: DateTime.new(2016))
+            .create_triggered_webhook(uuid: "256", created_at: DateTime.new(2016))
             .create_webhook_execution
-            .create_triggered_webhook(trigger_uuid: "332", created_at: DateTime.new(2017))
+            .create_triggered_webhook(uuid: "332", created_at: DateTime.new(2017))
             .create_webhook_execution
-            .create_provider_webhook(uuid: "987")
-            .create_triggered_webhook(trigger_uuid: "876", created_at: DateTime.new(2017))
+            .create_provider_webhook(uuidd: "987")
+            .create_triggered_webhook(uuid: "876", created_at: DateTime.new(2017))
             .create_webhook_execution
-            .create_triggered_webhook(trigger_uuid: "638", created_at: DateTime.new(2018))
+            .create_triggered_webhook(uuid: "638", created_at: DateTime.new(2018))
             .create_webhook_execution
             .create_consumer_webhook
-            .create_triggered_webhook(trigger_uuid: "555", created_at: DateTime.new(2017))
+            .create_triggered_webhook(uuid: "555", created_at: DateTime.new(2017))
             .create_webhook_execution
-            .create_triggered_webhook(trigger_uuid: "777", created_at: DateTime.new(2018))
+            .create_triggered_webhook(uuid: "777", created_at: DateTime.new(2018))
             .create_webhook_execution
         end
 
         subject { Repository.new.find_latest_triggered_webhooks_for_pact(td.pact) }
 
         it "finds the latest triggered webhooks" do
-          expect(subject.collect(&:trigger_uuid).sort).to eq ["332", "638", "777"]
+          expect(subject.collect(&:uuid).sort).to eq ["332", "638", "777"]
         end
       end
 
@@ -670,18 +672,18 @@ module PactBroker
           td
             .create_pact_with_hierarchy("Foo", "1", "Bar")
             .create_webhook
-            .create_triggered_webhook(trigger_uuid: "1")
+            .create_triggered_webhook(uuid: "1")
             .create_webhook_execution
             .create_consumer_version("2")
             .create_pact
-            .create_triggered_webhook(trigger_uuid: "2")
+            .create_triggered_webhook(uuid: "2")
             .create_webhook_execution
         end
 
         subject { Repository.new.find_triggered_webhooks_for_pact(td.pact) }
 
         it "finds the triggered webhooks" do
-          expect(subject.collect(&:trigger_uuid).sort).to eq ["2"]
+          expect(subject.collect(&:uuid).sort).to eq ["2"]
         end
       end
 
@@ -691,15 +693,15 @@ module PactBroker
             .create_pact_with_hierarchy("Foo", "1", "Bar")
             .create_verification_webhook
             .create_verification(provider_version: "1")
-            .create_triggered_webhook(trigger_uuid: "1")
+            .create_triggered_webhook(uuid: "1")
             .create_verification(provider_version: "2", number: 2)
-            .create_triggered_webhook(trigger_uuid: "2")
+            .create_triggered_webhook(uuid: "2")
         end
 
         subject { Repository.new.find_triggered_webhooks_for_verification(td.verification) }
 
         it "finds the triggered webhooks" do
-          expect(subject.collect(&:trigger_uuid).sort).to eq ["2"]
+          expect(subject.collect(&:uuid).sort).to eq ["2"]
         end
       end
 


### PR DESCRIPTION
While I was doing the webhook policies, I realised that I had forgotten how the webhook_uuid/trigger_uuid were supposed to work for a webhook. Each webhook triggered for a particular event was supposed to have _the same_ trigger_uuid, and the combination of webhook_uuid and trigger_uuid was supposed to uniquely identify the triggered webhook. I'd added some code recently thinking that the trigger_uuid was meant to be unique, but it wasn't. I've added a plain `uuid` to the triggered webhook now, and it should now work as expected.