### PR TITLE
feat: Pacticipant pagination

### DIFF
--- a/lib/pact_broker/api/decorators/pacticipant_collection_decorator.rb
+++ b/lib/pact_broker/api/decorators/pacticipant_collection_decorator.rb
@@ -1,6 +1,7 @@
 require "roar/json/hal"
 require "pact_broker/api/pact_broker_urls"
 require_relative "embedded_version_decorator"
+require_relative "pagination_links"
 require "pact_broker/domain/pacticipant"
 require "pact_broker/api/decorators/pacticipant_decorator"
 
@@ -10,6 +11,8 @@ module PactBroker
       class PacticipantCollectionDecorator < BaseDecorator
 
         collection :entries, :as => :pacticipants, :class => PactBroker::Domain::Pacticipant, :extend => PactBroker::Api::Decorators::PacticipantDecorator, embedded: true
+
+        include PaginationLinks
 
         link :self do | options |
           pacticipants_url options[:base_url]

--- a/lib/pact_broker/api/resources/dashboard.rb
+++ b/lib/pact_broker/api/resources/dashboard.rb
@@ -35,7 +35,7 @@ module PactBroker
         private
 
         def index_items
-          index_service.find_index_items_for_api(identifier_from_path.merge(pagination_options(request) || {}))
+          index_service.find_index_items_for_api(identifier_from_path.merge(pagination_options || {}))
         end
       end
     end

--- a/lib/pact_broker/api/resources/dashboard.rb
+++ b/lib/pact_broker/api/resources/dashboard.rb
@@ -35,7 +35,7 @@ module PactBroker
         private
 
         def index_items
-          index_service.find_index_items_for_api(identifier_from_path.merge(pagination_options))
+          index_service.find_index_items_for_api(identifier_from_path.merge(pagination_options(request) || {}))
         end
       end
     end

--- a/lib/pact_broker/api/resources/pacticipants.rb
+++ b/lib/pact_broker/api/resources/pacticipants.rb
@@ -47,7 +47,7 @@ module PactBroker
         end
 
         def to_json
-          generate_json(pacticipant_service.find_all_pacticipants(pagination_options))
+          generate_json(pacticipant_service.find_all_pacticipants(pagination_options(request)))
         end
 
         def generate_json pacticipants

--- a/lib/pact_broker/api/resources/pacticipants.rb
+++ b/lib/pact_broker/api/resources/pacticipants.rb
@@ -3,12 +3,15 @@ require "pact_broker/api/decorators/pacticipant_decorator"
 require "pact_broker/domain/pacticipant"
 require "pact_broker/hash_refinements"
 require "pact_broker/api/contracts/pacticipant_create_schema"
+require "pact_broker/api/resources/pagination_methods"
 
 module PactBroker
   module Api
     module Resources
       class Pacticipants < BaseResource
         using PactBroker::HashRefinements
+        include PaginationMethods
+
 
         def content_types_provided
           [["application/hal+json", :to_json]]
@@ -44,7 +47,7 @@ module PactBroker
         end
 
         def to_json
-          generate_json(pacticipant_service.find_all_pacticipants)
+          generate_json(pacticipant_service.find_all_pacticipants(pagination_options))
         end
 
         def generate_json pacticipants

--- a/lib/pact_broker/api/resources/pacticipants.rb
+++ b/lib/pact_broker/api/resources/pacticipants.rb
@@ -47,7 +47,7 @@ module PactBroker
         end
 
         def to_json
-          generate_json(pacticipant_service.find_all_pacticipants(pagination_options(request)))
+          generate_json(pacticipant_service.find_all_pacticipants(pagination_options))
         end
 
         def generate_json pacticipants

--- a/lib/pact_broker/api/resources/pagination_methods.rb
+++ b/lib/pact_broker/api/resources/pagination_methods.rb
@@ -2,11 +2,15 @@ module PactBroker
   module Api
     module Resources
       module PaginationMethods
-        def pagination_options
-          {
-            page_number: request.query["pageNumber"]&.to_i || 1,
-            page_size: request.query["pageSize"]&.to_i || 100
-          }
+        def pagination_options(request)
+          if request.query["pageNumber"] || request.query["pageSize"]
+            {
+              page_number: request.query["pageNumber"]&.to_i || 1,
+              page_size: request.query["pageSize"]&.to_i || 100
+            }
+          else
+            nil
+          end
         end
       end
     end

