### PR TITLE
feat(webhooks): allow auth headers to be logged for debugging purposes

### DIFF
--- a/lib/pact_broker/config/runtime_configuration.rb
+++ b/lib/pact_broker/config/runtime_configuration.rb
@@ -52,6 +52,7 @@ module PactBroker
         webhook_http_code_success: [200, 201, 202, 203, 204, 205, 206],
         webhook_scheme_whitelist: ["https"],
         webhook_host_whitelist: [],
+        webhook_redact_sensitive_data: true,
         disable_ssl_verification: false,
         user_agent: "Pact Broker v#{PactBroker::VERSION}"
       )

--- a/lib/pact_broker/config/runtime_configuration_logging_methods.rb
+++ b/lib/pact_broker/config/runtime_configuration_logging_methods.rb
@@ -31,6 +31,9 @@ module PactBroker
               source: source_info.dig(key, :source) || {:type=>:defaults}
             }
           end.sort_by { |key, _| key }.each { |key, value| log_config_inner(key, value, logger) }
+          if self.webhook_redact_sensitive_data == false
+            logger.warn("WARNING!!! webhook_redact_sensitive_data is set to false. This will allow authentication information to be included in the webhook logs. This should only be used for debugging purposes. Do not run the application permanently in production with this value.")
+          end
         end
 
         def log_config_inner(key, value, logger)

--- a/lib/pact_broker/test/http_test_data_builder.rb
+++ b/lib/pact_broker/test/http_test_data_builder.rb
@@ -265,7 +265,9 @@ module PactBroker
           "request" => {
             "method" => "POST",
             "url" => url,
-            "body" => body || default_body
+            "body" => body || default_body,
+            "username" => "user",
+            "password" => "pass"
           }
         }.compact
         path = "webhooks/#{uuid}"
@@ -297,6 +299,8 @@ module PactBroker
             "method" => "POST",
             "url" => url,
             "headers" => { "Content-Type" => "application/json"},
