### PR TITLE
feat: do not allow contract content for a consumer version to be modified for all new Broker instances

### DIFF
--- a/db/migrations/20210810_set_allow_contract_modification.rb
+++ b/db/migrations/20210810_set_allow_contract_modification.rb
@@ -2,7 +2,7 @@ Sequel.migration do
   up do
     if from(:pact_publications).count != 0
       from(:config).insert(
-        name: "allow_contract_modification",
+        name: "allow_dangerous_contract_modification",
         type: "boolean",
         value: "1",
         created_at: Sequel.datetime_class.now,

--- a/db/migrations/20210810_set_allow_contract_modification.rb
+++ b/db/migrations/20210810_set_allow_contract_modification.rb
@@ -1,0 +1,17 @@
+Sequel.migration do
+  up do
+    if from(:pact_publications).count != 0
+      from(:config).insert(
+        name: "allow_contract_modification",
+        type: "boolean",
+        value: "1",
+        created_at: Sequel.datetime_class.now,
+        updated_at: Sequel.datetime_class.now
+      )
+    end
+  end
+
+  down do
+
+  end
+end

--- a/lib/pact_broker/config/runtime_configuration.rb
+++ b/lib/pact_broker/config/runtime_configuration.rb
@@ -65,6 +65,7 @@ module PactBroker
         use_first_tag_as_branch_time_limit: 10,
         auto_detect_main_branch: true,
         main_branch_candidates: ["develop", "main", "master"],
+        allow_contract_modification: false,
         semver_formats: ["%M.%m.%p%s%d", "%M.%m", "%M"],
         seed_example_data: true,
         features: []

--- a/lib/pact_broker/config/runtime_configuration.rb
+++ b/lib/pact_broker/config/runtime_configuration.rb
@@ -65,7 +65,7 @@ module PactBroker
         use_first_tag_as_branch_time_limit: 10,
         auto_detect_main_branch: true,
         main_branch_candidates: ["develop", "main", "master"],
-        allow_contract_modification: false,
+        allow_dangerous_contract_modification: false,
         semver_formats: ["%M.%m.%p%s%d", "%M.%m", "%M"],
         seed_example_data: true,
         features: []

--- a/lib/pact_broker/locale/en.yml
+++ b/lib/pact_broker/locale/en.yml
@@ -68,6 +68,7 @@ en:
         invalid_http_method: "Invalid HTTP method '%{method}'"
         invalid_url: "Invalid URL '%{url}'. Expected format: http://example.org"
         pact_missing_pacticipant_name: "was not found at expected path $.%{pacticipant}.name in the submitted pact file."
+        pact_content_modification_not_allowed: "Cannot change the content of the pact for %{consumer_name} version %{consumer_version_number}, as race conditions will cause unreliable results for can-i-deploy. Each pact must be published with a unique consumer version number. For more information see https://docs.pact.io/go/versioning"
         consumer_version_number_missing: "Please specify the consumer version number by setting the X-Pact-Consumer-Version header."
         consumer_version_number_header_invalid: "X-Pact-Consumer-Version '%{consumer_version_number}' cannot be parsed to a version number. The expected format (unless this configuration has been overridden) is a semantic version. eg. 1.3.0 or 2.0.4.rc1"
         consumer_version_number_invalid: "Consumer version number '%{consumer_version_number}' cannot be parsed to a version number. The expected format (unless this configuration has been overridden) is a semantic version. eg. 1.3.0 or 2.0.4.rc1"

--- a/lib/pact_broker/pacts/service.rb
+++ b/lib/pact_broker/pacts/service.rb
@@ -157,7 +157,7 @@ module PactBroker
       end
 
       def disallowed_modification?(existing_pact, new_json_content)
-        !PactBroker.configuration.allow_contract_modification && existing_pact && existing_pact.pact_version_sha != generate_sha(new_json_content)
+        !PactBroker.configuration.allow_dangerous_contract_modification && existing_pact && existing_pact.pact_version_sha != generate_sha(new_json_content)
       end
 
       private :update_pact

--- a/lib/pact_broker/pacts/service.rb
+++ b/lib/pact_broker/pacts/service.rb
@@ -156,6 +156,10 @@ module PactBroker
         updated_pact
       end
 
+      def disallowed_modification?(existing_pact, new_json_content)
+        !PactBroker.configuration.allow_contract_modification && existing_pact && existing_pact.pact_version_sha != generate_sha(new_json_content)
+      end
+
       private :update_pact
 
       # When no publication for the given consumer/provider/consumer version number exists

--- a/spec/features/publish_pact_spec.rb
+++ b/spec/features/publish_pact_spec.rb
@@ -30,12 +30,12 @@ describe "Publishing a pact" do
 
     before do
       td.create_pact_with_hierarchy("A Consumer", "1.2.3", "A Provider").and_return(:pact)
-      allow(PactBroker.configuration).to receive(:allow_contract_modification).and_return(allow_contract_modification)
+      allow(PactBroker.configuration).to receive(:allow_dangerous_contract_modification).and_return(allow_dangerous_contract_modification)
     end
 
     context "when the content is different" do
       context "when pact modification is allowed" do
-        let(:allow_contract_modification) { true }
+        let(:allow_dangerous_contract_modification) { true }
 
         it "returns a 200 Success" do
           expect(subject.status).to be 200
@@ -52,7 +52,7 @@ describe "Publishing a pact" do
     end
 
     context "when pact modification is not allowed" do
-      let(:allow_contract_modification) { false }
+      let(:allow_dangerous_contract_modification) { false }
 
       its(:status) { is_expected.to eq 409 }
       its(:body) { is_expected.to include "Cannot change the content of the pact for A Consumer version 1.2.3" }

--- a/spec/features/publish_pact_spec.rb
+++ b/spec/features/publish_pact_spec.rb
@@ -30,18 +30,32 @@ describe "Publishing a pact" do
 
     before do
       td.create_pact_with_hierarchy("A Consumer", "1.2.3", "A Provider").and_return(:pact)
+      allow(PactBroker.configuration).to receive(:allow_contract_modification).and_return(allow_contract_modification)
     end
 
-    it "returns a 200 Success" do
-      expect(subject.status).to be 200
+    context "when the content is different" do
+      context "when pact modification is allowed" do
+        let(:allow_contract_modification) { true }
+
+        it "returns a 200 Success" do
+          expect(subject.status).to be 200
+        end
+
+        it "returns an application/json Content-Type" do
+          expect(subject.headers["Content-Type"]).to eq "application/hal+json;charset=utf-8"
+        end
+
+        it "returns the pact in the response body" do
+          expect(response_body_json).to match_pact JSON.parse(pact_content)
+        end
+      end
     end
 
-    it "returns an application/json Content-Type" do
-      expect(subject.headers["Content-Type"]).to eq "application/hal+json;charset=utf-8"
-    end
+    context "when pact modification is not allowed" do
+      let(:allow_contract_modification) { false }
 
-    it "returns the pact in the response body" do
-      expect(response_body_json).to match_pact JSON.parse(pact_content)
+      its(:status) { is_expected.to eq 409 }
+      its(:body) { is_expected.to include "Cannot change the content of the pact for A Consumer version 1.2.3" }
     end
   end
 


### PR DESCRIPTION
Existing users will continue to be able to modify pacts unless they choose to set `allow_dangerous_contract_modification: false`. For all newly installed instances (ie. ones where there are no pact_publications at the time the migration is applied), contract modification will not be allowed. A 409 and an error message will be returned. I may put the actual diff in the response too.