### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/reproduce_issue.yml
+++ b/.github/workflows/reproduce_issue.yml
@@ -9,6 +9,9 @@ on:
       - 'issue/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/test-ruby-3.yml
+++ b/.github/workflows/test-ruby-3.yml
@@ -2,6 +2,9 @@ name: Tests for Ruby 3.0 - these are hardcoded to succeed so every commit doesn'
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   sqlite:
     if: "!contains(github.event.head_commit.message, '[ci-skip]')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   sqlite:
     if: "!contains(github.event.head_commit.message, '[ci-skip]')"


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
