### PR TITLE
chore: Add a page section to the pagination links

### DIFF
--- a/lib/pact_broker/api/decorators/pagination_links.rb
+++ b/lib/pact_broker/api/decorators/pagination_links.rb
@@ -8,6 +8,17 @@ module PactBroker
         include Roar::JSON::HAL
         include Roar::JSON::HAL::Links
 
+        property :page, getter: lambda { |context|
+          if context[:represented].respond_to?(:current_page)
+            {
+              number: context[:represented].current_page,
+              size: context[:represented].page_size,
+              totalElements: context[:represented].pagination_record_count,
+              totalPages: context[:represented].page_count,
+            }
+          end
+        }
+
         link :next do | context |
           if represented.respond_to?(:current_page) &&
               represented.respond_to?(:page_count) &&

--- a/spec/features/get_pacticipants_spec.rb
+++ b/spec/features/get_pacticipants_spec.rb
@@ -2,33 +2,45 @@ describe "Get pacticipants" do
 
   let(:path) { "/pacticipants" }
   let(:response_body_hash) { JSON.parse(subject.body, symbolize_names: true) }
-  let(:expected_response_body) { {name: "Foo"} }
+  let(:expected_response_body) { { name: "Foo" } }
 
   subject { get(path) }
 
-  context "when pacts exist" do
+  context "when pacticipants exist" do
 
     before do
       td.create_pacticipant("Foo")
-        .create_label("ios")
         .create_pacticipant("Bar")
-        .create_label("android")
+        .create_pacticipant("someOther")
     end
 
     it "returns a 200 OK" do
       expect(subject).to be_a_hal_json_success_response
     end
 
+    it "does not to contain page details" do
+      expect(response_body_hash).not_to have_key(:page)
+    end
+
     context "with pagination options" do
-      subject { get(path, { "pageSize" => "1", "pageNumber" => "1" }) }
+      subject { get(path, { "pageSize" => "2", "pageNumber" => "1" }) }
 
       it "paginates the response" do
-        expect(response_body_hash[:_links][:"pacticipants"].size).to eq 1
+        expect(response_body_hash[:_links][:"pacticipants"].size).to eq 2
       end
 
       it "includes the pagination relations" do
         expect(response_body_hash[:_links]).to have_key(:next)
       end
+
+      it "includes the page section" do
+        expect(response_body_hash).to have_key(:page)
+      end
+
+      it "outputs a whole number for total pages" do
+        expect(response_body_hash[:page][:totalPages]).to eq(2)
+      end
     end
   end
 end
+

--- a/spec/features/get_versions_spec.rb
+++ b/spec/features/get_versions_spec.rb
@@ -21,6 +21,10 @@ describe "Get versions" do
       expect(last_response_body[:_links][:"versions"].size).to eq 2
     end
 
+    it "does not to contain page details" do
+      expect(last_response_body).not_to have_key(:page)
+    end
+
     context "with pagination options" do
       subject { get(path, { "pageSize" => "1", "pageNumber" => "1" }) }
 
@@ -30,6 +34,10 @@ describe "Get versions" do
 
       it "includes the pagination relations" do
         expect(last_response_body[:_links]).to have_key(:next)
+      end
+
+      it "includes the page section" do
+        expect(last_response_body).to have_key(:page)
       end
     end
   end


### PR DESCRIPTION
This PR adds a page section to the pagination links. Paginated resources will now include these page details when a paginated response is returned. 