### PR TITLE
fix: Eagerly load pact publication fields

### DIFF
--- a/lib/pact_broker/domain/pact.rb
+++ b/lib/pact_broker/domain/pact.rb
@@ -41,7 +41,7 @@ module PactBroker
       end
 
       def consumer
-        consumer_version.pacticipant
+        @consumer || consumer_version.pacticipant
       end
 
       def consumer_version_tag_names


### PR DESCRIPTION
Calling `to_domain` on pact publication dataset elements is causing N+1 query problem. Simple preloading fixes the issue and improves `ProviderPactsForVerification` resource performance.

In our case `for-verification` requests went down from ~600 SQL queries to just 50.

I still have concerns for `remove_non_wip_for_branch` and `remove_non_wip_for_tag` as they are calling 4 similar and slow queries. Each of these function is called twice, so 8 slow (20ms on my local setup) queries for single request. I failed optimizing these methods as I would need to spend much more time to understand the logic behind it (and I see that these intermediate queries are used for debug logs).