### PR TITLE
refactor: refactor validation errors rendering

### DIFF
--- a/lib/pact_broker/api/contracts/README.md
+++ b/lib/pact_broker/api/contracts/README.md
@@ -1,4 +1,19 @@
-# Using dry-validation
+# Request validation
+
+Note: in this document, the word "contract" means a Dry::Validation::Contract, not a Pact consumer contract.
+
+## History of the validation errors format
+
+The original Pact Broker validation contracts returned a Hash in the format { "key[.key]" => ["error"] }.
+When we upgraded the contracts to Dry::Validation v1.8, we added a `.call` method to the
+PactBroker::Api::Contracts::BaseContract class that converted the Dry::Validation::MessageSet
+into a Hash, in as close to the original format as possible.
+We have since started supporting error responses in the problem+json format, so it makes more sense
+to have the contracts return the Dry::Validation::Result, and then use different decorators
+to render either the problem+json response or the old hash format.
+
+To avoid having to update every single contract spec, the validation specs use the method `format_errors_the_old_way(dry_validation_result)`
+from spec/support/api_contract_support.rb to convert the Dry::Validation::Result back into the old Hash format. New specs do not need to do this.
 
 ## Things you need to know about dry-validation
 
@@ -19,3 +34,4 @@
 
 * I cannot find any native support for Contract composition (there's schema composition, but I can't find Contract composition). The macros `validate_with_contract` and `validate_each_with_contract` in lib/pact_broker/api/contracts/dry_validation_macros.rb allow a child item or array of child items to be validated by a contract that is defined in a separate file, merging the results into the parent's results. There's an example in lib/pact_broker/api/contracts/pacts_for_verification_json_query_schema.rb
 * The format that dry-validation returns the error messages for arrays didn't work with the original Pact Broker error format, so the errors are formatted in lib/pact_broker/api/contracts/dry_validation_errors_formatter.rb (one day, the errors should be returned directly to the resource, and the error decorator can either format them in problem json, or raw hash)
+

--- a/lib/pact_broker/api/contracts/base_contract.rb
+++ b/lib/pact_broker/api/contracts/base_contract.rb
@@ -23,7 +23,7 @@ module PactBroker
         # @return [Hash] the validation errors to display to the user
         def self.call(params)
           params_to_validate = params.respond_to?(:symbolize_keys) ? params.symbolize_keys : params
-          format_errors(new.call(params_to_validate).errors)
+          new.call(params_to_validate)
         end
       end
     end

--- a/lib/pact_broker/api/contracts/configuration.rb
+++ b/lib/pact_broker/api/contracts/configuration.rb
@@ -22,6 +22,25 @@ module PactBroker
           end
         end
 
+        # @param [Class] errors_class will be a Hash class or Dry::Validation::MessageSet class
+        # @param [String] accept_header if this includes application/problem+json we render a application/problem+json response
+        # @return [Class] the decorator class
+        def validation_error_decorator_class_for(errors_class, accept_header)
+          if accept_header&.include?("application/problem+json")
+            if errors_class == Dry::Validation::MessageSet
+              PactBroker::Api::Decorators::DryValidationErrorsProblemJSONDecorator
+            else
+              PactBroker::Api::Decorators::ValidationErrorsProblemJSONDecorator
+            end
+          else
+            if errors_class == Dry::Validation::MessageSet
+              PactBroker::Api::Decorators::DryValidationErrorsDecorator
+            else
+              PactBroker::Api::Decorators::ValidationErrorsDecorator
+            end
+          end
+        end
+
         def self.default_configuration
           Configuration.new
         end

--- a/lib/pact_broker/api/contracts/dry_validation_errors_formatter.rb
+++ b/lib/pact_broker/api/contracts/dry_validation_errors_formatter.rb
@@ -5,6 +5,8 @@ module PactBroker
     module Contracts
       module DryValidationErrorsFormatter
 
+        extend self
+
         # Formats the dry validation errors in the expected PactBroker error format of { :key => ["errors"] }
         # where there are no nested hashes.
         # @param [Dry::Validation::MessageSet] errors

