### PR TITLE
fix: Improve matrix request performance

### DIFF
--- a/lib/pact_broker/domain/version.rb
+++ b/lib/pact_broker/domain/version.rb
@@ -241,6 +241,13 @@ module PactBroker
         end
         # rubocop: enable Metrics/CyclomaticComplexity
 
+        def pacticipants_set
+          from_self(alias: :v)
+            .select_group(Sequel[:v][:pacticipant_id])
+            .collect(&:pacticipant_id)
+            .to_set
+        end
+
         # private
 
         def calculate_max_version_order_and_join_back_to_versions(query, selector)

--- a/lib/pact_broker/matrix/quick_row.rb
+++ b/lib/pact_broker/matrix/quick_row.rb
@@ -124,15 +124,17 @@ module PactBroker
         end
 
         def eager_all_the_things
-          eager(:consumer)
-          .eager(:provider)
-          .eager(consumer_version: [{ current_deployed_versions: :environment }, { current_supported_released_versions: :environment }, { branch_versions: :branch_head }])
-          .eager(provider_version: [{ current_deployed_versions: :environment }, { current_supported_released_versions: :environment }, { branch_versions: :branch_head }])
-          .eager(:verification)
-          .eager(:pact_publication)
-          .eager(:pact_version)
-          .eager(:consumer_version_tags)
-          .eager(:provider_version_tags)
+          eager(
+            :consumer,
+            :provider,
+            :verification,
+            :pact_publication,
+            :pact_version,
+            consumer_version: { current_deployed_versions: :environment, current_supported_released_versions: :environment, branch_versions: [:branch_head, :version, branch: :pacticipant] },
+            provider_version: { current_deployed_versions: :environment, current_supported_released_versions: :environment, branch_versions: [:branch_head, :version, branch: :pacticipant] },
+            consumer_version_tags: { version: :pacticipant },
+            provider_version_tags: { version: :pacticipant }
+          )
         end
 
         def default_scope


### PR DESCRIPTION
Fix some N+1 query issues by using sequel eager loading and similar preloading techniques.

In our case, this request was executing ~150 queries - now it is 56.
