### PR TITLE
chore: remove redundant embedded objects from deployed and released versions resources

### DIFF
--- a/lib/pact_broker/api/decorators/deployed_versions_decorator.rb
+++ b/lib/pact_broker/api/decorators/deployed_versions_decorator.rb
@@ -1,11 +1,11 @@
 require "pact_broker/api/decorators/base_decorator"
-require "pact_broker/api/decorators/deployed_version_decorator"
+require "pact_broker/api/decorators/embedded_deployed_version_decorator"
 
 module PactBroker
   module Api
     module Decorators
       class DeployedVersionsDecorator < BaseDecorator
-        collection :entries, as: :deployedVersions, embedded: true, :extend => PactBroker::Api::Decorators::DeployedVersionDecorator
+        collection :entries, as: :deployedVersions, embedded: true, :extend => PactBroker::Api::Decorators::EmbeddedDeployedVersionDecorator
 
         link :self do | context |
           href = append_query_if_present(context[:resource_url], context[:query_string])

--- a/lib/pact_broker/api/decorators/embedded_deployed_version_decorator.rb
+++ b/lib/pact_broker/api/decorators/embedded_deployed_version_decorator.rb
@@ -1,0 +1,29 @@
+require "pact_broker/api/decorators/base_decorator"
+require "pact_broker/api/decorators/embedded_pacticipant_decorator"
+require "pact_broker/api/decorators/embedded_version_decorator"
+require "pact_broker/api/decorators/environment_decorator"
+
+module PactBroker
+  module Api
+    module Decorators
+      class EmbeddedDeployedVersionDecorator < BaseDecorator
+        property :uuid
+        property :currently_deployed, camelize: true
+        property :applicationInstance, getter: lambda { |_| target }
+        property :undeployedAt, getter: lambda { |_|  undeployed_at ? FormatDateTime.call(undeployed_at) : nil }, writeable: false
+
+        property :pacticipant, :extend => EmbeddedPacticipantDecorator, writeable: false, embedded: true, if: -> (user_options:, **_other) { user_options[:expand]&.include?(:pacticipant) }
+        property :version,     :extend => EmbeddedVersionDecorator,     writeable: false, embedded: true, if: -> (user_options:, **_other) { user_options[:expand]&.include?(:version) }
+        property :environment, :extend => EnvironmentDecorator,         writeable: false, embedded: true, if: -> (user_options:, **_other) { user_options[:expand]&.include?(:environment) }
+
+        include Timestamps
+
+        link :self do | user_options |
+          {
+            href: deployed_version_url(represented, user_options.fetch(:base_url))
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/pact_broker/api/decorators/embedded_deployed_version_decorator.rb
+++ b/lib/pact_broker/api/decorators/embedded_deployed_version_decorator.rb
@@ -9,6 +9,7 @@ module PactBroker
       class EmbeddedDeployedVersionDecorator < BaseDecorator
         property :uuid
         property :currently_deployed, camelize: true
+        property :target, camelize: true # deprecated
         property :applicationInstance, getter: lambda { |_| target }
         property :undeployedAt, getter: lambda { |_|  undeployed_at ? FormatDateTime.call(undeployed_at) : nil }, writeable: false
 

--- a/lib/pact_broker/api/decorators/embedded_released_version_decorator.rb
+++ b/lib/pact_broker/api/decorators/embedded_released_version_decorator.rb
@@ -1,0 +1,27 @@
+require "pact_broker/api/decorators/base_decorator"
+require "pact_broker/api/decorators/embedded_pacticipant_decorator"
+require "pact_broker/api/decorators/embedded_version_decorator"
+require "pact_broker/api/decorators/environment_decorator"
+
+module PactBroker
+  module Api
+    module Decorators
+      class EmbeddedReleasedVersionDecorator < BaseDecorator
+        property :uuid
+        property :currently_supported, camelize: true
+        include Timestamps
+        property :supportEndedAt, getter: lambda { |_|  support_ended_at ? FormatDateTime.call(support_ended_at) : nil }, writeable: false
+
+        property :pacticipant, :extend => EmbeddedPacticipantDecorator, writeable: false, embedded: true, if: -> (user_options:, **_other) { user_options[:expand]&.include?(:pacticipant) }
+        property :version,     :extend => EmbeddedVersionDecorator,     writeable: false, embedded: true, if: -> (user_options:, **_other) { user_options[:expand]&.include?(:version) }
+        property :environment, :extend => EnvironmentDecorator,         writeable: false, embedded: true, if: -> (user_options:, **_other) { user_options[:expand]&.include?(:environment) }
+
+        link :self do | user_options |
+          {
+            href: released_version_url(represented, user_options.fetch(:base_url))
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/pact_broker/api/decorators/released_versions_decorator.rb
+++ b/lib/pact_broker/api/decorators/released_versions_decorator.rb
@@ -1,11 +1,11 @@
 require "pact_broker/api/decorators/base_decorator"
-require "pact_broker/api/decorators/released_version_decorator"
+require "pact_broker/api/decorators/embedded_released_version_decorator"
 
 module PactBroker
   module Api
     module Decorators
       class ReleasedVersionsDecorator < BaseDecorator
-        collection :entries, as: :releasedVersions, embedded: true, :extend => PactBroker::Api::Decorators::ReleasedVersionDecorator
+        collection :entries, as: :releasedVersions, embedded: true, :extend => PactBroker::Api::Decorators::EmbeddedReleasedVersionDecorator
 
         link :self do | context |
           href = append_query_if_present(context[:resource_url], context[:query_string])

--- a/lib/pact_broker/api/resources/currently_deployed_versions_for_environment.rb
+++ b/lib/pact_broker/api/resources/currently_deployed_versions_for_environment.rb
@@ -21,7 +21,7 @@ module PactBroker
         end
 
         def to_json
-          decorator_class(decorator_name).new(deployed_versions).to_json(**decorator_options(title: title))
+          decorator_class(decorator_name).new(deployed_versions).to_json(**decorator_options(title: title, expand: [:pacticipant, :version]))
         end
 
         def policy_name

--- a/lib/pact_broker/api/resources/currently_supported_versions_for_environment.rb
+++ b/lib/pact_broker/api/resources/currently_supported_versions_for_environment.rb
@@ -21,7 +21,7 @@ module PactBroker
         end
 
         def to_json
-          decorator_class(decorator_name).new(released_versions).to_json(**decorator_options(title: title))
+          decorator_class(decorator_name).new(released_versions).to_json(**decorator_options(title: title, expand: [:pacticipant, :version]))
         end
 
         def policy_name

--- a/lib/pact_broker/api/resources/deployed_versions_for_version_and_environment.rb
+++ b/lib/pact_broker/api/resources/deployed_versions_for_version_and_environment.rb
@@ -78,7 +78,7 @@ module PactBroker
         end
 
         def title
-          "Deployed versions for #{pacticipant_name} version #{pacticipant_version_number}"
+          "Deployed versions for #{pacticipant_name} version #{pacticipant_version_number} in environment #{environment.display_name}"
         end
       end
     end

--- a/spec/features/get_currently_deployed_versions_for_version_spec.rb
+++ b/spec/features/get_currently_deployed_versions_for_version_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Get currently deployed versions for version" do
   it "returns a list of deployed versions" do
     expect(response_body_hash[:_embedded][:deployedVersions]).to be_a(Array)
     expect(response_body_hash[:_embedded][:deployedVersions].size).to eq 1
-    expect(response_body_hash[:_links][:self][:title]).to eq "Deployed versions for Foo version 1"
+    expect(response_body_hash[:_links][:self][:title]).to eq "Deployed versions for Foo version 1 in environment Test"
     expect(response_body_hash[:_links][:self][:href]).to end_with(path)
   end
 end


### PR DESCRIPTION
Before we document this endpoint, I want to remove the embedded objects that are redundant in the deployed/released versions collection endpoints. Technically, this is a breaking change, but I know that none of our UI/client tools use those properties, and I'd rather remove them now before people start using it.