### PR TITLE
fix(ui): no space after `tag:`

### DIFF
--- a/lib/pact_broker/ui/views/matrix/show.haml
+++ b/lib/pact_broker/ui/views/matrix/show.haml
@@ -195,7 +195,7 @@
               .tag-parent{"title": tag.tooltip, "data-toggle": "tooltip", "data-placement": "right"}
                 %a{href: tag.url}
                   .tag.badge.badge-primary
-                    = "tag:" + ellipsisize(tag.name)
+                    = "tag: " + ellipsisize(tag.name)
             - line.other_provider_version_tags.each do | tag |
               .tag-parent{"title": tag.tooltip, "data-toggle": "tooltip", "data-placement": "right"}
                 %a{href: tag.url}


### PR DESCRIPTION
# Description

Add a space after `tag:`

![image](https://user-images.githubusercontent.com/14187625/203359862-fcfb80a0-f0f9-47fc-923a-4fca06ddca61.png)