### PR TITLE
feat: improve performance of matrix when multiple selectors are specified

### DIFF
--- a/lib/pact_broker/domain/version.rb
+++ b/lib/pact_broker/domain/version.rb
@@ -213,6 +213,7 @@ module PactBroker
         end
 
         # rubocop: disable Metrics/CyclomaticComplexity
+        # @param [PactBroker::Matrix::UnresolvedSelector] selector
         def for_selector(selector)
           query = self
           query = query.where_pacticipant_name(selector.pacticipant_name) if selector.pacticipant_name

--- a/lib/pact_broker/matrix/every_row.rb
+++ b/lib/pact_broker/matrix/every_row.rb
@@ -5,6 +5,21 @@ module PactBroker
     class EveryRow < PactBroker::Matrix::QuickRow
       set_dataset(Sequel.as(:pact_publications, :p))
 
+      class Verification < Sequel::Model(:verifications)
+        dataset_module do
+          select(:select_verification_columns, Sequel[:verifications][:id].as(:verification_id), :provider_version_id, Sequel[:verifications][:created_at].as(:provider_version_created_at), Sequel[:verifications][:pact_version_id])
+          select(:select_pact_version_id, Sequel[:verifications][:pact_version_id])
+
+          def select_distinct_pact_version_id
+            select_pact_version_id.distinct
+          end
+
+          def join_versions(versions_dataset)
+            join(versions_dataset, { Sequel[:verifications][:provider_version_id] => Sequel[:versions][:id] }, table_alias: :versions)
+          end
+        end
+      end
+
       P_V_JOIN = { Sequel[:p][:pact_version_id] => Sequel[:v][:pact_version_id] }
 
       PACT_COLUMNS = [
@@ -29,12 +44,18 @@ module PactBroker
       ALL_COLUMNS = PACT_COLUMNS + VERIFICATION_COLUMNS
 
       SELECT_ALL_COLUMN_ARGS = [:select_all_columns] + ALL_COLUMNS
+      SELECT_PACT_COLUMNS_ARGS = [:select_pact_columns] + PACT_COLUMNS
 
       dataset_module do
         select(*SELECT_ALL_COLUMN_ARGS)
+        select(*SELECT_PACT_COLUMNS_ARGS)
 
         def join_verifications
           left_outer_join(:verifications, P_V_JOIN, { table_alias: :v } )
+        end
+
+        def verification_model
+          EveryRow::Verification
         end
 
         def inner_join_verifications

--- a/lib/pact_broker/matrix/every_row.rb
+++ b/lib/pact_broker/matrix/every_row.rb
@@ -14,7 +14,7 @@ module PactBroker
             select_pact_version_id.distinct
           end
 
-          def join_versions(versions_dataset)
+          def join_versions_dataset(versions_dataset)
             join(versions_dataset, { Sequel[:verifications][:provider_version_id] => Sequel[:versions][:id] }, table_alias: :versions)
           end
         end
@@ -58,10 +58,7 @@ module PactBroker
           EveryRow::Verification
         end
 
-        def inner_join_verifications
-          join(:verifications, P_V_JOIN, { table_alias: :v } )
-        end
-
+        # TODO refactor this to get rid of QueryIds
         def inner_join_verifications_matching_one_selector_provider_or_provider_version(query_ids)
           verifications = db[:verifications]
             .select(*JOINED_VERIFICATION_COLUMNS)
@@ -70,17 +67,6 @@ module PactBroker
             }
 
           join(verifications, P_V_JOIN, { table_alias: :v } )
-        end
-
-        def verifications_for(query_ids)
-          db[:verifications]
-            .select(*JOINED_VERIFICATION_COLUMNS)
-            .where {
-              Sequel.&(
-                QueryBuilder.consumer_in_pacticipant_ids(query_ids),
-                QueryBuilder.provider_or_provider_version_matches(query_ids)
-              )
-            }
         end
       end
     end

