### PR TITLE
feat: suppport `page` + `size` as pagination params

### DIFF
--- a/lib/pact_broker/api/contracts/pagination_query_params_schema.rb
+++ b/lib/pact_broker/api/contracts/pagination_query_params_schema.rb
@@ -5,8 +5,13 @@ module PactBroker
     module Contracts
       class PaginationQueryParamsSchema < BaseContract
         params do
+          # legacy format
           optional(:pageNumber).maybe(:integer).value(gteq?: 1)
           optional(:pageSize).maybe(:integer).value(gteq?: 1)
+
+          # desired format
+          optional(:page).maybe(:integer).value(gteq?: 1)
+          optional(:size).maybe(:integer).value(gteq?: 1)
         end
       end
     end

--- a/lib/pact_broker/api/decorators/branch_decorator.rb
+++ b/lib/pact_broker/api/decorators/branch_decorator.rb
@@ -18,7 +18,7 @@ module PactBroker
         link "pb:latest-version" do | user_options |
           {
             title: "Latest version for branch",
-            href: branch_versions_url(represented, user_options.fetch(:base_url)) + "?pageSize=1"
+            href: branch_versions_url(represented, user_options.fetch(:base_url)) + "?size=1"
           }
         end
 

--- a/lib/pact_broker/api/decorators/pagination_links.rb
+++ b/lib/pact_broker/api/decorators/pagination_links.rb
@@ -24,7 +24,7 @@ module PactBroker
               represented.respond_to?(:page_count) &&
               represented.current_page < represented.page_count
             {
-              href: context[:resource_url] + "?pageSize=#{represented.page_size}&pageNumber=#{represented.current_page + 1}",
+              href: context[:resource_url] + "?size=#{represented.page_size}&page=#{represented.current_page + 1}",
               title: "Next page"
             }
 
@@ -34,7 +34,7 @@ module PactBroker
         link :previous do | context |
           if represented.respond_to?(:first_page?) && !represented.first_page?
             {
-              href: context[:resource_url] + "?pageSize=#{represented.page_size}&pageNumber=#{represented.current_page - 1}",
+              href: context[:resource_url] + "?size=#{represented.page_size}&page=#{represented.current_page - 1}",
               title: "Previous page"
             }
           end

--- a/lib/pact_broker/api/resources/pagination_methods.rb
+++ b/lib/pact_broker/api/resources/pagination_methods.rb
@@ -2,6 +2,7 @@ module PactBroker
   module Api
     module Resources
       module PaginationMethods
