### PR TITLE
feat: Add consumer and provider pattern to webhooks

### DIFF
--- a/lib/pact_broker/doc/views/webhooks.markdown
+++ b/lib/pact_broker/doc/views/webhooks.markdown
@@ -79,6 +79,23 @@ To specify an XML body, you will need to use a correctly escaped string (or use 
 
 **BEWARE** While the basic auth password, and any header containing the word `authorization` or `token` will be redacted from the UI and the logs, the password could be reverse engineered from the database, so make a separate account for the Pact Broker to use in your webhooks. Don't use your personal account!
 
+#### Consumer or provider wildcard pattern matching
+
+Webhooks can be created to match certain set of consumers or providers events. Use `pattern` attribute for either `provider` or `consumer`. Both are optional, but they cannot be provided when `name` attribute is present. You can use wildcard pattern here: `*` - matching any sequence (including empty) or `?` - matching any single character. Following example would trigger a webhook when any contract with provider matching `* Async` (e.g. `Zoo App Async`, `Animal Service Async` but not `Visitor Async Service`) changed its content:
+
+        {
+          "provider": {
+            "pattern": "* Async"
+          },
+          "events": [{
+            "name": "contract_content_changed"
+          }],
+          "request": {
+            "method": "POST",
+            "url": "http://master.ci.my.domain:8085/rest/api/latest/queue/SOME-PROJECT"
+          }
+        }
+
 #### Event types
 
 `contract_published:` triggered every time a contract is published. It is not recommended to trigger your provider verification build every time a contract is published - see `contract_content_changed` below.

--- a/spec/lib/pact_broker/api/contracts/webhook_contract_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/webhook_contract_spec.rb
@@ -85,6 +85,31 @@ module PactBroker
             end
           end
 
+          context "with a consumer pattern" do
+            let(:json) do
+              valid_webhook_with do |hash|
+                hash["consumer"].delete("name")
+                hash["consumer"]["pattern"] = "* Consumer"
+              end
+            end
+
+            it "contains no errors" do
+              expect(subject.errors).to be_empty
+            end
+          end
+
+          context "with a consumer pattern and name provided" do
+            let(:json) do
+              valid_webhook_with do |hash|
+                hash["consumer"]["pattern"] = "* Consumer"
+              end
+            end
+
+            it "contains consumer.name error" do
+              expect(subject.errors[:'consumer.name']).to eq ['cannot be provided when pattern is present']
+            end
+          end
+
           context "with a nil provider name" do
             let(:json) do
               valid_webhook_with do |hash|
@@ -128,6 +153,31 @@ module PactBroker
 
             it "contains no errors" do
               expect(subject.errors[:'provider.name']).to eq ["does not match an existing pacticipant"]
+            end
+          end
+
+          context "with provider pattern" do
+            let(:json) do
+              valid_webhook_with do |hash|
+                hash["provider"].delete("name")
+                hash["provider"]['pattern'] = '* Provider'
+              end
+            end
+
+            it "contains no errors" do
+              expect(subject.errors).to be_empty
+            end
+          end
+
+          context "with a provider pattern and name" do
+            let(:json) do
+              valid_webhook_with do |hash|
+                hash["provider"]['pattern'] = '* Provider'
+              end
+            end
+
+            it "contains no errors" do
+              expect(subject.errors[:'provider.name']).to eq ["cannot be provided when pattern is present"]
             end
           end
 

--- a/spec/lib/pact_broker/webhooks/repository_spec.rb
+++ b/spec/lib/pact_broker/webhooks/repository_spec.rb
@@ -465,6 +465,46 @@ module PactBroker
 
           its(:size) { is_expected.to eq 0 }
         end
+
+        context "when the webhook is specified for matching consumer pattern" do
+          before do
+            td.create_webhook(event_names: ["contract_published"], consumer_pattern: "* Async")
+              .create_consumer("Consumer Async")
+              .create_provider("Provider")
+          end
+
+          its(:size) { is_expected.to eq 1 }
+        end
+
+        context "when the webhook is specified for consumer pattern that does not match" do
+          before do
+            td.create_webhook(event_names: ["contract_published"], consumer_pattern: "* Async")
+              .create_consumer("Consumer")
+              .create_provider("Provider")
+          end
+
+          its(:size) { is_expected.to eq 0 }
+        end
+
+        context "when the webhook is specified for matching provider pattern" do
+          before do
+            td.create_webhook(event_names: ["contract_published"], provider_pattern: "* Async")
+              .create_consumer("Consumer")
+              .create_provider("Provider Async")
+          end
+
+          its(:size) { is_expected.to eq 1 }
+        end
+
+        context "when the webhook is specified for provider pattern that does not match" do
+          before do
+            td.create_webhook(event_names: ["contract_published"], provider_pattern: "* Async")
+              .create_consumer("Consumer")
+              .create_provider("Provider")
+          end
+
+          its(:size) { is_expected.to eq 0 }
+        end
       end
 
       describe "create_triggered_webhook" do


### PR DESCRIPTION
Base on [slack conversation](https://pact-foundation.slack.com/archives/C9VPNUJR2/p1629473556134200) we would like to add an ability to create webhooks with consumer/provider pattern instead of name so webhooks can be triggered when event happens on subset of pacticipants. 

This is draft, created to validate the idea by providing documentation and specs first.