--- a/lib/pact_broker/api/decorators/dry_validation_errors_decorator.rb
+++ b/lib/pact_broker/api/decorators/dry_validation_errors_decorator.rb
@@ -1,0 +1,32 @@
+# Formats Dry::Validation::MessageSet errors into the "old" Pact Broker errors format
+# TODO: delete this in favour of problem+json in the next major version
+
+require "pact_broker/api/contracts/dry_validation_errors_formatter"
+
+module PactBroker
+  module Api
+    module Decorators
+      class DryValidationErrorsDecorator
+
+        # @param errors [Hash]
+        def initialize(errors)
+          @errors = errors
+        end
+
+        # @return [Hash]
+        def to_hash(*_args, **_kwargs)
+          { errors: PactBroker::Api::Contracts::DryValidationErrorsFormatter.format_errors(errors) }
+        end
+
+        # @return [String] JSON
+        def to_json(*args, **kwargs)
+          to_hash(*args, **kwargs).to_json
+        end
+
+        private
+
+        attr_reader :errors
+      end
+    end
+  end
+end

--- a/lib/pact_broker/api/decorators/dry_validation_errors_problem_json_decorator.rb
+++ b/lib/pact_broker/api/decorators/dry_validation_errors_problem_json_decorator.rb
@@ -1,0 +1,45 @@
+# Formats a Dry::Validation::MessageSet into application/problem+json format.
+
+module PactBroker
+  module Api
+    module Decorators
+      class DryValidationErrorsProblemJSONDecorator
+        # @param errors [Dry::Validation::MessageSet]
+        def initialize(errors)
+          @errors = errors
+        end
+
+        # @return [Hash]
+        def to_hash(user_options:, **)
+          error_list = errors.collect{ |e| error_hash(e, user_options[:base_url]) }
+          {
+            "title" => "Validation errors",
+            "type" => "#{user_options[:base_url]}/problems/validation-error",
+            "status" => 400,
+            "instance" => "/",
+            "errors" => error_list
+          }
+        end
+
+        # @return [String] JSON
+        def to_json(*args, **kwargs)
+          to_hash(*args, **kwargs).to_json
+        end
+
+        private
+
+        attr_reader :errors
+
+        def error_hash(error, base_url)
+          {
+            "type" => "#{base_url}/problems/invalid-body-property-value",
+            "title" => "Validation error",
+            "detail" => error.text,
+            "pointer" => "/" + error.path.join("/"),
+            "status" => 400
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/pact_broker/api/decorators/error_decorator.rb
+++ b/lib/pact_broker/api/decorators/error_decorator.rb
@@ -1,0 +1,30 @@
+# Formats a nested Hash of errors into the "old" Pact Broker errors format
+# TODO: delete this in favour of problem+json in the next major version
+
+module PactBroker
+  module Api
+    module Decorators
+      class ErrorDecorator
+
+        # @param error [String]
+        def initialize(error)
+          @error = error
+        end
+
+        # @return [Hash]
+        def to_hash(*_args, **_kwargs)
+          { error: error }
+        end
+
+        # @return [String] JSON
+        def to_json(*args, **kwargs)
+          to_hash(*args, **kwargs).to_json
+        end
+
+        private
+
+        attr_reader :error
+      end
+    end
+  end
+end

--- a/lib/pact_broker/api/decorators/validation_errors_decorator.rb
+++ b/lib/pact_broker/api/decorators/validation_errors_decorator.rb
@@ -1,0 +1,30 @@
+# Formats a nested Hash of errors, or an Array of Strings, into the "old" Pact Broker errors format
+# TODO: delete this in favour of problem+json in the next major version
+
+module PactBroker
+  module Api
+    module Decorators
+      class ValidationErrorsDecorator
+
+        # @param errors [Hash, Array<String>]
+        def initialize(errors)
+          @errors = errors
+        end
+
+        # @return [Hash]
+        def to_hash(*_args, **_kwargs)
+          { errors: errors }
+        end
+
+        # @return [String] JSON
+        def to_json(*args, **kwargs)
+          to_hash(*args, **kwargs).to_json
+        end
+
+        private
+
+        attr_reader :errors
+      end
+    end
+  end
+end

--- a/lib/pact_broker/api/decorators/validation_errors_problem_json_decorator.rb
+++ b/lib/pact_broker/api/decorators/validation_errors_problem_json_decorator.rb
@@ -1,5 +1,4 @@
-# Formats a nested Hash of errors as it comes out of the Dry Validation library
-# into application/problem+json format.
+# Formats a nested Hash of errors into application/problem+json format.
 require "pact_broker/string_refinements"
 
 module PactBroker

--- a/lib/pact_broker/api/resources/base_resource.rb
+++ b/lib/pact_broker/api/resources/base_resource.rb
@@ -257,8 +257,9 @@ module PactBroker
         end
 
         def validation_errors_for_schema?(schema_to_use = schema, params_to_validate = params)
-          if (errors = schema_to_use.call(params_to_validate)).any?
-            set_json_validation_error_messages(errors)
+          result = schema_to_use.call(params_to_validate)
+          if result.errors.any?
+            set_json_validation_error_messages(result.errors)
             true
           else
             false

--- a/spec/lib/pact_broker/api/contracts/base_contract_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/base_contract_spec.rb
@@ -4,6 +4,7 @@ module PactBroker
   module Api
     module Contracts
       describe BaseContract do
+        include PactBroker::Test::ApiContractSupport
 
         class TestContract < BaseContract
           json do
@@ -13,7 +14,7 @@ module PactBroker
 
         describe ".call" do
           context "when an array is supplied" do
-            subject { TestContract.call([1]) }
+            subject { format_errors_the_old_way(TestContract.call([1])) }
 
             it "doesn't blow up" do
               expect(subject[:name]).to eq ["is missing"]

--- a/spec/lib/pact_broker/api/contracts/can_i_deploy_query_schema_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/can_i_deploy_query_schema_spec.rb
@@ -1,16 +1,19 @@
 require "pact_broker/api/contracts/can_i_deploy_query_schema"
+require "pact_broker/api/contracts/dry_validation_errors_formatter"
 
 module PactBroker
   module Api
     module Contracts
       describe CanIDeployQuerySchema do
+        include PactBroker::Test::ApiContractSupport
+
         before do
           allow(PactBroker::Pacticipants::Service).to receive(:find_pacticipant_by_name).and_return(pacticipant)
         end
 
         let(:pacticipant) { double("pacticipant") }
 
-        subject { CanIDeployQuerySchema.call(params) }
+        subject { format_errors_the_old_way(CanIDeployQuerySchema.call(params)) }
 
         context "with valid params" do
           let(:params) do

--- a/spec/lib/pact_broker/api/contracts/configuration_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/configuration_spec.rb
@@ -1,0 +1,43 @@
+require "pact_broker/api/contracts/configuration"
+
+module PactBroker
+  module Api
+    module Contracts
+      describe Configuration do
+        describe "#validation_error_decorator_class_for" do
+          let(:configuration) { Configuration.new }
+
+          subject { configuration.validation_error_decorator_class_for(errors_class, accept_header) }
+
+          context "when given Dry::Validation::MessageSet and application/hal+json, application/problem+json" do
+            let(:errors_class) { Dry::Validation::MessageSet }
+            let(:accept_header) { "application/hal+json, application/problem+json" }
+
+            it { is_expected.to be PactBroker::Api::Decorators::DryValidationErrorsProblemJSONDecorator }
+          end
+
+          context "when given Hash and application/hal+json, application/problem+json" do
+            let(:errors_class) { Hash }
+            let(:accept_header) { "application/hal+json, application/problem+json" }
+
+            it { is_expected.to be PactBroker::Api::Decorators::ValidationErrorsProblemJSONDecorator }
+          end
+
+          context "when given Dry::Validation::MessageSet and application/hal+json" do
+            let(:errors_class) { Dry::Validation::MessageSet }
+            let(:accept_header) { "application/hal+json" }
+
+            it { is_expected.to be PactBroker::Api::Decorators::DryValidationErrorsDecorator }
+          end
+
+          context "when given Hash and application/hal+json" do
+            let(:errors_class) { Hash }
+            let(:accept_header) { "application/hal+json" }
+
+            it { is_expected.to be PactBroker::Api::Decorators::ValidationErrorsDecorator }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/pact_broker/api/contracts/environment_schema_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/environment_schema_spec.rb
@@ -4,6 +4,8 @@ module PactBroker
   module Api
     module Contracts
       describe EnvironmentSchema do
+        include PactBroker::Test::ApiContractSupport
+
         before do
           allow(PactBroker::Deployments::EnvironmentService).to receive(:find_by_name).and_return(existing_environment)
         end
@@ -27,7 +29,7 @@ module PactBroker
           }]
         end
 
