### PR TITLE
fix(matrix): prevent long version names overflow the table

### DIFF
--- a/lib/pact_broker/versions/abbreviate_number.rb
+++ b/lib/pact_broker/versions/abbreviate_number.rb
@@ -3,10 +3,14 @@ module PactBroker
     class AbbreviateNumber
 
       def self.call version_number
-        if version_number
-          version_number.gsub(/[A-Za-z0-9]{40}/) do | val |
-            val[0..6]
-          end
+        return version_number unless version_number
+
+        # hard limit of max 50 characters
+        version_length = version_number.length
+        return version_number[0...39] + "…" + version_number[version_length - 10...version_length] if version_length > 50
+
+        version_number.gsub(/[A-Za-z0-9]{40}/) do | val |
+          val[0..6]
         end
       end
     end

--- a/spec/lib/pact_broker/versions/abbreviate_number_spec.rb
+++ b/spec/lib/pact_broker/versions/abbreviate_number_spec.rb
@@ -8,7 +8,8 @@ module PactBroker
           ["202326572516dea6998a7f311fcaa161c0768fc2", "2023265"],
           ["1.2.3+areallyreallyreallylongexplanation", "1.2.3+areallyreallyreallylongexplanation"],
           ["2516dea6998a7f", "2516dea6998a7f"],
-          ["1.2.3+202326572516dea6998a7f311fcaa161c0768fc2", "1.2.3+2023265"]
+          ["1.2.3+202326572516dea6998a7f311fcaa161c0768fc2", "1.2.3+2023265"],
+          ["this-is-very-long-text-this-is-very-long-text-this-is-very-long-text-this-is-very-long-text", "this-is-very-long-text-this-is-very-lon…-long-text"]
         ]
 
         TEST_CASES.each do |(input, output)|


### PR DESCRIPTION
Make sure that the display version number is no longer than 50 characters to avoid content overflow

Related to #510