### PR TITLE
feat: improve error message when request has non UTF-8 characters in the body

### DIFF
--- a/lib/pact_broker/api/resources/all_webhooks.rb
+++ b/lib/pact_broker/api/resources/all_webhooks.rb
@@ -30,10 +30,7 @@ module PactBroker
         end
 
         def malformed_request?
-          if request.post?
-            return invalid_json? || validation_errors?(webhook)
-          end
-          false
+          super || (request.post? && validation_errors?(webhook))
         end
 
         def to_json

--- a/lib/pact_broker/api/resources/currently_deployed_versions_for_environment.rb
+++ b/lib/pact_broker/api/resources/currently_deployed_versions_for_environment.rb
@@ -8,10 +8,6 @@ module PactBroker
       class CurrentlyDeployedVersionsForEnvironment < BaseResource
         using PactBroker::StringRefinements
 
-        def content_types_accepted
-          [["application/json", :from_json]]
-        end
-
         def content_types_provided
           [["application/hal+json", :to_json]]
         end

--- a/lib/pact_broker/api/resources/currently_supported_versions_for_environment.rb
+++ b/lib/pact_broker/api/resources/currently_supported_versions_for_environment.rb
@@ -8,10 +8,6 @@ module PactBroker
       class CurrentlySupportedVersionsForEnvironment < BaseResource
         using PactBroker::StringRefinements
 
-        def content_types_accepted
-          [["application/json", :from_json]]
-        end
-
         def content_types_provided
           [["application/hal+json", :to_json]]
         end

--- a/lib/pact_broker/api/resources/deployed_version.rb
+++ b/lib/pact_broker/api/resources/deployed_version.rb
@@ -8,11 +8,6 @@ module PactBroker
       class DeployedVersion < BaseResource
         include PactBroker::Messages
 