-        subject { EnvironmentSchema.call(params) }
+        subject { format_errors_the_old_way(EnvironmentSchema.call(params)) }
 
         context "with valid params" do
           it { is_expected.to be_empty }

--- a/spec/lib/pact_broker/api/contracts/pacticipant_create_schema_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/pacticipant_create_schema_spec.rb
@@ -4,6 +4,8 @@ module PactBroker
   module Api
     module Contracts
       describe PacticipantCreateSchema do
+        include PactBroker::Test::ApiContractSupport
+
         let(:params) do
           {
             name: name,
@@ -19,7 +21,7 @@ module PactBroker
 
         let(:main_branch) { "main" }
 
-        subject { PacticipantCreateSchema.call(params) }
+        subject { format_errors_the_old_way(PacticipantCreateSchema.call(params)) }
 
         context "with valid params" do
           it { is_expected.to be_empty }

--- a/spec/lib/pact_broker/api/contracts/pacticipant_schema_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/pacticipant_schema_spec.rb
@@ -4,6 +4,8 @@ module PactBroker
   module Api
     module Contracts
       describe PacticipantSchema do
+        include PactBroker::Test::ApiContractSupport
+
         let(:params) do
           {
             name: "pact-broker",
@@ -17,7 +19,7 @@ module PactBroker
 
         let(:main_branch) { "main" }
 
-        subject { PacticipantSchema.call(params) }
+        subject { format_errors_the_old_way(PacticipantSchema.call(params)) }
 
         context "with valid params" do
           it { is_expected.to be_empty }

--- a/spec/lib/pact_broker/api/contracts/pacts_for_verification_json_query_schema_combinations_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/pacts_for_verification_json_query_schema_combinations_spec.rb
@@ -4,6 +4,8 @@ module PactBroker
   module Api
     module Contracts
       describe PactsForVerificationJSONQuerySchema do
+        include PactBroker::Test::ApiContractSupport
+
         ALL_PROPERTIES = {
           mainBranch: true,
           matchingBranch: true,
@@ -49,7 +51,7 @@ module PactBroker
 
             it "is valid" do
               params = { consumerVersionSelectors: [selector], providerVersionBranch: "main" }
-              expect(PactsForVerificationJSONQuerySchema.(params)).to be_empty
+              expect(PactsForVerificationJSONQuerySchema.(params).errors).to be_empty
             end
 
             extra_keys = ALL_PROPERTIES.keys - valid_key_combination - [:consumer]
@@ -61,11 +63,11 @@ module PactBroker
               describe "with #{selector_with_extra_key}" do
                 if expect_to_be_valid
                   it "is valid" do
-                    expect(PactsForVerificationJSONQuerySchema.(params)).to be_empty
+                    expect(PactsForVerificationJSONQuerySchema.(params).errors).to be_empty
                   end
                 else
                   it "is not valid" do
-                    expect(PactsForVerificationJSONQuerySchema.(params)).to_not be_empty
+                    expect(PactsForVerificationJSONQuerySchema.(params).errors).to_not be_empty
                   end
                 end
               end
@@ -76,7 +78,7 @@ module PactBroker
                 it "is valid" do
                   params = { consumerVersionSelectors: [selector_with_consumer], providerVersionBranch: "main" }
 
-                  expect(PactsForVerificationJSONQuerySchema.(params).empty?).to be true
+                  expect(PactsForVerificationJSONQuerySchema.(params).errors.empty?).to be true
                 end
               end
             end

--- a/spec/lib/pact_broker/api/contracts/pacts_for_verification_json_query_schema_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/pacts_for_verification_json_query_schema_spec.rb
@@ -4,6 +4,8 @@ module PactBroker
   module Api
     module Contracts
       describe PactsForVerificationJSONQuerySchema do
+        include PactBroker::Test::ApiContractSupport
+
         let(:params) do
           {
             providerVersionTags: provider_version_tags,
@@ -20,7 +22,7 @@ module PactBroker
           }]
         end
 
-        subject { PactsForVerificationJSONQuerySchema.(params) }
+        subject { format_errors_the_old_way(PactsForVerificationJSONQuerySchema.(params)) }
 
         context "when nothing is specified" do
           let(:params) { {} }

--- a/spec/lib/pact_broker/api/contracts/pacts_for_verification_query_string_schema_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/pacts_for_verification_query_string_schema_spec.rb
@@ -4,6 +4,8 @@ module PactBroker
   module Api
     module Contracts
       describe PactsForVerificationQueryStringSchema do
+        include PactBroker::Test::ApiContractSupport
+
         let(:params) do
           {
             provider_version_tags: provider_version_tags,
@@ -20,7 +22,7 @@ module PactBroker
           }]
         end
 
-        subject { PactsForVerificationQueryStringSchema.(params) }
+        subject { format_errors_the_old_way(PactsForVerificationQueryStringSchema.(params)) }
 
         context "when the params are valid" do
           it "has no errors" do

--- a/spec/lib/pact_broker/api/contracts/pagination_query_params_schema_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/pagination_query_params_schema_spec.rb
@@ -4,11 +4,13 @@ module PactBroker
   module Api
     module Contracts
       describe PaginationQueryParamsSchema do
+        include PactBroker::Test::ApiContractSupport
+
         let(:params) do
           {}
         end
 
-        subject { PaginationQueryParamsSchema.call(params) }
+        subject { format_errors_the_old_way(PaginationQueryParamsSchema.call(params)) }
 
         context "with empty params" do
           it { is_expected.to be_empty }

--- a/spec/lib/pact_broker/api/contracts/publish_contracts_schema_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/publish_contracts_schema_spec.rb
@@ -4,6 +4,8 @@ module PactBroker
   module Api
     module Contracts
       describe PublishContractsSchema do
+        include PactBroker::Test::ApiContractSupport
+
         let(:params) do
           {
             :pacticipantName => pacticipant_name,
@@ -41,7 +43,7 @@ module PactBroker
         let(:decoded_parsed_content) { contract_hash }
         let(:content_type) { "application/json" }
 
-        subject { PublishContractsSchema.call(params) }
+        subject { format_errors_the_old_way(PublishContractsSchema.call(params)) }
 
         context "with valid params" do
           it { is_expected.to be_empty }

--- a/spec/lib/pact_broker/api/contracts/put_pact_params_contract_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/put_pact_params_contract_spec.rb
@@ -5,6 +5,8 @@ module PactBroker
   module Api
     module Contracts
       describe PutPactParamsContract do
+        include PactBroker::Test::ApiContractSupport
+
         before do
           allow(PactBroker.configuration).to receive(:order_versions_by_date).and_return(order_versions_by_date)
         end
@@ -24,7 +26,7 @@ module PactBroker
           }
         end
 
-        subject { PutPactParamsContract.call(pact_params) }
+        subject { format_errors_the_old_way(PutPactParamsContract.call(pact_params)) }
 
         describe "errors" do
           let(:attributes) { valid_attributes }

--- a/spec/lib/pact_broker/api/contracts/verification_contract_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/verification_contract_spec.rb
@@ -6,16 +6,17 @@ module PactBroker
   module Api
     module Contracts
       describe VerificationContract do
+        include PactBroker::Test::ApiContractSupport
 
-        subject { VerificationContract.call(params) }
         let(:verification) { PactBroker::Domain::Verification.new }
         let(:valid_params) { { success: success, providerApplicationVersion: provider_version, buildUrl: build_url } }
         let(:params) { valid_params }
-
         let(:success) { true }
         let(:provider_version) { "4.5.6" }
         let(:build_url) { "http://foo" }
         let(:order_versions_by_date) { false }
+
+        subject { format_errors_the_old_way(VerificationContract.call(params)) }
 
         def modify hash, options
           hash.delete(options.fetch(:without))

--- a/spec/lib/pact_broker/api/contracts/webhook_contract_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/webhook_contract_spec.rb
@@ -5,6 +5,8 @@ module PactBroker
   module Api
     module Contracts
       describe WebhookContract do
+        include PactBroker::Test::ApiContractSupport
+
         let(:json) { load_fixture "webhook_valid_with_pacticipants.json" }
         let(:hash) { JSON.parse(json) }
         let(:webhook) { PactBroker::Api::Decorators::WebhookDecorator.new(Domain::Webhook.new).from_json(json) }
@@ -12,7 +14,7 @@ module PactBroker
         let(:consumer) { double("consumer") }
         let(:provider) { double("provider") }
 
-        subject { WebhookContract.call(hash) }
+        subject { format_errors_the_old_way(WebhookContract.call(hash)) }
 
         def valid_webhook_with
           hash = load_json_fixture "webhook_valid_with_pacticipants.json"

--- a/spec/lib/pact_broker/api/decorators/dry_validation_errors_problem_json_decorator_spec.rb
+++ b/spec/lib/pact_broker/api/decorators/dry_validation_errors_problem_json_decorator_spec.rb
@@ -1,0 +1,52 @@
+require "pact_broker/api/decorators/dry_validation_errors_problem_json_decorator"
+require "pact_broker/api/contracts/base_contract"
+
+module PactBroker
+  module Api
+    module Decorators
+      describe DryValidationErrorsProblemJSONDecorator do
+        describe "#to_json" do
+
+          class TestContract < PactBroker::Api::Contracts::BaseContract
+            json do
+              optional(:foo).maybe(:hash) do
+                required(:bar).filled(:string)
+              end
+            end
+          end
+
+          let(:decorator_options) { { user_options: { base_url: "http://example.org" } } }
+
+          subject { DryValidationErrorsProblemJSONDecorator.new(validation_errors).to_hash(**decorator_options) }
+
+          context "with a hash of errors" do
+            let(:validation_errors) do
+              TestContract.new.call({ foo: { bar: 1 }}).errors
+            end
+
+            let(:expected_hash) do
+              {
+                "title" => "Validation errors",
+                "type" => "http://example.org/problems/validation-error",
+                "status" => 400,
+                "instance" => "/",
+
+                "errors" => [
+                  {
+                    "type" => "http://example.org/problems/invalid-body-property-value",
+                    "pointer" => "/foo/bar",
+                    "title" => "Validation error",
+                    "detail" => "must be a string",
+                    "status" => 400
+                  }
+                ]
+              }
+            end
+
+            it { is_expected.to match_pact(expected_hash, allow_unexpected_keys: false)}
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/pact_broker/api/decorators/validation_errors_problem_json_decorator_spec.rb
+++ b/spec/lib/pact_broker/api/decorators/validation_errors_problem_json_decorator_spec.rb
@@ -96,7 +96,7 @@ module PactBroker
             it { is_expected.to match_pact(expected_hash, allow_unexpected_keys: false)}
           end
 
-          context "with an array of strings (shouldn't happen, but can't guarantee it doesn't" do
+          context "with an array of strings (PactBroker::Matrix::Service.validate_selectors returns this :grimace:)" do
             let(:validation_errors) do
               ["error 1", "error 2"]
             end

--- a/spec/lib/pact_broker/api/resources/all_webhooks_spec.rb
+++ b/spec/lib/pact_broker/api/resources/all_webhooks_spec.rb
@@ -25,7 +25,7 @@ module PactBroker::Api
         before do
           allow(webhook_service).to receive(:create).and_return(saved_webhook)
           allow(webhook_service).to receive(:next_uuid).and_return(next_uuid)
-          allow(PactBroker::Api::Contracts::WebhookContract).to receive(:call).and_return(errors)
+          allow(PactBroker::Api::Contracts::WebhookContract).to receive(:call).and_return(double("result", errors: errors) )
           allow(PactBroker::Domain::Webhook).to receive(:new).and_return(webhook)
         end
 

--- a/spec/lib/pact_broker/api/resources/error_handling_methods_spec.rb
+++ b/spec/lib/pact_broker/api/resources/error_handling_methods_spec.rb
@@ -1,0 +1,44 @@
+require "pact_broker/api/resources/error_handling_methods"
+
+module PactBroker
+  module Api
+    module Resources
+      describe ErrorHandlingMethods do
+        class TestResource < PactBroker::Api::Resources::BaseResource; end
+
+        describe "#set_json_validation_error_messages" do
+          before do
+            allow(application_context.api_contract_configuration).to receive(:validation_error_decorator_class_for).and_return(decorator_class)
+          end
+          let(:decorator_class) { double("decorator class", new: decorator) }
+          let(:decorator) { double("Decorator", to_json: "body")}
+          let(:request) { double("request", env: env, path_info: path_info, headers: headers).as_null_object }
+          let(:path_info) { { application_context: application_context } }
+          let(:application_context) { PactBroker::ApplicationContext.default_application_context }
+          let(:response) { double("response").as_null_object }
+          let(:env) { { "pactbroker.base_url" => "http://example.org" } }
+          let(:headers) { { "Accept" => "application/hal+json,application/problem+json" } }
+          let(:errors) { { "foo" => ["bar"] }  }
+          let(:resource) { BaseResource.new(request, response) }
+
+          subject { resource.set_json_validation_error_messages(errors) }
+
+          it "gets the decorator for the errors" do
+            expect(application_context.api_contract_configuration).to receive(:validation_error_decorator_class_for).with(Hash, "application/hal+json,application/problem+json")
+            subject
+          end
+
+          it "generates the response body" do
+            expect(decorator).to receive(:to_json).with(user_options: { base_url: "http://example.org"})
+            subject
+          end
+
+          it "sets the response body" do
+            expect(response).to receive(:body=).with("body")
+            subject
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/pact_broker/api/resources/integrations_spec.rb
+++ b/spec/lib/pact_broker/api/resources/integrations_spec.rb
@@ -10,7 +10,7 @@ module PactBroker
             allow(integration_service).to receive(:find_all).and_return(integrations)
             allow_any_instance_of(described_class).to receive(:decorator_class).and_return(decorator_class)
             allow_any_instance_of(described_class).to receive_message_chain(:decorator_class, :eager_load_associations).and_return(eager_load_associations)
-            allow(PactBroker::Api::Contracts::PaginationQueryParamsSchema).to receive(:call).and_return(errors)
+            allow(PactBroker::Api::Contracts::PaginationQueryParamsSchema).to receive(:call).and_return(double("result", errors: errors))
           end
 
           let(:integration_service) { class_double("PactBroker::Integrations::Service").as_stubbed_const }

--- a/spec/lib/pact_broker/api/resources/pact_spec.rb
+++ b/spec/lib/pact_broker/api/resources/pact_spec.rb
@@ -82,7 +82,7 @@ module PactBroker::Api
           let(:errors) { { messages: ["messages"] } }
 
           before do
-            allow(Contracts::PutPactParamsContract).to receive(:call).and_return(errors)
+            allow(Contracts::PutPactParamsContract).to receive(:call).and_return(double("result", errors: errors))
           end
 
           it "returns a 400 error" do

--- a/spec/lib/pact_broker/api/resources/pacticipant_webhooks_spec.rb
+++ b/spec/lib/pact_broker/api/resources/pacticipant_webhooks_spec.rb
@@ -118,7 +118,7 @@ module PactBroker::Api
         before do
           allow(webhook_service).to receive(:create).and_return(saved_webhook)
           allow(webhook_service).to receive(:next_uuid).and_return(next_uuid)
-          allow(PactBroker::Api::Contracts::WebhookContract).to receive(:call).and_return(errors)
+          allow(PactBroker::Api::Contracts::WebhookContract).to receive(:call).and_return(double("result", errors: errors))
           allow(PactBroker::Domain::Webhook).to receive(:new).and_return(webhook)
         end
 

--- a/spec/lib/pact_broker/api/resources/pacticipants_spec.rb
+++ b/spec/lib/pact_broker/api/resources/pacticipants_spec.rb
@@ -57,7 +57,7 @@ module PactBroker
           before do
             allow(PactBroker::Pacticipants::Service).to receive(:create).and_return(created_model)
             allow(decorator_class).to receive(:new).and_return(decorator)
-            allow(schema).to receive(:call).and_return(errors)
+            allow(schema).to receive(:call).and_return(double("result", errors: errors))
           end
 
           subject { post "/pacticipants", request_body, "CONTENT_TYPE" => "application/json" }

--- a/spec/lib/pact_broker/api/resources/verifications_spec.rb
+++ b/spec/lib/pact_broker/api/resources/verifications_spec.rb
@@ -23,7 +23,7 @@ module PactBroker
           before do
             allow_any_instance_of(Verifications).to receive(:handle_webhook_events) { |&block| block.call }
             allow(PactBroker::Verifications::Service).to receive(:create).and_return(verification)
-            allow(PactBroker::Api::Contracts::VerificationContract).to receive(:call).and_return(errors)
+            allow(PactBroker::Api::Contracts::VerificationContract).to receive(:call).and_return(double("result", errors: errors))
             allow(PactBrokerUrls).to receive(:decode_pact_metadata).and_return(parsed_metadata)
           end
 

--- a/spec/lib/pact_broker/api/resources/webhook_spec.rb
+++ b/spec/lib/pact_broker/api/resources/webhook_spec.rb
@@ -56,7 +56,7 @@ module PactBroker::Api
           allow(PactBroker::Webhooks::Service).to receive(:create).and_return(created_webhook)
           allow_any_instance_of(Webhook).to receive(:consumer).and_return(consumer)
           allow_any_instance_of(Webhook).to receive(:provider).and_return(provider)
-          allow(PactBroker::Api::Contracts::WebhookContract).to receive(:call).and_return(errors)
+          allow(PactBroker::Api::Contracts::WebhookContract).to receive(:call).and_return(double("result", errors: errors))
         end
 
 

--- a/spec/support/api_contract_support.rb
+++ b/spec/support/api_contract_support.rb
@@ -1,0 +1,13 @@
+require "pact_broker/api/contracts/dry_validation_errors_formatter"
+
+module PactBroker
+  module Test
+    module ApiContractSupport
+
+      # See lib/pact_broker/api/contracts/README.md
+      def format_errors_the_old_way(dry_validation_result)
+        PactBroker::Api::Contracts::DryValidationErrorsFormatter.format_errors(dry_validation_result.errors)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This refactor changes the validation contracts from returning a Hash to returning the Dry::Validation::Result.

The reason this is necessary is it makes it easier to render the validation errors as problem+json. 

The old way went Dry::Validation::MessageSet => hacky smush into custom format Hash => hacky smush into problem+json format. This can result in information loss in relation to the path of the errors. Also, the custom format Hash [only supports 1 array in the path](https://github.com/pact-foundation/pact_broker/blob/3b4b66b/lib/pact_broker/api/contracts/dry_validation_errors_formatter.rb#L16), and we need 2 levels of arrays for the new provider contracts all-in-one endpoint.

The new approach is to return the Dry::Validation::Result from the validation contracts, and then format the Dry::Validation::MessageSet using a decorator in the resource (like we do for normal domain object resources). This means we have a lossless translation from error messages into problem+json, and don't need to have custom code for the new provider contract endpoint.