### PR TITLE
chore: Add simplecov threshold

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,19 +16,10 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby_version }}
       - run: "bundle install"
-      - name: "Install CodeClimate Test Reporter"
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
       - name: Tests
-        run: bundle exec rake
+        run: "bundle exec rake"
         env:
           PACTFLOW_PACT_OSS_TOKEN: ${{ secrets.PACTFLOW_PACT_OSS_TOKEN }}
-
-      #- name: Report test coverage
-      #  run: ./cc-test-reporter after-build --exit-code 0 || true
-    # env:
-      # CC_TEST_REPORTER_ID: dc2c30b67c9e2a5309e1aef699c30fdab55ba4f0e4f1beac029ba93e293835db
   postgres:
     if: "!contains(github.event.head_commit.message, '[ci-skip]')"
     runs-on: "ubuntu-latest"

--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -1,6 +1,19 @@
 require "simplecov"
 
-SimpleCov.command_name ENV["SIMPLECOV_COMMAND_NAME"] if ENV["SIMPLECOV_COMMAND_NAME"]
+SimpleCov.minimum_coverage 90
+
+if ENV["SIMPLECOV_COMMAND_NAME"]
+  SimpleCov.command_name ENV["SIMPLECOV_COMMAND_NAME"]
+  case ENV["SIMPLECOV_COMMAND_NAME"]
+  when "spec:quick"
+    SimpleCov.minimum_coverage 92
+  when "spec:slow"
+    SimpleCov.minimum_coverage 92
+  when "pact:verify"
+    SimpleCov.minimum_coverage 62
+  end
+end
+
 SimpleCov.start do
   add_filter "/db/"
   add_filter "/example/"


### PR DESCRIPTION
So codeclimate will run on default config .rubocop.yml and github action
will run on .rubocop.github-action.yml.

github-action rubocop will include Performance code which is not
supported at the moment by codeclimate.