### PR TITLE
fix: edge case in webhook description rendering with participants specified by labels

### DIFF
--- a/lib/pact_broker/domain/webhook.rb
+++ b/lib/pact_broker/domain/webhook.rb
@@ -63,11 +63,11 @@ module PactBroker
       end
 
       def consumer_name
-        consumer && (consumer.name || (consumer.label && "labeled '#{consumer.label}'"))
+        consumer && (consumer.name || (consumer.label && "#{provider ? 'consumers ' : ''}labeled '#{consumer.label}'"))
       end
 
       def provider_name
-        provider && (provider.name || (provider.label && "labeled '#{provider.label}'"))
+        provider && (provider.name || (provider.label && "#{consumer ? 'providers ' : ''}labeled '#{provider.label}'"))
       end
 
       def trigger_on_contract_content_changed?

--- a/spec/lib/pact_broker/domain/webhook_spec.rb
+++ b/spec/lib/pact_broker/domain/webhook_spec.rb
@@ -32,18 +32,53 @@ module PactBroker
 
         context "with a consumer and provider" do
           it { is_expected.to eq "A webhook for the pact between Consumer and Provider" }
+
+          context "when provider is specified by a label" do
+            let(:provider) { WebhookPacticipant.new(label: "provider-label")}
+
+            it { is_expected.to eq "A webhook for the pact between Consumer and providers labeled 'provider-label'" }
+          end
+
+          context "when consumer is specified by a label" do
+            let(:consumer) { WebhookPacticipant.new(label: "consumer-label")}
+
+            it { is_expected.to eq "A webhook for the pact between consumers labeled 'consumer-label' and Provider" }
+          end
+
+          context "when both are specified by labels" do
+            let(:consumer) { WebhookPacticipant.new(label: "consumer-label")}
+            let(:provider) { WebhookPacticipant.new(label: "provider-label")}
+
+            it do
+              is_expected.to eq(
+                "A webhook for the pact between consumers labeled 'consumer-label' and providers labeled 'provider-label'"
+              )
+            end
+          end
         end
 
         context "with a consumer only" do
           let(:provider) { nil }
 
           it { is_expected.to eq "A webhook for all pacts with consumer Consumer" }
+
+          context "when specified by a label" do
+            let(:consumer) { WebhookPacticipant.new(label: "consumer-label")}
+
+            it { is_expected.to eq "A webhook for all pacts with consumer labeled 'consumer-label'" }
+          end
         end
 
         context "with a provider only" do
           let(:consumer) { nil }
 
           it { is_expected.to eq "A webhook for all pacts with provider Provider" }
+
+          context "when specified by a label" do
+            let(:provider) { WebhookPacticipant.new(label: "provider-label")}
+
+            it { is_expected.to eq "A webhook for all pacts with provider labeled 'provider-label'" }
+          end
         end
 
         context "with neither a consumer nor a provider" do


### PR DESCRIPTION
Fix an edge case in webhook description rendering with participants specified by labels
Before:
<img width="281" alt="image" src="https://user-images.githubusercontent.com/12977304/136065600-8dc5cbc7-c812-4ddf-b5e3-c047c19018c6.png">


After:
`A webhook for the pact between consumers labeled 'consumer-label' and Provider`
`A webhook for the pact between consumers labeled 'consumer-label' and providers labeled 'provider-label'`