--- a/lib/pact_broker/api/resources/pagination_methods.rb
+++ b/lib/pact_broker/api/resources/pagination_methods.rb
@@ -4,9 +4,9 @@ module PactBroker
       module PaginationMethods
         def pagination_options
           {
-            page_number: request.query["pageNumber"]&.to_i,
-            page_size: request.query["pageSize"]&.to_i
-          }.compact
+            page_number: request.query["pageNumber"]&.to_i || 1,
+            page_size: request.query["pageSize"]&.to_i || 100
+          }
         end
       end
     end

--- a/lib/pact_broker/api/resources/pagination_methods.rb
+++ b/lib/pact_broker/api/resources/pagination_methods.rb
@@ -2,7 +2,7 @@ module PactBroker
   module Api
     module Resources
       module PaginationMethods
-        def pagination_options(request)
+        def pagination_options
           if request.query["pageNumber"] || request.query["pageSize"]
             {
               page_number: request.query["pageNumber"]&.to_i || 1,

--- a/lib/pact_broker/api/resources/versions.rb
+++ b/lib/pact_broker/api/resources/versions.rb
@@ -1,7 +1,6 @@
 require "pact_broker/api/resources/base_resource"
 require "pact_broker/configuration"
 require "pact_broker/api/decorators/versions_decorator"
-require "pact"
 require "pact_broker/api/resources/pagination_methods"
 
 
@@ -28,7 +27,7 @@ module PactBroker
         end
 
         def versions
-          @versions ||= version_service.find_all_pacticipant_versions_in_reverse_order(pacticipant_name, pagination_options)
+          @versions ||= version_service.find_all_pacticipant_versions_in_reverse_order(pacticipant_name, pagination_options(request))
         end
 
         def policy_name

--- a/lib/pact_broker/api/resources/versions.rb
+++ b/lib/pact_broker/api/resources/versions.rb
@@ -23,7 +23,7 @@ module PactBroker
         end
 
         def versions
-          @versions ||= pacticipant_service.find_all_pacticipant_versions_in_reverse_order(pacticipant_name, pagination_options)
+          @versions ||= version_service.find_all_pacticipant_versions_in_reverse_order(pacticipant_name, pagination_options)
         end
 
         def policy_name

--- a/lib/pact_broker/api/resources/versions.rb
+++ b/lib/pact_broker/api/resources/versions.rb
@@ -1,11 +1,16 @@
 require "pact_broker/api/resources/base_resource"
 require "pact_broker/configuration"
 require "pact_broker/api/decorators/versions_decorator"
+require "pact"
+require "pact_broker/api/resources/pagination_methods"
+
 
 module PactBroker
   module Api
     module Resources
       class Versions < BaseResource
+        include PaginationMethods
+
         def content_types_provided
           [["application/hal+json", :to_json]]
         end

--- a/lib/pact_broker/api/resources/versions.rb
+++ b/lib/pact_broker/api/resources/versions.rb
@@ -29,17 +29,6 @@ module PactBroker
         def policy_name
           :'versions::versions'
         end
-
-        def pagination_options
-          if request.query["pageNumber"] || request.query["pageSize"]
-            {
-              page_number: request.query["pageNumber"]&.to_i || 1,
-              page_size: request.query["pageSize"]&.to_i || 100
-            }
-          else
-            nil
-          end
-        end
       end
     end
   end

--- a/lib/pact_broker/api/resources/versions.rb
+++ b/lib/pact_broker/api/resources/versions.rb
@@ -27,7 +27,7 @@ module PactBroker
         end
 
         def versions
-          @versions ||= version_service.find_all_pacticipant_versions_in_reverse_order(pacticipant_name, pagination_options(request))
+          @versions ||= version_service.find_all_pacticipant_versions_in_reverse_order(pacticipant_name, pagination_options)
         end
 
         def policy_name

--- a/lib/pact_broker/pacticipants/repository.rb
+++ b/lib/pact_broker/pacticipants/repository.rb
@@ -26,26 +26,14 @@ module PactBroker
         PactBroker::Domain::Pacticipant.where(id: id).single_record
       end
 
-      def find_all
-        find
+      def find_all(pagination_options = nil)
+        find(pagination_options)
       end
 
-      def find options = {}
+      def find options = {}, pagination_options
         query = PactBroker::Domain::Pacticipant.select_all_qualified
         query = query.label(options[:label_name]) if options[:label_name]
-        query.order_ignore_case(Sequel[:pacticipants][:name]).eager(:labels).eager(:latest_version).all
-      end
-
-      def find_all_pacticipant_versions_in_reverse_order name, pagination_options = nil
-        pacticipant = pacticipant_repository.find_by_name!(name)
-        query = PactBroker::Domain::Version
-                  .where(pacticipant: pacticipant)
-                  .eager(:pacticipant)
-                  .eager(branch_versions: [:version, :branch_head, { branch: :pacticipant }])
-                  .eager(tags: :head_tag)
-                  .eager(:pact_publications)
-                  .reverse_order(:order)
-        query.all_with_pagination_options(pagination_options)
+        query.order_ignore_case(Sequel[:pacticipants][:name]).eager(:labels).eager(:latest_version).all_with_pagination_options(pagination_options)
       end
 
       def find_by_name_or_create name

--- a/lib/pact_broker/pacticipants/repository.rb
+++ b/lib/pact_broker/pacticipants/repository.rb
@@ -27,13 +27,13 @@ module PactBroker
       end
 
       def find_all(pagination_options = nil)
-        find({:pagination_options => pagination_options})
+        find({}, pagination_options)
       end
 
-      def find options = {}
+      def find(options = {}, pagination_options = nil)
         query = PactBroker::Domain::Pacticipant.select_all_qualified
         query = query.label(options[:label_name]) if options[:label_name]
-        query.order_ignore_case(Sequel[:pacticipants][:name]).eager(:labels).eager(:latest_version).all_with_pagination_options(options[:pagination_options])
+        query.order_ignore_case(Sequel[:pacticipants][:name]).eager(:labels).eager(:latest_version).all_with_pagination_options(pagination_options)
       end
 
       def find_by_name_or_create name

--- a/lib/pact_broker/pacticipants/repository.rb
+++ b/lib/pact_broker/pacticipants/repository.rb
@@ -30,10 +30,10 @@ module PactBroker
         find(pagination_options)
       end
 
-      def find options = {}, pagination_options
+      def find options = {}
         query = PactBroker::Domain::Pacticipant.select_all_qualified
         query = query.label(options[:label_name]) if options[:label_name]
-        query.order_ignore_case(Sequel[:pacticipants][:name]).eager(:labels).eager(:latest_version).all_with_pagination_options(pagination_options)
+        query.order_ignore_case(Sequel[:pacticipants][:name]).eager(:labels).eager(:latest_version).all_with_pagination_options(options[:pagination_options])
       end
 
       def find_by_name_or_create name

--- a/lib/pact_broker/pacticipants/repository.rb
+++ b/lib/pact_broker/pacticipants/repository.rb
@@ -27,7 +27,7 @@ module PactBroker
       end
 
       def find_all(pagination_options = nil)
-        find(pagination_options)
+        find({:pagination_options => pagination_options})
       end
 
       def find options = {}

--- a/lib/pact_broker/pacticipants/service.rb
+++ b/lib/pact_broker/pacticipants/service.rb
@@ -48,8 +48,8 @@ module PactBroker
         pacticipant_repository.find_by_id(id)
       end
 
-      def self.find(options)
-        pacticipant_repository.find(options)
+      def self.find(options, pagination_options = nil)
+        pacticipant_repository.find(options, pagination_options)
       end
 
       def self.find_pacticipant_repository_url_by_pacticipant_name(name)

--- a/lib/pact_broker/pacticipants/service.rb
+++ b/lib/pact_broker/pacticipants/service.rb
@@ -49,7 +49,7 @@ module PactBroker
       end
 
       def self.find(options, pagination_options = nil)
-        pacticipant_repository.find(name, pagination_options)
+        pacticipant_repository.find(options, pagination_options)
       end
 
       def self.find_pacticipant_repository_url_by_pacticipant_name(name)

--- a/lib/pact_broker/pacticipants/service.rb
+++ b/lib/pact_broker/pacticipants/service.rb
@@ -48,8 +48,8 @@ module PactBroker
         pacticipant_repository.find_by_id(id)
       end
 
-      def self.find(options, pagination_options = nil)
-        pacticipant_repository.find(options, pagination_options)
+      def self.find(options)
+        pacticipant_repository.find(options)
       end
 
       def self.find_pacticipant_repository_url_by_pacticipant_name(name)

--- a/lib/pact_broker/pacticipants/service.rb
+++ b/lib/pact_broker/pacticipants/service.rb
@@ -32,8 +32,8 @@ module PactBroker
           } .collect{ | name | pacticipant_repository.find_by_name(name) }
       end
 
