### PR TITLE
fix(cleanup): Improve delete orphans SQL query

### DIFF
--- a/docs/configuration.yml
+++ b/docs/configuration.yml
@@ -100,6 +100,15 @@ groups:
         default_value: 5
         allowed_values_description: A positive integer or float, as a string.
         more_info: https://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html#label-General+connection+options
+      sql_enable_caller_logging:
+        description: |-
+          Whether or not to enable caller_logging extension for database connection.
+          When enabled it logs source path that caused SQL query.
+        default_value: false
+        allowed_values:
+          - true
+          - false
+        more_info: https://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/caller_logging_rb.html
       database_max_connections:
         description: "The maximum size of the connection pool (4 connections by default on most databases)"
         default_value: 4

--- a/lib/pact_broker/db/clean_incremental.rb
+++ b/lib/pact_broker/db/clean_incremental.rb
@@ -92,8 +92,23 @@ module PactBroker
       end
 
       def delete_orphan_pact_versions
-        referenced_pact_version_ids = db[:pact_publications].select(:pact_version_id).union(db[:verifications].select(:pact_version_id))
-        db[:pact_versions].where(id: referenced_pact_version_ids).invert.delete
+        db[:pact_versions].where(id: orphan_pact_versions).delete
+      rescue Sequel::DatabaseError => e
+        raise unless e.cause.class.name == "Mysql2::Error"
+
+        ids = orphan_pact_versions.map { |row| row[:id] }
+        db[:pact_versions].where(id: ids).delete
+      end
+
+      def orphan_pact_versions
+        db[:pact_versions]
+          .left_join(:pact_publications, pact_version_id: :id)
+          .left_join(:verifications, pact_version_id: :id)
+          .select(Sequel[:pact_versions][:id])
+          .where(
+            Sequel[:pact_publications][:id] => nil,
+            Sequel[:verifications][:id] => nil
+          )
       end
 
       def version_info(version)

--- a/spec/lib/pact_broker/db/clean_incremental_spec.rb
+++ b/spec/lib/pact_broker/db/clean_incremental_spec.rb
@@ -3,8 +3,7 @@ require "pact_broker/matrix/unresolved_selector"
 
 module PactBroker
   module DB
-    # Inner queries don't work on MySQL. Seriously, MySQL???
-    xdescribe CleanIncremental do
+    describe CleanIncremental do
       def pact_publication_count_for(consumer_name, version_number)
         PactBroker::Pacts::PactPublication.where(consumer_version: PactBroker::Domain::Version.where_pacticipant_name(consumer_name).where(number: version_number)).count
       end
@@ -85,13 +84,12 @@ module PactBroker
               expect { subject }.to_not change { PactBroker::Domain::Version.count }
             end
 
-            # Always fails on github actions, never locally :shrug:
-            it "returns info on what will be deleted", pending: ENV["CI"] == "true" do
+            # Randomly fails on github actions, never locally :shrug:
+            it "returns info on what will be deleted", skip: ENV["CI"] == "true" do
               Approvals.verify(subject, :name => "clean_incremental_dry_run", format: :json)
             end
           end
         end
-
 
         context "with orphan pact versions" do
           before do

--- a/spec/lib/pact_broker/verifications/repository_spec.rb
+++ b/spec/lib/pact_broker/verifications/repository_spec.rb
@@ -46,9 +46,9 @@ module PactBroker
 
           it "creates a PactVersionProviderTagSuccessfulVerification for each tag" do
             expect { subject }.to change { PactVersionProviderTagSuccessfulVerification.count }.by(2)
-            expect(PactVersionProviderTagSuccessfulVerification.first).to have_attributes(
-              wip: false,
-              provider_version_tag_name: "foo"
+            expect(PactVersionProviderTagSuccessfulVerification.all).to contain_exactly(
+              have_attributes(wip: false, provider_version_tag_name: "foo"),
+              have_attributes(wip: false, provider_version_tag_name: "bar"),
             )
           end
         end


### PR DESCRIPTION
Original query to delete orphans was terribly slow and was unable to finish within default 15s timeout. Instead of excluding all ids from union, we left join all 3 tables and select only rows that have no joined values in `pact_publications` or verifications.

Additionaly, the query was fixed for mysql. Whenever the Mysql error occures instead of embedded query, ids are fetched and then directly used in delete query.

[edit] 

Added `sql_enable_caller_logging` configuration documentation as it was causing specs failures. 
