### PR TITLE
feat: support setting feature toggles via individual environment variables

### DIFF
--- a/lib/pact_broker/config/runtime_configuration_logging_methods.rb
+++ b/lib/pact_broker/config/runtime_configuration_logging_methods.rb
@@ -28,7 +28,7 @@ module PactBroker
           (self.class.config_attributes - [:base_url]).collect(&:to_s).each_with_object({})do | key, new_hash |
             new_hash[key] = {
               value: self.send(key.to_sym),
-              source: source_info.dig(key, :source) || {:type=>:defaults}
+              source: source_info.dig(key, :source) || source_info.dig(key) || { type: :defaults }
             }
           end.sort_by { |key, _| key }.each { |key, value| log_config_inner(key, value, logger) }
           if self.webhook_redact_sensitive_data == false

--- a/lib/pact_broker/feature_toggle.rb
+++ b/lib/pact_broker/feature_toggle.rb
@@ -15,7 +15,7 @@ module PactBroker
     end
 
     def self.feature_in_env_var?(feature)
-      PactBroker.configuration.features.include?(feature.to_s.downcase)
+      PactBroker.configuration.features[feature.to_s.downcase.to_sym] == true
     end
   end
 

--- a/spec/lib/pact_broker/config/runtime_configuration_spec.rb
+++ b/spec/lib/pact_broker/config/runtime_configuration_spec.rb
@@ -107,10 +107,18 @@ module PactBroker
           end
         end
 
-        context "with both the list format and the hash format" do
-          it "blows up (can't work out how to make these two work together)" do
+        context "with the list env var defined first and the individual env vars defined last" do
+          it "uses the individual env vars" do
             with_env("PACT_BROKER_FEATURES" => "feat1 feat2 feat3", "PACT_BROKER_FEATURES__FEAT4" => "true", "PACT_BROKER_FEATURES__FEAT5" => "false") do
-              expect { RuntimeConfiguration.new }.to raise_error IndexError
+              expect(RuntimeConfiguration.new.features).to eq feat4: true, feat5: false
+            end
+          end
+        end
+
+        context "with the individual env vars defined first and the list env var defined last" do
+          it "uses the list env var" do
+            with_env("PACT_BROKER_FEATURES__FEAT4" => "true", "PACT_BROKER_FEATURES__FEAT5" => "false", "PACT_BROKER_FEATURES" => "feat1 feat2 feat3") do
+              expect(RuntimeConfiguration.new.features).to eq feat1: true, feat2: true, feat3: true
             end
           end
         end

--- a/spec/lib/pact_broker/config/runtime_configuration_spec.rb
+++ b/spec/lib/pact_broker/config/runtime_configuration_spec.rb
@@ -1,8 +1,11 @@
 require "pact_broker/config/runtime_configuration"
+require "anyway/testing/helpers"
 
 module PactBroker
   module Config
     describe RuntimeConfiguration do
+      include Anyway::Testing::Helpers
+
       describe "base_url" do
         it "does not expose base_url for delegation" do
           expect(RuntimeConfiguration.getter_and_setter_method_names).to_not include :base_url
@@ -76,6 +79,46 @@ module PactBroker
           end
 
           its(:webhook_certificates) { is_expected.to eq [{ description: "cert1", content: "abc" }, { description: "cert1", content: "abc" }] }
+        end
+      end
+
+      describe "features" do
+        context "with the PACT_BROKER_FEATURES env var with a space delimited list of enabled features" do
+          it "parses the string to a hash" do
+            with_env("PACT_BROKER_FEATURES" => "feat1 feat2") do
+              expect(RuntimeConfiguration.new.features).to eq feat1: true, feat2: true
+            end
+          end
+        end
+
+        context "with the PACT_BROKER_FEATURES env var with an empty string" do
+          it "parses the string to a hash" do
+            with_env("PACT_BROKER_FEATURES" => "") do
+              expect(RuntimeConfiguration.new.features).to eq({})
+            end
+          end
+        end
+
+        context "with a different env var for each feature" do
+          it "merges the env vars into a hash" do
+            with_env("PACT_BROKER_FEATURES__FEAT1" => "true", "PACT_BROKER_FEATURES__FEAT2" => "false") do
+              expect(RuntimeConfiguration.new.features).to eq feat1: true, feat2: false
+            end
+          end
+        end
+
+        context "with both the list format and the hash format" do
+          it "blows up (can't work out how to make these two work together)" do
+            with_env("PACT_BROKER_FEATURES" => "feat1 feat2 feat3", "PACT_BROKER_FEATURES__FEAT4" => "true", "PACT_BROKER_FEATURES__FEAT5" => "false") do
+              expect { RuntimeConfiguration.new }.to raise_error IndexError
+            end
+          end
+        end
+
+        context "with no feature env vars" do
+          it "returns an empty hash" do
+            expect(RuntimeConfiguration.new.features).to eq({})
+          end
         end
       end
     end


### PR DESCRIPTION
Implements https://github.com/pact-foundation/pact_broker/issues/610


Supports toggling individual features using the format `PACT_BROKER_FEATURES__<FEAT_NAME>=true`. This is primarily to allow better control of feature toggles for PactFlow.

The original format of `PACT_BROKER_FEATURES=<feat_name> <feat_name> <feat_name>" is still supported, but both cannot be used at the same time. Which ever environment variable is defined "last" (according to the order in which the environment variables are iterated in memory) will win.