--- a/lib/pact_broker/matrix/integrations_repository.rb
+++ b/lib/pact_broker/matrix/integrations_repository.rb
@@ -1,0 +1,122 @@
+# A "find only" repository for the PactBroker::Matrix::Integration object.
+# The PactBroker::Matrix::Integration object is not a Sequel Model like the PactBroker::Integrations::Integration - it is built from the
+# matrix data specifically for a given matrix query, and as well as the consumer/provider attributes, it also
+# knows whether or not that particular depdency is required in the context of the specific matrix query.
+# eg. a HTTP consumer will always require that a provider is deployed, but a provider can be deployed if the consumer does not exist
+# in the given environment yet.
+
+module PactBroker
+  module Matrix
+    class IntegrationsRepository
+
+      # This is parameterised to Pactflow can have its own base model
+      # @param [Class<QuickRow>] base_model_for_integrations
+      def initialize(base_model_for_integrations)
+        @base_model_for_integrations = base_model_for_integrations
+      end
+
+      # Find all the Integrations required for this query, using the options to determine whether to find
+      # the inferred integrations or not.
+      # @param [Array<PactBroker::Matrix::ResolvedSelector>] resolved_specified_selectors
+      # @param [Boolean] infer_selectors_for_integrations
+      # @return [Array<PactBroker::Matrix::Integration>]
+      def find_integrations_for_specified_selectors(resolved_specified_selectors, infer_selectors_for_integrations)
+        if infer_selectors_for_integrations
+          find_integrations_for_specified_selectors_with_inferred_integrations(resolved_specified_selectors)
+        else
+          find_integrations_for_specified_selectors_only(resolved_specified_selectors)
+        end
+      end
+
+      private
+
+      attr_reader :base_model_for_integrations
+
+      # Find the Integrations only for the selectors specifed in the query (don't infer any others)
+      # @param [Array<PactBroker::Matrix::ResolvedSelector>] resolved_specified_selectors
+      # @return [Array<PactBroker::Matrix::Integration>]
+      def find_integrations_for_specified_selectors_only(resolved_specified_selectors)
+        specified_pacticipant_names = resolved_specified_selectors.collect(&:pacticipant_name)
+        base_model_for_integrations
+          .distinct_integrations(resolved_specified_selectors)
+          .all
+          .collect(&:to_hash)
+          .collect do | integration_hash |
+            required = is_a_row_for_this_integration_required?(specified_pacticipant_names, integration_hash[:consumer_name])
+            Integration.from_hash(integration_hash.merge(required: required))
+          end
+      end
+
+      # Find the Integrations for the specified selectors and infer the other Integrations
+      # @param [Array<PactBroker::Matrix::ResolvedSelector>] resolved_specified_selectors
+      # @return [Array<PactBroker::Matrix::Integration>]
+      def find_integrations_for_specified_selectors_with_inferred_integrations(resolved_specified_selectors)
+        integrations = integrations_where_specified_selector_is_consumer(resolved_specified_selectors) +
+                        integrations_where_specified_selector_is_provider(resolved_specified_selectors)
+        deduplicate_integrations(integrations)
+      end
+
+      # Find all the providers for the consumers specified in the query. Takes into account the consumer versions specified in the query,
+      # not just the consumer names.
+      # @param [Array<PactBroker::Matrix::ResolvedSelector>] the resolved selectors that were specified in the query
+      # @return [Array<PactBroker::Matrix::Integration>]
+      def integrations_where_specified_selector_is_consumer(resolved_specified_selectors)
+        resolved_specified_selectors.flat_map do | selector |
+          # Could optimise this to all in one query, but it's a small gain
+          base_model_for_integrations
+            .distinct_integrations_for_selector_as_consumer(selector)
+            .all
+            .collect do | integration |
+              Integration.from_hash(
+                consumer_id: integration[:consumer_id],
+                consumer_name: integration[:consumer_name],
+                provider_id: integration[:provider_id],
+                provider_name: integration[:provider_name],
+                required: true # consumer requires the provider to be present
+              )
+            end
+        end
+      end
+
+      # Why does the consumer equivalent of this method use the QuickRow distinct_integrations_for_selector_as_consumer
+      # while this method uses the Integration?
+      # Find all the consumers for the providers specified in the query. Does not take into consideration the provider version (not sure why).
+      # @param [Array<PactBroker::Matrix::ResolvedSelector>] the resolved selectors that were specified in the query
+      # @return [Array<PactBroker::Matrix::Integration>]
+      def integrations_where_specified_selector_is_provider(resolved_specified_selectors)
+        integrations_involving_specified_providers = PactBroker::Integrations::Integration
+                                                      .where(provider_id: resolved_specified_selectors.collect(&:pacticipant_id))
+                                                      .eager(:consumer, :provider)
+                                                      .all
+
+        integrations_involving_specified_providers.collect do | integration |
+          Integration.from_hash(
+            consumer_id: integration.consumer.id,
+            consumer_name: integration.consumer.name,
+            provider_id: integration.provider.id,
+            provider_name: integration.provider.name,
+            required: false # provider does not require the consumer to be present
+          )
+        end
+      end
+
+      # Deduplicate a list of Integrations
+      # @param [Array<PactBroker::Matrix::Integration>] integrations
+      # @return [Array<PactBroker::Matrix::Integration>]
+      def deduplicate_integrations(integrations)
+        integrations
+          .group_by{ | integration| [integration.consumer_id, integration.provider_id] }
+          .values
+          .collect { | duplicate_integrations | duplicate_integrations.find(&:required?) || duplicate_integrations.first }
+      end
+
+      # If a specified pacticipant is a consumer, then its provider is required to be deployed
+      # to the same environment before the consumer can be deployed.
+      # If a specified pacticipant is a provider only, then it may be deployed
+      # without the consumer being present, but cannot break an existing consumer.
+      def is_a_row_for_this_integration_required?(specified_pacticipant_names, consumer_name)
+        specified_pacticipant_names.include?(consumer_name)
+      end
+    end
+  end
+end

