### PR TITLE
chore: Set log_dir correctly

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -3,7 +3,11 @@ require "pact_broker"
 ENV["TZ"] = "Australia/Melbourne"
 
 app = PactBroker::App.new do | config |
-  config.log_dir = nil # log to stdout instead of file
+  if config.log_stream == :file
+    config.log_dir = File.expand_path("./log")
+  else
+    config.log_dir = nil # log to stdout instead of file
+  end
   config.base_urls = ["http://localhost:9292"]
   config.database_url = "sqlite:////tmp/pact_broker_database.sqlite3"
 end


### PR DESCRIPTION
If the `log_stream` is a file, set it to a `log` directory, otherwise set
it to `nil` to log to `sdtout` instead.

This is to fix the error when starting the server in latest commit

```
Traceback (most recent call last):
        22: from /home/user/.asdf/installs/ruby/2.7.3/bin/ruby_executable_hooks:22:in `<main>'
        21: from /home/user/.asdf/installs/ruby/2.7.3/bin/ruby_executable_hooks:22:in `eval'
        20: from /home/user/.asdf/installs/ruby/2.7.3/bin/rackup:23:in `<main>'
        19: from /home/user/.asdf/installs/ruby/2.7.3/bin/rackup:23:in `load'
        18: from /home/user/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rack-2.2.3/bin/rackup:5:in `<top (required)>'
        17: from /home/user/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:168:in `start'
        16: from /home/user/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:311:in `start'
        15: from /home/user/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:379:in `handle_profiling'
        14: from /home/user/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:312:in `block in start'
        13: from /home/user/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:422:in `wrapped_app'
        12: from /home/user/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:249:in `app'
        11: from /home/user/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:349:in `build_app_and_options_from_config'
        10: from /home/user/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:66:in `parse_file'
         9: from /home/user/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:105:in `load_file'
         8: from /home/user/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:116:in `new_from_string'
         7: from /home/user/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:116:in `eval'
         6: from /home/user/dev/pactflow/pact_broker/config.ru:5:in `block in <main>'
         5: from /home/user/dev/pactflow/pact_broker/config.ru:5:in `new'
         4: from /home/user/dev/pactflow/pact_broker/lib/pact_broker/app.rb:49:in `initialize'
         3: from /home/user/dev/pactflow/pact_broker/lib/pact_broker/app.rb:97:in `post_configure'
         2: from /home/user/dev/pactflow/pact_broker/lib/pact_broker/app.rb:134:in `configure_database_connection'
         1: from /home/user/dev/pactflow/pact_broker/lib/pact_broker/configuration.rb:125:in `logger'
/home/user/dev/pactflow/pact_broker/lib/pact_broker/configuration.rb:114:in `logger_from_runtime_configuration': undefined method `+' for nil:NilClass (NoMethodError)
```
