### PR TITLE
chore: Remove unnecessary blank check

### DIFF
--- a/lib/pact_broker/ui/views/index/show.haml
+++ b/lib/pact_broker/ui/views/index/show.haml
@@ -7,10 +7,9 @@
     %h1.page-header
       Pacts
 
-    - unless errors.blank?
-      - errors.each do | error |
-        %div.alert.alert-danger
-          = error
+    - errors.each do | error |
+      %div.alert.alert-danger
+        = error
 
     %form{action: "#{base_url}"}
       .search-field


### PR DESCRIPTION
There are multiple reasons to remove the `errors.blank?` check when
rendering the main page view
- The check is not correct (this is my fault by the way, too much Rails
  :D). Hence the main page is not rendered
![2022-07-06_00-44](https://user-images.githubusercontent.com/4962863/177355032-dc5d9981-1896-4c85-bf11-53bf3791a4b7.png)

- The check is not necessary as if the `errors` array is empty, no error
  will be rendered any way