--- a/lib/pact_broker/matrix/integrations_repository.rb
+++ b/lib/pact_broker/matrix/integrations_repository.rb
@@ -64,7 +64,7 @@ module PactBroker
         resolved_specified_selectors.flat_map do | selector |
           # Could optimise this to all in one query, but it's a small gain
           base_model_for_integrations
-            .distinct_integrations_for_selector_as_consumer(selector)
+            .integrations_for_selector_as_consumer(selector)
             .all
             .collect do | integration |
               Integration.from_hash(
@@ -78,7 +78,7 @@ module PactBroker
         end
       end
 
-      # Why does the consumer equivalent of this method use the QuickRow distinct_integrations_for_selector_as_consumer
+      # Why does the consumer equivalent of this method use the QuickRow integrations_for_selector_as_consumer
       # while this method uses the Integration?
       # Find all the consumers for the providers specified in the query. Does not take into consideration the provider version (not sure why).
       # @param [Array<PactBroker::Matrix::ResolvedSelector>] the resolved selectors that were specified in the query

--- a/lib/pact_broker/matrix/query_builder.rb
+++ b/lib/pact_broker/matrix/query_builder.rb
@@ -46,11 +46,11 @@ module PactBroker
         Sequel.|(*ors)
       end
 
-      # Some selecters are specified in the query, others are implied (when only one pacticipant is specified,
-      # the integrations are automatically worked out, and the selectors for these are of type :implied )
+      # Some selecters are specified in the query, others are inferred (when only one pacticipant is specified,
+      # the integrations are automatically worked out, and the selectors for these are of type :inferred )
       # When there are 3 pacticipants that each have dependencies on each other (A->B, A->C, B->C), the query
-      # to deploy C (implied A, implied B, specified C) was returning the A->B row because it matched the
-      # implied selectors as well.
+      # to deploy C (inferred A, inferred B, specified C) was returning the A->B row because it matched the
+      # inferred selectors as well.
       # This extra filter makes sure that every row that is returned actually matches one of the specified
       # selectors.
       def self.either_consumer_or_provider_was_specified_in_query(query_ids, qualifier = nil)

--- a/lib/pact_broker/matrix/query_ids.rb
+++ b/lib/pact_broker/matrix/query_ids.rb
@@ -1,3 +1,5 @@
+# This is left over from the old way of querying the matrix, and should eventually be deleted entirely
+
 module PactBroker
   module Matrix
     class QueryIds
@@ -26,14 +28,6 @@ module PactBroker
 
       def self.collect_ids(hashes, key)
         hashes.collect{ |s| s[key] }.flatten.compact
-      end
-
-      def pacticipant_id
-        pacticipant_ids.first
-      end
-
-      def pacticipant_version_id
-        pacticipant_version_ids.first
       end
     end
   end

--- a/lib/pact_broker/matrix/quick_row.rb
+++ b/lib/pact_broker/matrix/quick_row.rb
@@ -206,6 +206,7 @@ module PactBroker
           rows_where_selector_matches_consumer_cols.union(rows_where_selector_matches_provider_cols)
         end
 
+
         # When the user has specified multiple selectors, we only want to join the verifications for
         # the specified selectors. This is because of the behaviour of the left outer join.
         # Imagine a pact has been verified by a provider version that was NOT specified in the selectors.
@@ -215,6 +216,7 @@ module PactBroker
         # Instead, we need to filter the verifications dataset down to only the ones specified in the selectors first,
         # and THEN join them to the pacts, so that we get a row for the pact with null provider version
         # and verification fields.
+        # IDEA FOR OPTIMISATION - would it work to limit the pact_publications query and the verifications query to the limit of the overall query?
         # @param [Array<PactBroker::Matrix::ResolvedSelector>] selectors
         # @param [Symbol] pact_columns the method to call on the QuickRow/EveryRow model to get the right columns required for the particular query
         # @param [Symbol] verifications_columns the method to call on the QuickRow::Verifications/EveryRow::Verifications model to get the right columns required for the particular query

--- a/lib/pact_broker/matrix/repository.rb
+++ b/lib/pact_broker/matrix/repository.rb
@@ -195,7 +195,8 @@ module PactBroker
       # rubocop: enable Metrics/CyclomaticComplexity
 
       def query_matrix selectors, options
-        query = base_model(options).select_all_columns
+        query = base_model(options)
+                  #.select_all_columns
                   .matching_selectors(selectors)
                   .order_by_last_action_date
 

--- a/lib/pact_broker/matrix/resolved_selector.rb
+++ b/lib/pact_broker/matrix/resolved_selector.rb
@@ -187,6 +187,10 @@ module PactBroker
         !ignore?
       end
 
+      def original_selector
+        self[:original_selector]
+      end
+
       # rubocop: disable Metrics/CyclomaticComplexity, Metrics/MethodLength
       def description
         if latest_tagged? && pacticipant_version_number

--- a/lib/pact_broker/matrix/resolved_selector.rb
+++ b/lib/pact_broker/matrix/resolved_selector.rb
@@ -4,7 +4,9 @@ require "pact_broker/hash_refinements"
 # This is created from either specified or inferred data, based on the user's query
 # eg.
 # can-i-deploy --pacticipant Foo --version 1 (this is a specified selector)
-#              --to prod (this is used to create inferred selectors)
+#              --to prod (this is used to create inferred selectors, one for each integrated pacticipant in that environment)
+# When an UnresolvedSelector specifies multiple application versions (eg. { tag: "prod" }) then a ResolvedSelector
+# is created for every Version object found for the original selector.
 
 module PactBroker
   module Matrix

--- a/lib/pact_broker/matrix/resolved_selector_builder.rb
+++ b/lib/pact_broker/matrix/resolved_selector_builder.rb
@@ -34,6 +34,10 @@ module PactBroker
 
       # When a single selector specifies multiple versions (eg. "all prod pacts"), this expands
       # the single selector into one selector for each version.
+      # When a pacticipant is found, but there are no versions matching the selector,
+      # the versions array will be have a single item which is nil (`[nil]`).
+      # See PactBroker::Matrix::SelectorResolver#find_versions_for_selector
+      # There may be a better way to pass in this information.
       def build_resolved_selectors_for_versions(pacticipant, versions, unresolved_selector, selector_type)
         one_of_many = versions.compact.size > 1
         versions.collect do | version |
@@ -62,8 +66,6 @@ module PactBroker
       end
 
       def selector_for_all_versions_of_a_pacticipant(pacticipant, unresolved_selector, selector_type)
-        # Doesn't make sense to ignore this, as you can't have a can-i-deploy query
-        # for "all versions of a pacticipant". But whatever.
         ResolvedSelector.for_pacticipant(
           pacticipant,
           unresolved_selector,

--- a/lib/pact_broker/matrix/resolved_selector_builder.rb
+++ b/lib/pact_broker/matrix/resolved_selector_builder.rb
@@ -1,0 +1,84 @@
+# Builds a PactBroker::Matrix::UnresolvedSelector based on the given
+# UnresolvedSelector, selector type, Pacticipant and Version objects,
+# using the selector_ignorer to work out if the built ResolvedSelector
+# should be marked as ignored or not.
+
+module PactBroker
+  module Matrix
+    class ResolvedSelectorBuilder
+
+      attr_accessor :pacticipant, :versions
+
+      # @param [PactBroker::Matrix::UnresolvedSelector] unresolved_selector
+      # @param [Symbol] selector_type :specified or :inferred
+      # @param [PactBroker::Matrix::Ignorer] selector_ignorer
+      def initialize(unresolved_selector, selector_type, selector_ignorer)
+        @unresolved_selector = unresolved_selector
+        @selector_type = selector_type
+        @selector_ignorer = selector_ignorer
+      end
+
+      def build
+        if pacticipant && versions
+          build_resolved_selectors_for_versions(pacticipant, versions, unresolved_selector, selector_type)
+        elsif pacticipant
+          selector_for_all_versions_of_a_pacticipant(pacticipant, unresolved_selector, selector_type)
+        else
+          build_selector_for_non_existing_pacticipant(unresolved_selector, selector_type)
+        end
+      end
+
+      private
+
+      attr_reader :unresolved_selector, :selector_type, :selector_ignorer
+
+      # When a single selector specifies multiple versions (eg. "all prod pacts"), this expands
+      # the single selector into one selector for each version.
+      def build_resolved_selectors_for_versions(pacticipant, versions, unresolved_selector, selector_type)
+        one_of_many = versions.compact.size > 1
+        versions.collect do | version |
+          if version
+            selector_for_found_version(pacticipant, version, unresolved_selector, selector_type, one_of_many)
+          else
+            selector_for_non_existing_version(pacticipant, unresolved_selector, selector_type)
+          end
+        end
+      end
+
+      def selector_for_non_existing_version(pacticipant, unresolved_selector, selector_type)
+        ignore = selector_ignorer.ignore_pacticipant?(pacticipant)
+        ResolvedSelector.for_pacticipant_and_non_existing_version(pacticipant, unresolved_selector, selector_type, ignore)
+      end
+
+      # rubocop: disable Metrics/ParameterLists
+      def selector_for_found_version(pacticipant, version, unresolved_selector, selector_type, one_of_many)
+        ResolvedSelector.for_pacticipant_and_version(
+          pacticipant,
+          version,
+          unresolved_selector,
+          selector_type,
+          selector_ignorer.ignore_pacticipant_version?(pacticipant, version),
+          one_of_many
+        )
+      end
+      # rubocop: enable Metrics/ParameterLists
+
+      def selector_for_all_versions_of_a_pacticipant(pacticipant, unresolved_selector, selector_type)
+        # Doesn't make sense to ignore this, as you can't have a can-i-deploy query
+        # for "all versions of a pacticipant". But whatever.
+        ResolvedSelector.for_pacticipant(
+          pacticipant,
+          unresolved_selector,
+          selector_type,
+          selector_ignorer.ignore_pacticipant?(pacticipant)
+        )
+      end
+
+      # only relevant for ignore selectors, validation stops this happening for the normal
+      # selectors
+      def build_selector_for_non_existing_pacticipant(unresolved_selector, selector_type)
+        ResolvedSelector.for_non_existing_pacticipant(unresolved_selector, selector_type, false)
+      end
+    end
+  end
+end

--- a/lib/pact_broker/matrix/resolved_selector_builder.rb
+++ b/lib/pact_broker/matrix/resolved_selector_builder.rb
@@ -50,7 +50,6 @@ module PactBroker
         ResolvedSelector.for_pacticipant_and_non_existing_version(pacticipant, unresolved_selector, selector_type, ignore)
       end
 
-      # rubocop: disable Metrics/ParameterLists
       def selector_for_found_version(pacticipant, version, unresolved_selector, selector_type, one_of_many)
         ResolvedSelector.for_pacticipant_and_version(
           pacticipant,
@@ -61,7 +60,6 @@ module PactBroker
           one_of_many
         )
       end
-      # rubocop: enable Metrics/ParameterLists
 
       def selector_for_all_versions_of_a_pacticipant(pacticipant, unresolved_selector, selector_type)
         # Doesn't make sense to ignore this, as you can't have a can-i-deploy query

--- a/lib/pact_broker/matrix/resolved_selectors_builder.rb
+++ b/lib/pact_broker/matrix/resolved_selectors_builder.rb
@@ -1,0 +1,39 @@
+require "pact_broker/matrix/selector_resolver"
+
+# Builds the array of ResolvedSelector objects using the
+# ignore selectors, the specified selectors, and the inferred integrations.
+
+module PactBroker
+  module Matrix
+    class ResolvedSelectorsBuilder
+      attr_reader :ignore_selectors, :specified_selectors, :inferred_selectors
+
+      def initialize
+        @inferred_selectors = []
+      end
+
+      # @param [Array<PactBroker::Matrix::UnresolvedSelector>]
+      # @param [Hash] options
+      def resolve_selectors(unresolved_specified_selectors, unresolved_ignore_selectors)
+        # must do this first because we need the ignore selectors to resolve the specified selectors
+        @ignore_selectors = SelectorResolver.resolved_ignore_selectors(unresolved_ignore_selectors)
+        @specified_selectors = SelectorResolver.resolve_specified_selectors(unresolved_specified_selectors, ignore_selectors)
+      end
+
+      # Use the given Integrations to work out what the selectors are for the versions that the versions for the specified
+      # selectors should be deployed with.
+      # eg. For `can-i-deploy --pacticipant Foo --version adfjkwejr --to-environment prod`, work out the selectors for the integrated application
+      # versions in the prod environment.
+      # @param [Array<PactBroker::Matrix::Integration>] integrations
+      def resolve_inferred_selectors(integrations, options)
+        @inferred_selectors = SelectorResolver.resolve_inferred_selectors(specified_selectors, ignore_selectors, integrations, options)
+      end
+
+      # All the resolved selectors to be used in the matrix query, specified and inferred (if any)
+      # @return [Array<PactBroker::Matrix::ResolvedSelector>]
+      def all_selectors
+        specified_selectors + inferred_selectors
+      end
+    end
+  end
+end

--- a/lib/pact_broker/matrix/row_ignorer.rb
+++ b/lib/pact_broker/matrix/row_ignorer.rb
@@ -1,0 +1,36 @@
+module PactBroker
+  module Matrix
+    class RowIgnorer
+
+      class << self
+        # Splits the matrix rows into considered rows and ignored rows, based on the
+        # ignore selectors specified by the user in the can-i-deploy command (eg. --ignore SomeProviderThatIsNotReadyYet).
+        # @param [Array<QuickRow, EveryRow>] rows
+        # @param [<PactBroker::Matrix::ResolvedSelector>] resolved_ignore_selectors
+        # @return [Array<QuickRow, EveryRow>] considered_rows, [Array<QuickRow, EveryRow>] ignored_rows
+        def split_rows_into_considered_and_ignored(rows, resolved_ignore_selectors)
+          if resolved_ignore_selectors.any?
+            considered, ignored = [], []
+            rows.each do | row |
+              if ignore_row?(resolved_ignore_selectors, row)
+                ignored << row
+              else
+                considered << row
+              end
+            end
+            return considered, ignored
+          else
+            return rows, []
+          end
+        end
+
+        def ignore_row?(resolved_ignore_selectors, row)
+          resolved_ignore_selectors.any? do | s |
+            s.pacticipant_id == row.consumer_id  && (s.only_pacticipant_name_specified? || s.pacticipant_version_id == row.consumer_version_id) ||
+              s.pacticipant_id == row.provider_id  && (s.only_pacticipant_name_specified? || s.pacticipant_version_id == row.provider_version_id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pact_broker/matrix/selector_ignorer.rb
+++ b/lib/pact_broker/matrix/selector_ignorer.rb
@@ -1,0 +1,59 @@
+# This class determines whether or not a resolved selector (both specified and inferred)
+# that is about to be created should be marked as "ignored".
+# It uses the ignore selectors are provided in the can-i-deploy CLI command like so:
+#   can-i-deploy --pacticipant Foo --version 234243 --to-environment prod --ignore SomeProviderThatIsNotReadyYet [--version SomeOptionalVersion]
+# The ignored flag on the ResolvedSelector is used to determine whether or not a failing/missing row
+# in the can-i-deploy matrix should be ignored.
+# This allows can-i-deploy to pass successfully when a dependency is known to be not ready,
+# but the developer wants to deploy the application anyway.
+
+# The only reason why we need to resolve the ignore selectors is that we check in PactBroker::Matrix::DeploymentStatusSummary
+# whether or not the pacticipant or version they specify actually exist.
+# We could actually have performed the ignore checks just using the name and version number.
+
+module PactBroker
+  module Matrix
+    class SelectorIgnorer
+
+      # @param [Array<PactBroker::Matrix::UnresolvedSelector>] resolved_ignore_selectors
+      def initialize(resolved_ignore_selectors)
+        @resolved_ignore_selectors = resolved_ignore_selectors
+      end
+
+      # Whether the pacticipant should be ignored if the verification results are missing/failed.
+      # @param [PactBroker::Domain::Pacticipant] pacticipant
+      # @return [Boolean]
+      def ignore_pacticipant?(pacticipant)
+        resolved_ignore_selectors.any? do | s |
+          s.pacticipant_id == pacticipant.id && s.only_pacticipant_name_specified?
+        end
+      end
+
+      # Whether the pacticipant version should be ignored if the verification results are missing/failed.
+      # @param [PactBroker::Domain::Pacticipant] pacticipant
+      # @param [PactBroker::Domain::Version] version
+      # @return [Boolean]
+      def ignore_pacticipant_version?(pacticipant, version)
+        resolved_ignore_selectors.any? do | s |
+          s.pacticipant_id == pacticipant.id && (s.only_pacticipant_name_specified? || s.pacticipant_version_id == version.id)
+        end
+      end
+
+      private
+
+      attr_reader :resolved_ignore_selectors
+    end
+
+    # Used when resolving the ignore selecors in the first place - the process for resolving normal selectors
+    # and ignore selectors is almost the same, but it makes no sense to ignore an ignore selector.
+    class NilSelectorIgnorer
+      def ignore_pacticipant?(*)
+        false
+      end
+
+      def ignore_pacticipant_version?(*)
+        false
+      end
+    end
+  end
+end

--- a/lib/pact_broker/matrix/selector_resolver.rb
+++ b/lib/pact_broker/matrix/selector_resolver.rb
@@ -1,0 +1,130 @@
+require "pact_broker/repositories"
+require "pact_broker/matrix/resolved_selector"
+require "pact_broker/matrix/resolved_selector_builder"
+require "pact_broker/matrix/selector_ignorer"
+
+
+# Take the selectors and options provided by the user (eg. [{ pacticipant_name: "Foo", pacticipant_version_number: "1" }], { to_environment: "prod" })
+# that use pacticipant/version/branch/environment names,
+# and look up the IDs of all the objects, and return them as ResolvedSelector objects.
+# For unresolved selectors that specify a collection of versions (eg. { branch: "main" }) a ResolvedSelector
+# will be returned for every pacticipant version found. This will eventually be used in the can-i-deploy
+# logic in PactBroker::Matrix::DeploymentStatusSummary to work out if there are any missing verifications.
+
+module PactBroker
+  module Matrix
+    class SelectorResolver
+      class << self
+        include PactBroker::Repositories
+
+        # Resolve any ignore selectors used in the can-i-deploy command e.g `--ignore SomeProviderThatIsNotReadyYet`
+        # @param [Array<PactBroker::Matrix::UnresolvedSelector>] unresolved_ignore_selectors
+        # @return [Array<PactBroker::Matrix::ResolvedSelector>]
+        def resolved_ignore_selectors(unresolved_ignore_selectors)
+          # When resolving the ignore_selectors, use the NilSelectorIgnorer because it doesn't make sense to ignore
+          # the ignore selectors.
+          resolve_versions_and_add_ids(unresolved_ignore_selectors, :ignored, NilSelectorIgnorer.new)
+        end
+
+        # Resolve the selectors that were specified in the can-i-deploy command eg. `--pacticipant Foo --version 43434`
+        # There may be one or multiple.
+        # @param [Array<PactBroker::Matrix::UnresolvedSelector>] unresolved_specified_selectors
+        # @param [Array<PactBroker::Matrix::ResolvedSelector>] resolved_ignore_selectors previously resolved selectors for the versions to ignore
+        # @return [Array<PactBroker::Matrix::ResolvedSelector>]
+        def resolve_specified_selectors(unresolved_specified_selectors, resolved_ignore_selectors)
+          resolve_versions_and_add_ids(unresolved_specified_selectors, :specified, SelectorIgnorer.new(resolved_ignore_selectors))
+        end
+
+        # When the can-i-deploy command uses any of the `--to` options (eg. `--to-environment ENV` or `--to TAG`)
+        # we need to create the inferred selectors for the pacticipant versions in that environment/with that tag/branch.
+        # eg. if A -> B, and the CLI command is `can-i-deploy --pacticipant A --version 3434 --to-environment prod`,
+        # then we need to make the inferred selector for pacticipant B with the version that is in prod.
+        # @param [Array<PactBroker::Matrix::ResolvedSelector>] resolved_specified_selectors
+        # @param [Array<PactBroker::Matrix::ResolvedSelector>] resolved_ignore_selectors
+        # @param [Array<PactBroker::Matrix::Integration>] integrations
+        # @param [Hash] options
+        # @return [Array<PactBroker::Matrix::ResolvedSelector>]
+        def resolve_inferred_selectors(resolved_specified_selectors, resolved_ignore_selectors, integrations, options)
+          all_pacticipant_names = integrations.collect(&:pacticipant_names).flatten.uniq
+          specified_names = resolved_specified_selectors.collect{ |s| s[:pacticipant_name] }
+          inferred_pacticipant_names = all_pacticipant_names - specified_names
+          unresolved_selectors = build_unresolved_selectors_for_inferred_pacticipants(inferred_pacticipant_names, options)
+          resolve_versions_and_add_ids(unresolved_selectors, :inferred, SelectorIgnorer.new(resolved_ignore_selectors))
+        end
+
+        # Find the IDs of every pacticipant and version in the UnresolvedSelectors, and return them as ResolvedSelectors,
+        # expanding selectors for multiple versions.
+        # This gets called first for the ignore selectors, then the specified selectors, and then the inferred selectors.
+        # When it gets called for the first time for the ignore selectors, they will be passed in as the unresolved_selectors, and the resolved_ignore_selectors
+        # will be empty.
+        # The next times it is called with the specified selectors and the inferred selectors, the previously resolved ignore selectors will be passed in
+        # as resolved_ignore_selectors so we can work out which of those selectors needs to be ignored.
+        #
+        # @param [Array<PactBroker::Matrix::UnresolvedSelector>] unresolved_selectors
+        # @param [Symbol] selector_type which may be :specified or :inferred
+        # @param [SelectorIgnorer] selector_ignorer
+        # @return [Array<PactBroker::Matrix::ResolvedSelector>]
+        def resolve_versions_and_add_ids(unresolved_selectors, selector_type, selector_ignorer)
+          pacticipants_hash = find_pacticipants_for_selectors(unresolved_selectors)
+          unresolved_selectors.collect do | unresolved_selector |
+            build_selectors(pacticipants_hash, unresolved_selector, selector_type, selector_ignorer)
+          end.flatten
+        end
+
+        private :resolve_versions_and_add_ids
+
+        # Return a Hash of the pacticipant names used in the selectors, where the key is the name and the value is the pacticipant
+        # @return [Hash<String, PactBroker::Domain::Pacticipant>]
+        def find_pacticipants_for_selectors(unresolved_selectors)
+          names = unresolved_selectors.collect(&:pacticipant_name)
+          PactBroker::Domain::Pacticipant.where(name: names).all.group_by(&:name).transform_values(&:first)
+        end
+
+        private :find_pacticipants_for_selectors
+
+        def build_selectors(pacticipants_hash, unresolved_selector, selector_type, selector_ignorer)
+          selector_builder = ResolvedSelectorBuilder.new(unresolved_selector, selector_type, selector_ignorer)
+          selector_builder.pacticipant = pacticipants_hash[unresolved_selector.pacticipant_name]
+          if selector_builder.pacticipant
+            versions = find_versions_for_selector(unresolved_selector)
+            selector_builder.versions = versions
+          end
+          selector_builder.build
+        end
+
+        # Find the pacticipant versions for the unresolved selector.
+        # @param [PactBroker::Matrix::UnresolvedSelector] unresolved_selector
+        def find_versions_for_selector(unresolved_selector)
+          # For selectors that just set the pacticipant name, there's no need to resolve the version -
+          # only the pacticipant ID will be used in the query
+          return nil if unresolved_selector.all_for_pacticipant?
+          versions = version_repository.find_versions_for_selector(unresolved_selector)
+
+          if unresolved_selector.latest
+            [versions.first]
+          else
+            versions.empty? ? [nil] : versions
+          end
+        end
+
+        private :find_versions_for_selector
+
+        # Build an unresolved selector for the integrations that we have inferred for the target environment/branch/tag
+        # @param [Array<String>] inferred_pacticipant_names the names of the pacticipants that we have determined to be integrated with the versions for the specified selectors
+        def build_unresolved_selectors_for_inferred_pacticipants(inferred_pacticipant_names, options)
+          inferred_pacticipant_names.collect do | pacticipant_name |
+            selector = UnresolvedSelector.new(pacticipant_name: pacticipant_name)
+            selector.tag = options[:tag] if options[:tag]
+            selector.branch = options[:branch] if options[:branch]
+            selector.main_branch = options[:main_branch] if options[:main_branch]
+            selector.latest = options[:latest] if options[:latest]
+            selector.environment_name = options[:environment_name] if options[:environment_name]
+            selector
+          end
+        end
+
+        private :build_unresolved_selectors_for_inferred_pacticipants
+      end
+    end
+  end
+end

--- a/lib/pact_broker/repositories.rb
+++ b/lib/pact_broker/repositories.rb
@@ -55,6 +55,10 @@ module PactBroker
       get_repository(:integration_repository)
     end
 
+    def matrix_integration_repository
+      get_repository(:matrix_integration_repository)
+    end
+
     # rubocop: disable Metrics/MethodLength
     def register_default_repositories
       register_repository(:pacticipant_repository) do
@@ -104,6 +108,12 @@ module PactBroker
       register_repository(:integration_repository) do
         require "pact_broker/integrations/repository"
         PactBroker::Integrations::Repository.new
+      end
+
+      register_repository(:matrix_integration_repository) do
+        require "pact_broker/matrix/integrations_repository"
+        require "pact_broker/matrix/quick_row"
+        PactBroker::Matrix::IntegrationsRepository.new(PactBroker::Matrix::QuickRow)
       end
 
       # rubocop: enable Metrics/MethodLength

--- a/lib/pact_broker/test/test_data_builder.rb
+++ b/lib/pact_broker/test/test_data_builder.rb
@@ -386,6 +386,14 @@ module PactBroker
         self
       end
 
+      # @param [Hash] parameters
+      # @option parameters [String] :provider_version
+      # @option parameters [Array<String>] :tag_names
+      # @option parameters [String] :branch
+      # @option parameters [Boolean] :success
+      # @option parameters [Integer] :number
+      # @option parameters [Boolean] :wip
+      # @option parameters [Boolean] :test_results
       def create_verification parameters = {}
         # This should use the verification service. what a mess
         parameters.delete(:comment)

--- a/spec/lib/pact_broker/matrix/every_row_spec.rb
+++ b/spec/lib/pact_broker/matrix/every_row_spec.rb
@@ -19,11 +19,11 @@ module PactBroker
         end
 
         let(:selector_1) do
-          PactBroker::Matrix::ResolvedSelector.for_pacticipant(foo, {}, :specified, false)
+          PactBroker::Matrix::ResolvedSelector.for_pacticipant(foo, PactBroker::Matrix::UnresolvedSelector.new(pacticipant_name: "Foo"), :specified, false)
         end
 
         let(:selector_2) do
-          PactBroker::Matrix::ResolvedSelector.for_pacticipant(bar, {}, :specified, false)
+          PactBroker::Matrix::ResolvedSelector.for_pacticipant(bar, PactBroker::Matrix::UnresolvedSelector.new(pacticipant_name: "Bar"), :specified, false)
         end
 
         let(:selectors) { [selector_1, selector_2] }

--- a/spec/lib/pact_broker/matrix/every_row_spec.rb
+++ b/spec/lib/pact_broker/matrix/every_row_spec.rb
@@ -99,35 +99,6 @@ module PactBroker
           expect(subject.all?(&:has_verification?)).to be true
         end
       end
-
-      describe "join_verifications_for" do
-        before do
-          td.create_pact_with_verification("Foo", "1", "Bar", "2")
-            .create_provider("Wiffle")
-            .create_pact
-            .create_verification(provider_version: "5")
-        end
-
-        let(:query_ids) do
-          double("query_ids",
-            all_pacticipant_ids: [foo.id, bar.id],
-            pacticipant_version_ids: [],
-            pacticipant_ids: [foo.id, bar.id]
-          )
-        end
-
-        subject do
-          EveryRow
-            .select_all_columns
-            .join_verifications_for(query_ids)
-            .all
-        end
-
-        it "pre-filters the verifications before joining them" do
-          expect(subject.size).to eq 2
-          expect(subject.find{ |r| r.provider_id == wiffle.id && !r.has_verification? }).to_not be nil
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
This PR is practically un-reviewable, as I have re-written and refactored large chunks of the matrix code, for both performance and readability reasons. It had to be done however, and I'm pleased with the results.

Things worth noting:

## Performance optimisation

* To reproduce the performance issues we have in prod on my local machine, I had to use a postgres docker container with `--cpu-period=100000 --cpu-quota=50000`, because my dev machine has way more CPU than our prod database, and the queries would otherwise run practically instantaneously.
* For the very large tenant dataset that was causing us problems recently
  * calculating the integrations has been reduced from 26 seconds to a few hundred milliseconds
  * performing the actual matrix query has been reduced from 26 seconds to 4 seconds
  * the overall time has been reduced from almost a minute to 5 seconds
  * there may be further possibility for optimisation, but it will be diminishing returns

## Refactoring

* The very large PactBroker::Matrix::Repository class has had its logic split up into a bunch of smaller, single purpose classes that are hopefully much more understandable.
* Despite the large number of production code changes, there was only one change required in in the test code, and the matrix query code is the most thoroughly tested piece of code in the project, so I'm as confident as I can be that I have not introduced any bugs.