+        # rubocop: disable Metrics/CyclomaticComplexity
         def pagination_options
           if request.query["page"] || request.query["size"]
             {

--- a/lib/pact_broker/api/resources/pagination_methods.rb
+++ b/lib/pact_broker/api/resources/pagination_methods.rb
@@ -3,7 +3,12 @@ module PactBroker
     module Resources
       module PaginationMethods
         def pagination_options
-          if request.query["pageNumber"] || request.query["pageSize"]
+          if request.query["page"] || request.query["size"]
+            {
+              page_number: request.query["page"]&.to_i || 1,
+              page_size: request.query["size"]&.to_i || 100
+            }
+          elsif request.query["pageNumber"] || request.query["pageSize"]
             {
               page_number: request.query["pageNumber"]&.to_i || 1,
               page_size: request.query["pageSize"]&.to_i || 100

--- a/spec/features/get_branch_versions_spec.rb
+++ b/spec/features/get_branch_versions_spec.rb
@@ -27,9 +27,9 @@ describe "Get a branch version" do
   end
 
   context "with pagination options" do
-    subject { get(path, { "pageSize" => "2", "pageNumber" => "1" }) }
+    subject { get(path, { "size" => "2", "page" => "1" }) }
 
-    it "only returns the number of items specified in the pageSize" do
+    it "only returns the number of items specified in the size" do
       expect(JSON.parse(subject.body).dig("_embedded", "versions").size).to eq 2
     end
 

--- a/spec/features/get_integrations_spec.rb
+++ b/spec/features/get_integrations_spec.rb
@@ -23,7 +23,7 @@ describe "Get integrations" do
   end
 
   context "with pagination options" do
-    let(:query) { { "pageSize" => "2", "pageNumber" => "1" } }
+    let(:query) { { "size" => "2", "page" => "1" } }
 
     it_behaves_like "a paginated response"
   end

--- a/spec/features/get_pacticipant_branches_spec.rb
+++ b/spec/features/get_pacticipant_branches_spec.rb
@@ -21,9 +21,9 @@ describe "Get pacticipant branches" do
   it_behaves_like "a page"
 
   context "with pagination options" do
-    subject { get(path, { "pageSize" => "2", "pageNumber" => "1" }) }
+    subject { get(path, { "size" => "2", "number" => "1" }) }
 
-    it "only returns the number of items specified in the pageSize" do
+    it "only returns the number of items specified in the size" do
       expect(response_body_hash[:_links][:"pb:branches"].size).to eq 2
     end
 

--- a/spec/features/get_pacticipants_spec.rb
+++ b/spec/features/get_pacticipants_spec.rb
@@ -23,9 +23,9 @@ describe "Get pacticipants" do
     end
 
     context "with pagination options" do
-      subject { get(path, { "pageSize" => "2", "pageNumber" => "1" }) }
+      subject { get(path, { "size" => "2", "page" => "1" }) }
 
-      it "only returns the number of items specified in the pageSize" do
+      it "only returns the number of items specified in the page" do
         expect(response_body_hash[:_links][:"pacticipants"].size).to eq 2
       end
 

--- a/spec/features/get_versions_spec.rb
+++ b/spec/features/get_versions_spec.rb
@@ -26,7 +26,7 @@ describe "Get versions" do
     end
 
     context "with pagination options" do
-      subject { get(path, { "pageSize" => "1", "pageNumber" => "1" }) }
+      subject { get(path, { "size" => "1", "page" => "1" }) }
 
       it "paginates the response" do
         expect(last_response_body[:_links][:"versions"].size).to eq 1

--- a/spec/fixtures/approvals/get_provider_pacts_for_verification.approved.json
+++ b/spec/fixtures/approvals/get_provider_pacts_for_verification.approved.json
@@ -38,7 +38,7 @@
             },
             "_links": {
               "self": {
-                "href": "http://example.org/pacts/provider/Provider/consumer/Consumer%202/pact-version/0f22f551a422b027066db7635cad8bd8a59ac869/metadata/c1tdW3RdPXByb2Qmc1tdW2xdPXRydWUmc1tdW2N2XT04",
+                "href": "http://example.org/pacts/provider/Provider/consumer/Consumer%202/pact-version/0f22f551a422b027066db7635cad8bd8a59ac869/metadata/c1tdW3RdPXByb2Qmc1tdW2xdPXRydWUmc1tdW2N2XT0y",
                 "name": "Pact between Consumer 2 (4.5.6) and Provider"
               }
             }

--- a/spec/fixtures/approvals/get_provider_pacts_for_verification.approved.json
+++ b/spec/fixtures/approvals/get_provider_pacts_for_verification.approved.json
@@ -38,7 +38,7 @@
             },
             "_links": {
               "self": {
-                "href": "http://example.org/pacts/provider/Provider/consumer/Consumer%202/pact-version/0f22f551a422b027066db7635cad8bd8a59ac869/metadata/c1tdW3RdPXByb2Qmc1tdW2xdPXRydWUmc1tdW2N2XT0y",
+                "href": "http://example.org/pacts/provider/Provider/consumer/Consumer%202/pact-version/0f22f551a422b027066db7635cad8bd8a59ac869/metadata/c1tdW3RdPXByb2Qmc1tdW2xdPXRydWUmc1tdW2N2XT04",
                 "name": "Pact between Consumer 2 (4.5.6) and Provider"
               }
             }

--- a/spec/fixtures/approvals/pacticipant_branches_decorator.approved.json
+++ b/spec/fixtures/approvals/pacticipant_branches_decorator.approved.json
@@ -11,7 +11,7 @@
           },
           "pb:latest-version": {
             "title": "Latest version for branch",
-            "href": "http://example.org/pacticipants/Foo/branches/main/versions?pageSize=1"
+            "href": "http://example.org/pacticipants/Foo/branches/main/versions?size=1"
           }
         }
       }

--- a/spec/lib/pact_broker/api/contracts/pagination_query_params_schema_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/pagination_query_params_schema_spec.rb
@@ -19,25 +19,51 @@ module PactBroker
         context "with values that are not numeric" do
           let(:params) do
             {
-              "pageNumber" => "a",
-              "pageSize" => "3.2"
+              "page" => "a",
+              "size" => "3.2"
             }
           end
 