-        def initialize
-          super
-          @currently_deployed_param = params(default: {})[:currentlyDeployed]
-        end
-
         def content_types_provided
           [
             ["application/hal+json", :to_json]
@@ -31,14 +26,6 @@ module PactBroker
 
         def resource_exists?
           !!deployed_version
-        end
-
-        def malformed_request?
-          if request.patch?
-            return invalid_json?
-          else
-            false
-          end
         end
 
         def to_json
@@ -73,7 +60,14 @@ module PactBroker
 
         private
 
-        attr_reader :currently_deployed_param
+        # can't use ||= with a potentially nil value
+        def currently_deployed_param
+          if defined?(@currently_deployed_param)
+            @currently_deployed_param
+          else
+            @currently_deployed_param = params(default: {})[:currentlyDeployed]
+          end
+        end
 
         def process_currently_deployed_param
           if currently_deployed_param == false

--- a/lib/pact_broker/api/resources/environment.rb
+++ b/lib/pact_broker/api/resources/environment.rb
@@ -22,11 +22,7 @@ module PactBroker
         end
 
         def malformed_request?
-          if request.put? && environment
-            invalid_json? || validation_errors_for_schema?(schema, params.merge(uuid: uuid))
-          else
-            false
-          end
+          super || (request.put? && environment && validation_errors_for_schema?(schema, params.merge(uuid: uuid)))
         end
 
         def from_json

--- a/lib/pact_broker/api/resources/environments.rb
+++ b/lib/pact_broker/api/resources/environments.rb
@@ -27,11 +27,7 @@ module PactBroker
         end
 
         def malformed_request?
-          if request.post?
-            invalid_json? || validation_errors_for_schema?(schema, params.merge(uuid: uuid))
-          else
-            false
-          end
+          super || (request.post? && validation_errors_for_schema?(schema, params.merge(uuid: uuid)))
         end
 
         def create_path

--- a/lib/pact_broker/api/resources/pact.rb
+++ b/lib/pact_broker/api/resources/pact.rb
@@ -42,12 +42,9 @@ module PactBroker
           potential_duplicate_pacticipants?(pact_params.pacticipant_names) || merge_conflict || disallowed_modification?
         end
 
+
         def malformed_request?
-          if request.patch? || request.put?
-            invalid_json? || contract_validation_errors?(Contracts::PutPactParamsContract.new(pact_params), pact_params)
-          else
-            false
-          end
+          super || ((request.patch? || request.really_put?) && contract_validation_errors?(Contracts::PutPactParamsContract.new(pact_params), pact_params))
         end
 
         def resource_exists?

--- a/lib/pact_broker/api/resources/pact_webhooks.rb
+++ b/lib/pact_broker/api/resources/pact_webhooks.rb
@@ -25,10 +25,7 @@ module PactBroker
         end
 
         def malformed_request?
-          if request.post?
-            return invalid_json? || validation_errors?(webhook)
-          end
-          false
+          super || (request.post? && validation_errors?(webhook))
         end
 
         def validation_errors? webhook

--- a/lib/pact_broker/api/resources/pacticipant.rb
+++ b/lib/pact_broker/api/resources/pacticipant.rb
@@ -26,11 +26,7 @@ module PactBroker
         end
 
         def malformed_request?
-          if request.patch? || request.put?
-            invalid_json? || validation_errors_for_schema?
-          else
-            false
-          end
+          super || ((request.patch? || request.really_put?) && validation_errors_for_schema?)
         end
 
         def from_json

--- a/lib/pact_broker/api/resources/pacticipant_webhooks.rb
+++ b/lib/pact_broker/api/resources/pacticipant_webhooks.rb
@@ -27,10 +27,7 @@ module PactBroker
         end
 
         def malformed_request?
-          if request.post?
-            return invalid_json? || webhook_validation_errors?(webhook)
-          end
-          false
+          super || (request.post? && webhook_validation_errors?(webhook))
         end
 
         def create_path

--- a/lib/pact_broker/api/resources/pacticipants.rb
+++ b/lib/pact_broker/api/resources/pacticipants.rb
@@ -23,10 +23,7 @@ module PactBroker
         end
 
         def malformed_request?
-          if request.post?
-            return invalid_json? || validation_errors_for_schema?
-          end
-          false
+          super || (request.post? && validation_errors_for_schema?)
         end
 
         def post_is_create?

--- a/lib/pact_broker/api/resources/provider_pacts_for_verification.rb
+++ b/lib/pact_broker/api/resources/provider_pacts_for_verification.rb
@@ -20,12 +20,7 @@ module PactBroker
         end
 
         def malformed_request?
-          if (errors = query_schema.call(query)).any?
-            set_json_validation_error_messages(errors)
-            true
-          else
-            false
-          end
+          super || ((request.get? || request.post?) && schema_validation_errors?)
         end
 
         def process_post
@@ -95,6 +90,15 @@ module PactBroker
 
         def nested_query
           @nested_query ||= Rack::Utils.parse_nested_query(request.uri.query)
+        end
+
+        def schema_validation_errors?
+          if (errors = query_schema.call(query)).any?
+            set_json_validation_error_messages(errors)
+            true
+          else
+            false
+          end
         end
       end
     end

--- a/lib/pact_broker/api/resources/publish_contracts.rb
+++ b/lib/pact_broker/api/resources/publish_contracts.rb
@@ -23,11 +23,7 @@ module PactBroker
         end
 
         def malformed_request?
-          if request.post?
-            invalid_json? || validation_errors_for_schema?
-          else
-            false
-          end
+          super || (request.post? && validation_errors_for_schema?)
         end
 
         def process_post

--- a/lib/pact_broker/api/resources/released_version.rb
+++ b/lib/pact_broker/api/resources/released_version.rb
@@ -8,11 +8,6 @@ module PactBroker
       class ReleasedVersion < BaseResource
         include PactBroker::Messages
 
-        def initialize
-          super
-          @currently_supported_param = params(default: {})[:currentlySupported]
-        end
-
         def content_types_provided
           [["application/hal+json", :to_json]]
         end
@@ -63,7 +58,14 @@ module PactBroker
 
         private
 
-        attr_reader :currently_supported_param
+        # can't use ||= with a potentially nil value
+        def currently_supported_param
+          if defined?(@currently_deployed_param)
+            @currently_supported_param
+          else
+            @currently_supported_param = params(default: {})[:currentlySupported]
+          end
+        end
 
         def process_currently_supported_param
           if currently_supported_param == false

--- a/lib/pact_broker/api/resources/verifications.rb
+++ b/lib/pact_broker/api/resources/verifications.rb
@@ -34,15 +34,7 @@ module PactBroker
         end
 
         def malformed_request?
-          if request.post?
-            return true if invalid_json?
-            errors = verification_service.errors(params)
-            if !errors.empty?
-              set_json_validation_error_messages(errors.messages)
-              return true
-            end
-          end
-          false
+          super || (request.post? && any_validation_errors?)
         end
 
         def create_path
@@ -90,6 +82,12 @@ module PactBroker
 
         def verification_params
           params(symbolize_names: false).merge("wip" => wip?, "pending" => pending?)
+        end
+
+        def any_validation_errors?
+          errors = verification_service.errors(params)
+          set_json_validation_error_messages(errors.messages) if !errors.empty?
+          !errors.empty?
         end
       end
     end

--- a/lib/pact_broker/api/resources/version.rb
+++ b/lib/pact_broker/api/resources/version.rb
@@ -25,14 +25,6 @@ module PactBroker
           !!version
         end
 
-        def malformed_request?
-          if request.put? && any_request_body?
-            invalid_json?
-          else
-            false
-          end
-        end
-
         def from_json
           if request.really_put?
             handle_request do

--- a/lib/pact_broker/api/resources/webhook.rb
+++ b/lib/pact_broker/api/resources/webhook.rb
@@ -27,10 +27,7 @@ module PactBroker
         end
 
         def malformed_request?
-          if request.put?
-            return invalid_json? || webhook_validation_errors?(parsed_webhook, uuid)
-          end
-          false
+          super || (request.put? && webhook_validation_errors?(parsed_webhook, uuid))
         end
 
         def from_json

--- a/lib/pact_broker/api/resources/webhook_execution.rb
+++ b/lib/pact_broker/api/resources/webhook_execution.rb
@@ -37,14 +37,16 @@ module PactBroker
         end
 
         def malformed_request?
-          if request.post?
+          if super
+            true
+          elsif request.post?
             if uuid
               false
             else
               webhook_validation_errors?(webhook)
             end
           else
-            super
+            false
           end
         end
 

--- a/lib/pact_broker/locale/en.yml
+++ b/lib/pact_broker/locale/en.yml
@@ -105,6 +105,7 @@ en:
         To disable this check, set `check_for_potential_duplicate_pacticipant_names` to false in the configuration.
       new_line_in_url_path: URL path cannot contain a new line character.
       tab_in_url_path: URL path cannot contain a tab character.
+      non_utf_8_char_in_request_body: "Request body has a non UTF-8 character at char %{char_number} and cannot be parsed as JSON. Fragment preceding invalid character is: '%{fragment}'"
 
       "400":
         title: 400 Malformed Request

--- a/spec/integration/endpoints/non_utf_8_spec.rb
+++ b/spec/integration/endpoints/non_utf_8_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe "a request to publish a pact with non-utf-8 chars" do
+
+  subject { put("/pacts/provider/Bar/consumer/Foo/version/2", pact_content, { "CONTENT_TYPE" => "application/json"}) }
+
+  context "with less than 100 chars preceding the invalid char" do
+    let(:pact_content) do
+      "ABCDEFG\x8FDEF"
+    end
+
+    its(:status) { is_expected.to eq 400 }
+
+    it "returns an error indicating where the non UTF-8 character is" do
+      expect(JSON.parse(subject.body)).to eq("error" => "Request body has a non UTF-8 character at char 8 and cannot be parsed as JSON. Fragment preceding invalid character is: 'ABCDEFG'")
+    end
+  end
+
+  context "with more than 100 chars preceding the invalid char" do
+    let(:pact_content) do
+      "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890\x8FDEF"
+    end
+
+    it "truncates the fragement included in the error message" do
+      expect(JSON.parse(subject.body)).to eq("error" => "Request body has a non UTF-8 character at char 101 and cannot be parsed as JSON. Fragment preceding invalid character is: '1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890'")
+    end
+  end
+end
+
+RSpec.describe "a request to publish a pact with invalid JSON" do
+  let(:pact_content) do
+    "{"
+  end
+
+  subject { put("/pacts/provider/Bar/consumer/Foo/version/2", pact_content, { "CONTENT_TYPE" => "application/json"}) }
+
+  its(:status) { is_expected.to eq 400 }
+
+  it "returns an error message" do
+    expect(JSON.parse(subject.body)).to eq("error" => "JSON::ParserError - 859: unexpected token at '{'")
+  end
+end

--- a/spec/lib/pact_broker/api/resources/pact_spec.rb
+++ b/spec/lib/pact_broker/api/resources/pact_spec.rb
@@ -75,7 +75,7 @@ module PactBroker::Api
           end
 
           it "returns an error message" do
-            expect(JSON.parse(response.body)["error"]).to match(/Error parsing JSON/)
+            expect(JSON.parse(response.body)["error"]).to match(/JSON/)
           end
         end
 


### PR DESCRIPTION
The problem with the JSON body validation was that when an invalid UTF-8 character was found in the request body, an exception was raised with a message that included the entire request body, including the non UTF-8 character. When the error handler then attempted to render the exception message in JSON, it then caused another error to be raised. This meant that instead of a 400 response, the user was receiving a 500 response.

This change detects the non UTF-8 character and returns a helpful error message indicating where the invalid character is. It also adds a spec to ensure that every request that accepts JSON calls the appropriate validation method in `malformed_request?`.