+            "username" => "user",
+            "password" => "pass",
             "body" => {
               "eventName" => "${pactbroker.eventName}",
               "consumerVersionNumber" => "${pactbroker.consumerVersionNumber}",

--- a/lib/pact_broker/test/http_test_data_builder.rb
+++ b/lib/pact_broker/test/http_test_data_builder.rb
@@ -288,34 +288,9 @@ module PactBroker
       def create_global_webhook_for_anything_published(uuid: nil, url: "https://postman-echo.com/post")
         puts "Creating global webhook for contract changed event with uuid #{uuid}"
         uuid ||= SecureRandom.uuid
-        request_body = {
-          "description" => "A webhook for all consumers and providers",
-          "events" => [{
-            "name" => "contract_published"
-          },{
-            "name" => "provider_verification_published"
-          }],
-          "request" => {
-            "method" => "POST",
-            "url" => url,
-            "headers" => { "Content-Type" => "application/json"},
-            "username" => "user",
-            "password" => "pass",
-            "body" => {
-              "eventName" => "${pactbroker.eventName}",
-              "consumerVersionNumber" => "${pactbroker.consumerVersionNumber}",
-              "consumerVersionTags" => "${pactbroker.consumerVersionTags}",
-              "consumerVersionBranch" => "${pactbroker.consumerVersionBranch}",
-              "githubVerificationStatus" => "${pactbroker.githubVerificationStatus}",
-              "providerVersionNumber" => "${pactbroker.providerVersionNumber}",
-              "providerVersionTags" => "${pactbroker.providerVersionTags}",
-              "providerVersionBranch" => "${pactbroker.providerVersionBranch}",
-              "canIMerge" => "${pactbroker.providerMainBranchGithubVerificationStatus}"
-            }
-          }
-        }
+
         path = "webhooks/#{uuid}"
-        client.put(path, request_body.to_json).tap { |response| check_for_error(response) }
+        client.put(path, webhook_body_with_all_parameters(url).to_json).tap { |response| check_for_error(response) }
         separate
         self
       end
@@ -441,6 +416,35 @@ module PactBroker
           puts response.status
           puts response.body
         end
+      end
+
+      def webhook_body_with_all_parameters(url)
+        {
+          "description" => "A webhook for all consumers and providers",
+          "events" => [{
+            "name" => "contract_published"
+          },{
+            "name" => "provider_verification_published"
+          }],
+          "request" => {
+            "method" => "POST",
+            "url" => url,
+            "headers" => { "Content-Type" => "application/json"},
+            "username" => "user",
+            "password" => "pass",
+            "body" => {
+              "eventName" => "${pactbroker.eventName}",
+              "consumerVersionNumber" => "${pactbroker.consumerVersionNumber}",
+              "consumerVersionTags" => "${pactbroker.consumerVersionTags}",
+              "consumerVersionBranch" => "${pactbroker.consumerVersionBranch}",
+              "githubVerificationStatus" => "${pactbroker.githubVerificationStatus}",
+              "providerVersionNumber" => "${pactbroker.providerVersionNumber}",
+              "providerVersionTags" => "${pactbroker.providerVersionTags}",
+              "providerVersionBranch" => "${pactbroker.providerVersionBranch}",
+              "canIMerge" => "${pactbroker.providerMainBranchGithubVerificationStatus}"
+            }
+          }
+        }
       end
     end
   end

--- a/lib/pact_broker/webhooks/execution_configuration.rb
+++ b/lib/pact_broker/webhooks/execution_configuration.rb
@@ -25,6 +25,10 @@ module PactBroker
         with_updated_attribute(logging_options: { failure_log_message: value })
       end
 
+      def with_redact_sensitive_data(value)
+        with_updated_attribute(logging_options: { redact_sensitive_data: value })
+      end
+
       def with_retry_schedule(value)
         with_updated_attribute(retry_schedule: value)
       end

--- a/lib/pact_broker/webhooks/execution_configuration_creator.rb
+++ b/lib/pact_broker/webhooks/execution_configuration_creator.rb
@@ -10,6 +10,7 @@ module PactBroker
       def self.call(resource)
         PactBroker::Webhooks::ExecutionConfiguration.new
           .with_show_response(PactBroker.configuration.show_webhook_response?)
+          .with_redact_sensitive_data(PactBroker.configuration.webhook_redact_sensitive_data)
           .with_retry_schedule(PactBroker.configuration.webhook_retry_schedule)
           .with_http_success_codes(PactBroker.configuration.webhook_http_code_success)
           .with_user_agent(PactBroker.configuration.user_agent)

--- a/lib/pact_broker/webhooks/webhook_request_logger.rb
+++ b/lib/pact_broker/webhooks/webhook_request_logger.rb
@@ -51,7 +51,7 @@ module PactBroker
       end
 
       def log_request(webhook_request)
-        http_request = HttpRequestWithRedactedHeaders.new(webhook_request.http_request)
+        http_request = options[:redact_sensitive_data] ? HttpRequestWithRedactedHeaders.new(webhook_request.http_request) : webhook_request.http_request
         logger.info "Making webhook #{webhook_request.uuid} request #{http_request.method.upcase} URI=#{webhook_request.url} (headers and body in debug logs)"
         logger.debug "Webhook #{webhook_request.uuid} request headers=#{http_request.to_hash}"
         logger.debug "Webhook #{webhook_request.uuid} request body=#{http_request.body}"

--- a/script/data/webhook.rb
+++ b/script/data/webhook.rb
@@ -12,6 +12,7 @@ begin
     .delete_pacticipant("bar-provider")
     .create_pacticipant("foo-consumer")
     .create_pacticipant("bar-provider")
+    .create_version(pacticipant: "bar-provider", branch: "main", version: "1")
     .publish_pact_the_old_way(consumer: "foo-consumer", consumer_version: "1", provider: "bar-provider", content_id: "111", tag: "main")
     .get_pacts_for_verification(
       provider: "bar-provider",

--- a/spec/lib/pact_broker/config/runtime_configuration_documentation_spec.rb
+++ b/spec/lib/pact_broker/config/runtime_configuration_documentation_spec.rb
@@ -18,7 +18,8 @@ module PactBroker
         :semver_formats,
         :seed_example_data,
         :use_first_tag_as_branch_time_limit,
-        :validate_database_connection_config
+        :validate_database_connection_config,
+        :webhook_redact_sensitive_data
       ]
 
       (ATTRIBUTES - DELIBERATELY_UNDOCUMENTED_ATTRIBUTES).each do | attribute_name |

--- a/spec/lib/pact_broker/webhooks/webhook_request_logger_spec.rb
+++ b/spec/lib/pact_broker/webhooks/webhook_request_logger_spec.rb
@@ -16,7 +16,8 @@ module PactBroker
 
       let(:logger) { double("logger").as_null_object }
       let(:uuid) { "uuid" }
-      let(:options) { { failure_log_message: "oops", show_response: show_response, http_code_success: [200] } }
+      let(:options) { { failure_log_message: "oops", show_response: show_response, http_code_success: [200], redact_sensitive_data: redact_sensitive_data } }
+      let(:redact_sensitive_data) { true }
       let(:show_response) { true }
       let(:username) { nil }
       let(:password) { nil }
@@ -143,6 +144,14 @@ module PactBroker
 
           it "logs the Authorization header with a starred value" do
             expect(logs).to include "authorization: **********"
+          end
+
+          context "when redact_sensitive_data is false" do
+            let(:redact_sensitive_data) { false }
+
+            it "logs the real value of the Authorization header" do
+              expect(logs).to include "authorization: foo"
+            end
           end
         end
 


### PR DESCRIPTION
## With redaction

### App logs
```
2022-10-07 10:35:51.905153 D [80210:worker-1] PactBroker::Webhooks::WebhookRequestLogger -- 
Webhook 7a5da39c-8e50-4cc9-ae16-dfa5be043e8c request 
headers={"accept"=>["*/*"], "user-agent"=>["Pact Broker v2.104.0"], "authorization"=>["**********"], 
"host"=>["postman-echo.com"], "content-length"=>["499"], "content-type"=>["application/x-www-form-urlencoded"]}
```

### Logs returned via API

<img width="863" alt="Screen Shot 2022-10-07 at 10 50 07 am" src="https://user-images.githubusercontent.com/446228/194438679-a188f3ae-46b3-49dd-8c9f-60f40d55e7cd.png">

## With redaction disabled

### App logs
2022-10-07 10:51:28.802115 D [82363:worker-1] PactBroker::Webhooks::WebhookRequestLogger -- 
Webhook 7a5da39c-8e50-4cc9-ae16-dfa5be043e8c request 
headers={"accept"=>["*/*"], "user-agent"=>["Pact Broker v2.104.0"], "authorization"=>["Basic dXNlcjpwYXNz"], 
"host"=>["postman-echo.com"], "content-length"=>["499"], "content-type"=>["application/x-www-form-urlencoded"]}

### Logs returned via API

<img width="860" alt="Screen Shot 2022-10-07 at 10 51 51 am" src="https://user-images.githubusercontent.com/446228/194438740-08b99c31-2560-4687-966b-0aea39170c6c.png">