-      def self.find_all_pacticipants
-        pacticipant_repository.find_all
+      def self.find_all_pacticipants(pagination_options)
+        pacticipant_repository.find_all(pagination_options)
       end
 
       def self.find_pacticipant_by_name(name)
@@ -48,12 +48,8 @@ module PactBroker
         pacticipant_repository.find_by_id(id)
       end
 
-      def self.find(options)
-        pacticipant_repository.find options
-      end
-
-      def self.find_all_pacticipant_versions_in_reverse_order(name, pagination_options = nil)
-        pacticipant_repository.find_all_pacticipant_versions_in_reverse_order(name, pagination_options)
+      def self.find(options, pagination_options = nil)
+        pacticipant_repository.find(name, pagination_options)
       end
 
       def self.find_pacticipant_repository_url_by_pacticipant_name(name)

--- a/lib/pact_broker/versions/repository.rb
+++ b/lib/pact_broker/versions/repository.rb
@@ -59,6 +59,18 @@ module PactBroker
           .single_record
       end
 
+      def find_all_pacticipant_versions_in_reverse_order name, pagination_options = nil
+        pacticipant = pacticipant_repository.find_by_name!(name)
+        query = PactBroker::Domain::Version
+                  .where(pacticipant: pacticipant)
+                  .eager(:pacticipant)
+                  .eager(branch_versions: [:version, :branch_head, { branch: :pacticipant }])
+                  .eager(tags: :head_tag)
+                  .eager(:pact_publications)
+                  .reverse_order(:order)
+        query.all_with_pagination_options(pagination_options)
+      end
+
       # There may be a race condition if two simultaneous requests come in to create the same version
       def create(args)
         version_params = {

--- a/lib/pact_broker/versions/service.rb
+++ b/lib/pact_broker/versions/service.rb
@@ -26,6 +26,10 @@ module PactBroker
         version_repository.find_latest_by_pacticipant_name_and_branch_name(pacticipant_name, branch_name)
       end
 
+      def self.find_all_pacticipant_versions_in_reverse_order(name, pagination_options = nil)
+        version_repository.find_all_pacticipant_versions_in_reverse_order(name, pagination_options)
+      end
+
       def self.create_or_overwrite(pacticipant_name, version_number, version)
         pacticipant = pacticipant_repository.find_by_name_or_create(pacticipant_name)
         version = version_repository.create_or_overwrite(pacticipant, version_number, version)

--- a/spec/features/get_pacticipants_spec.rb
+++ b/spec/features/get_pacticipants_spec.rb
@@ -4,16 +4,15 @@ describe "Get pacticipants" do
   let(:response_body_hash) { JSON.parse(subject.body, symbolize_names: true) }
   let(:expected_response_body) { {name: "Foo"} }
 
-  subject { get path; last_response }
+  subject { get(path) }
 
-  context "when the pacts exist" do
+  context "when pacts exist" do
 
     before do
-      TestDataBuilder.new
-                     .create_pacticipant("Foo")
-                     .create_label("ios")
-                     .create_pacticipant("Bar")
-                     .create_label("android")
+      td.create_pacticipant("Foo")
+        .create_label("ios")
+        .create_pacticipant("Bar")
+        .create_label("android")
     end
 
     it "returns a 200 OK" do

--- a/spec/features/get_pacticipants_spec.rb
+++ b/spec/features/get_pacticipants_spec.rb
@@ -1,0 +1,35 @@
+describe "Get pacticipants" do
+
+  let(:path) { "/pacticipants" }
+  let(:response_body_hash) { JSON.parse(subject.body, symbolize_names: true) }
+  let(:expected_response_body) { {name: "Foo"} }
+
+  subject { get path; last_response }
+
+  context "when the pacts exist" do
+
+    before do
+      TestDataBuilder.new
+                     .create_pacticipant("Foo")
+                     .create_label("ios")
+                     .create_pacticipant("Bar")
+                     .create_label("android")
+    end
+
+    it "returns a 200 OK" do
+      expect(subject).to be_a_hal_json_success_response
+    end
+
+    context "with pagination options" do
+      subject { get(path, { "pageSize" => "1", "pageNumber" => "1" }) }
+
+      it "paginates the response" do
+        expect(response_body_hash[:_links][:"pacticipants"].size).to eq 1
+      end
+
+      it "includes the pagination relations" do
+        expect(response_body_hash[:_links]).to have_key(:next)
+      end
+    end
+  end
+end

--- a/spec/lib/pact_broker/pacticipants/repository_spec.rb
+++ b/spec/lib/pact_broker/pacticipants/repository_spec.rb
@@ -185,31 +185,6 @@ module PactBroker
 
       end
 
-      describe "#find_all_pacticipant_versions_in_reverse_order" do
-        before do
-          td
-            .create_consumer("Foo")
-            .create_consumer_version("1.2.3")
-            .create_consumer_version("4.5.6")
-            .create_consumer("Bar")
-            .create_consumer_version("8.9.0")
-        end
-
-        subject { Repository.new.find_all_pacticipant_versions_in_reverse_order "Foo" }
-
-        it "returns all the application versions for the given consumer" do
-          expect(subject.collect(&:number)).to eq ["4.5.6", "1.2.3"]
-        end
-
-        context "with pagination options" do
-          subject { Repository.new.find_all_pacticipant_versions_in_reverse_order "Foo", page_number: 1, page_size: 1 }
-
-          it "paginates the query" do
-            expect(subject.collect(&:number)).to eq ["4.5.6"]
-          end
-        end
-      end
-
       describe "#search_by_name" do
         let(:consumer_name) { "This is_a test-consumer" }
         let(:provider_name) { "and a test/provider" }

--- a/spec/lib/pact_broker/versions/repository_spec.rb
+++ b/spec/lib/pact_broker/versions/repository_spec.rb
@@ -25,6 +25,31 @@ module PactBroker
         end
       end
 
+      describe "#find_all_pacticipant_versions_in_reverse_order" do
+        before do
+          td
+            .create_consumer("Foo")
+            .create_consumer_version("1.2.3")
+            .create_consumer_version("4.5.6")
+            .create_consumer("Bar")
+            .create_consumer_version("8.9.0")
+        end
+
+        subject { Repository.new.find_all_pacticipant_versions_in_reverse_order "Foo" }
+
+        it "returns all the application versions for the given consumer" do
+          expect(subject.collect(&:number)).to eq ["4.5.6", "1.2.3"]
+        end
+
+        context "with pagination options" do
+          subject { Repository.new.find_all_pacticipant_versions_in_reverse_order "Foo", page_number: 1, page_size: 1 }
+
+          it "paginates the query" do
+            expect(subject.collect(&:number)).to eq ["4.5.6"]
+          end
+        end
+      end
+
       describe "#find_by_pacticipant_name_and_latest_tag" do
         before do
           td.create_consumer("Bar")


### PR DESCRIPTION
This PR:
- Follows existing pagination pattern used in versions and integration dashboard, implementing pagination for pacticipants
- Returns 'next' and 'previous' links in the GET 'pacticipants' response links as needed
- Utilises the pageNumber and pageSize parameters
- If only pageNumber is specified, page size defaults to 100
- If only pageSize is specified, page number defaults to 1
- Removes pagination_options from the versions resource as it can now use the shared version
- Move find_all_pacticipant_versions_in_reverse_order logic into version name space as it retrieves versions not pacticipants.