### PR TITLE
chore: Add pagination parameter validation for paginated endpoints.

### DIFF
--- a/lib/pact_broker/api/resources/branch_versions.rb
+++ b/lib/pact_broker/api/resources/branch_versions.rb
@@ -18,6 +18,10 @@ module PactBroker
           ["GET", "OPTIONS"]
         end
 
+        def malformed_request?
+          super || request.get? && validation_errors_for_schema?(schema, request.query)
+        end
+
         def resource_exists?
           !!branch
         end
@@ -40,6 +44,14 @@ module PactBroker
 
         def resource_title
           "Versions for branch #{branch.name} of #{branch.pacticipant.name}"
+        end
+
+        private
+
+        def schema
+          if request.get?
+            PactBroker::Api::Contracts::PaginationQueryParamsSchema
+          end
         end
       end
     end

--- a/lib/pact_broker/api/resources/dashboard.rb
+++ b/lib/pact_broker/api/resources/dashboard.rb
@@ -20,6 +20,10 @@ module PactBroker
           ["GET", "OPTIONS"]
         end
 
+        def malformed_request?
+          super || (request.get? && validation_errors_for_schema?(schema, request.query))
+        end
+
         def to_json
           decorator_class(:dashboard_decorator).new(index_items).to_json(**decorator_options)
         end
@@ -33,6 +37,12 @@ module PactBroker
         end
 
         private
+
+        def schema
+          if request.get?
+            PactBroker::Api::Contracts::PaginationQueryParamsSchema
+          end
+        end
 
         def index_items
           index_service.find_index_items_for_api(**identifier_from_path.merge(pagination_options))

--- a/lib/pact_broker/api/resources/pacticipants.rb
+++ b/lib/pact_broker/api/resources/pacticipants.rb
@@ -25,7 +25,15 @@ module PactBroker
         end
 
         def malformed_request?
-          super || (request.post? && validation_errors_for_schema?)
+          if super
+            true
+          elsif request.post? && validation_errors_for_schema?
+            true
+          elsif request.get? && validation_errors_for_schema?(schema, request.query)
+            true
+          else
+            false
+          end
         end
 
         def request_body_required?
@@ -68,7 +76,11 @@ module PactBroker
         private
 
         def schema
-          PactBroker::Api::Contracts::PacticipantCreateSchema
+          if request.get?
+            PactBroker::Api::Contracts::PaginationQueryParamsSchema
+          else
+            PactBroker::Api::Contracts::PacticipantCreateSchema
+          end
         end
 
         def eager_load_associations

--- a/lib/pact_broker/api/resources/versions.rb
+++ b/lib/pact_broker/api/resources/versions.rb
@@ -18,6 +18,10 @@ module PactBroker
           ["GET", "OPTIONS"]
         end
 
+        def malformed_request?
+          super || request.get? && validation_errors_for_schema?(schema, request.query)
+        end
+
         def resource_exists?
           !!pacticipant
         end
@@ -32,6 +36,14 @@ module PactBroker
 
         def policy_name
           :'versions::versions'
+        end
+
+        private
+
+        def schema
+          if request.get?
+            PactBroker::Api::Contracts::PaginationQueryParamsSchema
+          end
         end
       end
     end

--- a/spec/lib/pact_broker/api/resources/dashboard_spec.rb
+++ b/spec/lib/pact_broker/api/resources/dashboard_spec.rb
@@ -30,6 +30,12 @@ module PactBroker
             expect(response_body_hash["items"].size).to eq 1
           end
         end
+
+        context "with invalid pagination" do
+          subject { get(path, { pageNumber: -1, pageSize: -1 }) }
+
+          it_behaves_like "an invalid pagination params response"
+        end
       end
     end
   end

--- a/spec/lib/pact_broker/api/resources/pacticipants_spec.rb
+++ b/spec/lib/pact_broker/api/resources/pacticipants_spec.rb
@@ -40,6 +40,17 @@ module PactBroker
               and_return(pacticipants)
             expect(subject.status).to eq 200
           end
+
+          context "with invalid pagination params" do
+            let(:query) do
+              {
+                "pageSize" => "0",
+                "pageNumber" => "0",
+              }
+            end
+
+            it_behaves_like "an invalid pagination params response"
+          end
         end
 
         describe "POST" do

--- a/spec/support/shared_examples_for_responses.rb
+++ b/spec/support/shared_examples_for_responses.rb
@@ -28,6 +28,19 @@ shared_examples_for "a paginated response" do
   end
 end
 
+shared_examples_for "an invalid pagination params response" do
+  let(:response_body_hash) { JSON.parse(subject.body, symbolize_names: true) }
+
+  it "returns a a 400 status code" do
+    expect(subject.status).to eq 400
+  end
+
+  it "includes the parameter validation errors" do
+    expect(response_body_hash[:errors].has_key?(:pageNumber)).to be_truthy
+    expect(response_body_hash[:errors].has_key?(:pageSize)).to be_truthy
+  end
+end
+
 require "rspec/expectations"
 
 RSpec::Matchers.define :be_a_hal_json_success_response do


### PR DESCRIPTION
This PR adds validation for the pagination parameters to the endpoints that support pagination, and didn't yet have validation for these parameters. This will allow a 400 malformed request error to be returned, should the endpoints be called with invalid parameters. 


