### PR TITLE
fix: fix clean performance fix

### DIFF
--- a/lib/pact_broker/db/clean_incremental.rb
+++ b/lib/pact_broker/db/clean_incremental.rb
@@ -104,8 +104,8 @@ module PactBroker
 
       def orphan_pact_versions
         db[:pact_versions]
-          .left_join(:pact_publications, pact_version_id: :id)
-          .left_join(:verifications, pact_version_id: :id)
+          .left_join(:pact_publications, Sequel[:pact_publications][:pact_version_id]=> Sequel[:pact_versions][:id])
+          .left_join(:verifications, Sequel[:verifications][:pact_version_id]=> Sequel[:pact_versions][:id])
           .select(Sequel[:pact_versions][:id])
           .where(
             Sequel[:pact_publications][:id] => nil,

--- a/spec/lib/pact_broker/db/clean_incremental_spec.rb
+++ b/spec/lib/pact_broker/db/clean_incremental_spec.rb
@@ -3,8 +3,7 @@ require "pact_broker/matrix/unresolved_selector"
 
 module PactBroker
   module DB
-    # Inner queries don't work on MySQL. Seriously, MySQL???
-    xdescribe CleanIncremental do
+    describe CleanIncremental do
       def pact_publication_count_for(consumer_name, version_number)
         PactBroker::Pacts::PactPublication.where(consumer_version: PactBroker::Domain::Version.where_pacticipant_name(consumer_name).where(number: version_number)).count
       end
@@ -85,13 +84,12 @@ module PactBroker
               expect { subject }.to_not change { PactBroker::Domain::Version.count }
             end
 
-            # Always fails on github actions, never locally :shrug:
-            it "returns info on what will be deleted", pending: ENV["CI"] == "true" do
+            # Randomly fails on github actions, never locally :shrug:
+            it "returns info on what will be deleted", skip: ENV["CI"] == "true" do
               Approvals.verify(subject, :name => "clean_incremental_dry_run", format: :json)
             end
           end
         end
-
 
         context "with orphan pact versions" do
           before do

--- a/spec/lib/pact_broker/verifications/repository_spec.rb
+++ b/spec/lib/pact_broker/verifications/repository_spec.rb
@@ -46,9 +46,9 @@ module PactBroker
 
           it "creates a PactVersionProviderTagSuccessfulVerification for each tag" do
             expect { subject }.to change { PactVersionProviderTagSuccessfulVerification.count }.by(2)
-            expect(PactVersionProviderTagSuccessfulVerification.first).to have_attributes(
-              wip: false,
-              provider_version_tag_name: "foo"
+            expect(PactVersionProviderTagSuccessfulVerification.all).to contain_exactly(
+              have_attributes(wip: false, provider_version_tag_name: "foo"),
+              have_attributes(wip: false, provider_version_tag_name: "bar"),
             )
           end
         end


### PR DESCRIPTION
@barthez  I worked out what the issue was. The joins needed to be fully qualified, because the second join `.left_outer_join(:verifications, pact_version_id: :id)` inferred that the join was meant to link the verifications table with the pact publications table, when it should have been the pact_versions table.

```
# broken query
db[:pact_versions]
.left_outer_join(:pact_publications, pact_version_id: :id)
.left_outer_join(:verifications, pact_version_id: :id)
.select(Sequel[:pact_versions][:id])
.where(
  Sequel[:pact_publications][:id] => nil,
  Sequel[:verifications][:id] => nil
=> #<Sequel::SQLite::Dataset: "SELECT `pact_versions`.`id` FROM `pact_versions` 
LEFT OUTER JOIN `pact_publications` ON (`pact_publications`.`pact_version_id` = `pact_versions`.`id`) 

# This is where it goes wrong 
LEFT OUTER JOIN `verifications` ON (`verifications`.`pact_version_id` = `pact_publications`.`id`) 

WHERE ((`pact_publications`.`id` IS NULL) AND (`verifications`.`id` IS NULL))">


# working query
db[:pact_versions]
.left_join(:pact_publications, Sequel[:pact_publications][:pact_version_id]=> Sequel[:pact_versions][:id])
.left_join(:verifications, Sequel[:verifications][:pact_version_id]=> Sequel[:pact_versions][:id])
.select(Sequel[:pact_versions][:id])
.where(
  Sequel[:pact_publications][:id] => nil,
  Sequel[:verifications][:id] => nil
=> #<Sequel::SQLite::Dataset: "SELECT `pact_versions`.`id` FROM `pact_versions` 
LEFT JOIN `pact_publications` ON (`pact_publications`.`pact_version_id` = `pact_versions`.`id`) 
LEFT JOIN `verifications` ON (`verifications`.`pact_version_id` = `pact_versions`.`id`) 
WHERE ((`pact_publications`.`id` IS NULL) AND (`verifications`.`id` IS NULL))">
```
