### PR TITLE
fix: Improve SortContent performance on large contracts

### DIFF
--- a/lib/pact_broker/pacts/sort_content.rb
+++ b/lib/pact_broker/pacts/sort_content.rb
@@ -34,7 +34,7 @@ module PactBroker
         # You never can tell what people will do...
         if probably_array.is_a?(Array)
           array_with_ordered_hashes = order_hash_keys(probably_array)
-          array_with_ordered_hashes.sort{ |a, b| a.to_json <=> b.to_json }
+          array_with_ordered_hashes.sort_by(&:to_json)
         else
           probably_array
         end


### PR DESCRIPTION
Whenever `order_verifiable_content` was called on `interactions` or `messages` each item was serialized to json multiple times. With `sort_by` each iteam is serialized once.

[Flamegraph](https://github.com/SamSaffron/flamegraph) shows that this change intoduce a drop of SortContent#call percentage in PactContentDiff.to_text call from 30% to 17%.

I have tried different serializers (marshal, inspect) but apparently build-in JSON is the fastest (tired Oj JSON lib - it shown to be 1.5 faster than build-in, but I believe it is not worth a hassle).
