### PR TITLE
fix(clean): Cast max_age to integer when read from ENV

### DIFF
--- a/lib/pact_broker/db/clean/selector.rb
+++ b/lib/pact_broker/db/clean/selector.rb
@@ -22,6 +22,7 @@ module PactBroker
           new_hash = standard_hash.slice(*ATTRIBUTES)
           new_hash[:pacticipant_name] ||= standard_hash[:pacticipant] if standard_hash[:pacticipant]
           new_hash[:environment_name] ||= standard_hash[:environment] if standard_hash[:environment]
+          new_hash[:max_age] = Integer(new_hash[:max_age]) if new_hash[:max_age]
           new_hash[:source_hash] = hash
           new(new_hash.compact)
         end

--- a/spec/lib/pact_broker/db/clean/selector_spec.rb
+++ b/spec/lib/pact_broker/db/clean/selector_spec.rb
@@ -1,0 +1,29 @@
+require "pact_broker/db/clean/selector"
+
+module PactBroker
+  module DB
+    class Clean
+      describe Selector do
+        describe ".from_hash" do
+          subject { described_class.from_hash(data) }
+          let(:data) { {} }
+          context "with max_age" do
+            let(:data) { {"max_age" => "20"} }
+
+            it "parses integers" do
+              expect(subject.max_age).to eq(20)
+            end
+
+            context "with unexpected value" do
+              let(:data) { {"max_age" => "foobar"} }
+
+              it "raises argument error" do
+                expect { subject }.to raise_error(ArgumentError)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Thanks for quickly fixing the issue with dropping max_age selector when loaded from ENV. THe other issue araised: it isn't converted to Integer so it couldn't be used for actual filtering (`PactBroker::Domain::Version.where_age_less_than` uses it as subtraction argument). Added some specs to prevent regression in the future. 