-          its([:pageNumber]) { is_expected.to contain_exactly(match("integer"))}
-          its([:pageSize]) { is_expected.to contain_exactly(match("integer"))}
+          its([:page]) { is_expected.to contain_exactly(match("integer"))}
+          its([:size]) { is_expected.to contain_exactly(match("integer"))}
         end
 
         context "with values that are 0" do
           let(:params) do
             {
-              "pageNumber" => "-0",
-              "pageSize" => "-0"
+              "page" => "-0",
+              "size" => "-0"
             }
           end
 
-          its([:pageNumber]) { is_expected.to contain_exactly(match(/greater.*1/))}
-          its([:pageSize]) { is_expected.to contain_exactly(match(/greater.*1/))}
+          its([:page]) { is_expected.to contain_exactly(match(/greater.*1/))}
+          its([:size]) { is_expected.to contain_exactly(match(/greater.*1/))}
+        end
+
+        context "legacy format" do
+          context "with values that are not numeric" do
+            let(:params) do
+              {
+                "pageNumber" => "a",
+                "pageSize" => "3.2"
+              }
+            end
+
+            its([:pageNumber]) { is_expected.to contain_exactly(match("integer"))}
+            its([:pageSize]) { is_expected.to contain_exactly(match("integer"))}
+          end
+
+          context "with values that are 0" do
+            let(:params) do
+              {
+                "pageNumber" => "-0",
+                "pageSize" => "-0"
+              }
+            end
+
+            its([:pageNumber]) { is_expected.to contain_exactly(match(/greater.*1/))}
+            its([:pageSize]) { is_expected.to contain_exactly(match(/greater.*1/))}
+          end
         end
       end
     end

--- a/spec/lib/pact_broker/api/resources/dashboard_spec.rb
+++ b/spec/lib/pact_broker/api/resources/dashboard_spec.rb
@@ -24,7 +24,7 @@ module PactBroker
         end
 
         context "with pagination" do
-          subject { get(path, { pageNumber: 1, pageSize: 1 }) }
+          subject { get(path, { page: 1, size: 1 }) }
 
           it "only returns the items for the page" do
             expect(response_body_hash["items"].size).to eq 1
@@ -32,7 +32,7 @@ module PactBroker
         end
 
         context "with invalid pagination" do
-          subject { get(path, { pageNumber: -1, pageSize: -1 }) }
+          subject { get(path, { page: -1, size: -1 }) }
 
           it_behaves_like "an invalid pagination params response"
         end

--- a/spec/lib/pact_broker/api/resources/integrations_spec.rb
+++ b/spec/lib/pact_broker/api/resources/integrations_spec.rb
@@ -23,7 +23,7 @@ module PactBroker
           let(:errors) { {} }
 
           let(:path) { "/integrations" }
-          let(:params) { { "pageNumber" => "1", "pageSize" => "2" } }
+          let(:params) { { "page" => "1", "size" => "2" } }
 
           subject { get(path, params, rack_headers) }
 

--- a/spec/lib/pact_broker/api/resources/pacticipants_spec.rb
+++ b/spec/lib/pact_broker/api/resources/pacticipants_spec.rb
@@ -7,8 +7,8 @@ module PactBroker
         describe "GET" do
           let(:query) do
             {
-              "pageSize" => "10",
-              "pageNumber" => "1",
+              "size" => "10",
+              "page" => "1",
               "q" => "search"
             }
           end
@@ -44,8 +44,8 @@ module PactBroker
           context "with invalid pagination params" do
             let(:query) do
               {
-                "pageSize" => "0",
-                "pageNumber" => "0",
+                "size" => "0",
+                "page" => "0",
               }
             end
 

--- a/spec/support/shared_examples_for_responses.rb
+++ b/spec/support/shared_examples_for_responses.rb
@@ -45,8 +45,8 @@ shared_examples_for "an invalid pagination params response" do
   end
 
   it "includes the parameter validation errors" do
-    expect(response_body_hash[:errors].has_key?(:pageNumber)).to be_truthy
-    expect(response_body_hash[:errors].has_key?(:pageSize)).to be_truthy
+    expect(response_body_hash[:errors].has_key?(:page)).to be_truthy
+    expect(response_body_hash[:errors].has_key?(:size)).to be_truthy
   end
 end
 


### PR DESCRIPTION
Pagination URL params can now be specified with `page` and `size`, while preserving the older method of `pageNumber` and `pageSize`