### PR TITLE
fix: raise 404 on paths with missing path segments

### DIFF
--- a/lib/pact_broker/app.rb
+++ b/lib/pact_broker/app.rb
@@ -180,6 +180,7 @@ module PactBroker
       @app_builder.use PactBroker::Api::Middleware::HttpDebugLogs if configuration.http_debug_logging_enabled
       configure_basic_auth
       configure_rack_protection
+      @app_builder.use Rack::PactBroker::ApplicationContext, application_context
       @app_builder.use Rack::PactBroker::InvalidUriProtection
       @app_builder.use Rack::PactBroker::ResetThreadData
       @app_builder.use Rack::PactBroker::AddPactBrokerVersionHeader
@@ -189,7 +190,6 @@ module PactBroker
       @app_builder.use Rack::PactBroker::ConvertFileExtensionToAcceptHeader
       # Rack::PactBroker::SetBaseUrl needs to be before the Rack::PactBroker::HalBrowserRedirect
       @app_builder.use Rack::PactBroker::SetBaseUrl, configuration.base_urls
-      @app_builder.use Rack::PactBroker::ApplicationContext, application_context
 
       if configuration.use_hal_browser
         logger.info "Mounting HAL browser"

--- a/lib/rack/pact_broker/invalid_uri_protection.rb
+++ b/lib/rack/pact_broker/invalid_uri_protection.rb
@@ -12,6 +12,8 @@ module Rack
     class InvalidUriProtection
       include ::PactBroker::Messages
 
+      CONSECUTIVE_SLASH = /\/{2,}/
+
       def initialize app
         @app = app
       end
@@ -34,7 +36,9 @@ module Rack
 
       def valid_uri? env
         begin
-          parse(::Rack::Request.new(env).url)
+          uri = parse(::Rack::Request.new(env).url)
+          return nil if CONSECUTIVE_SLASH.match(uri.path)
+          uri
         rescue URI::InvalidURIError, ArgumentError
           nil
         end

--- a/lib/rack/pact_broker/invalid_uri_protection.rb
+++ b/lib/rack/pact_broker/invalid_uri_protection.rb
@@ -21,12 +21,12 @@ module Rack
       def call env
         if (uri = valid_uri?(env))
           if (error_message = validate(uri))
-            [422, headers, [body(env, error_message, "Unprocessable", "validation-errors", 422)]]
+            [422, headers, [body(env, error_message, "Unprocessable", "invalid-request-parameter-value", 422)]]
           else
             app.call(env)
           end
         else
-          [404, headers, [body(env, "Invalid Path", "Not Found", "not-found", 404)]]
+          [404, headers, [body(env, "Empty path component found", "Not Found", "not-found", 404)]]
         end
       end
 

--- a/spec/lib/rack/pact_broker/invalid_uri_protection_spec.rb
+++ b/spec/lib/rack/pact_broker/invalid_uri_protection_spec.rb
@@ -27,6 +27,14 @@ module Rack
           expect(subject.status).to eq 200
         end
 
+        context "when the path contains missing path segments" do
+          let(:path) { "/foo//bar" }
+
+          it "returns a 404" do
+            expect(subject.status).to eq 404
+          end
+        end
+
         context "when the URI contains a new line because someone forgot to strip the result of `git rev-parse HEAD`, and I have totally never done this before myself" do
           let(:path) { "/foo%0A/bar" }
 

--- a/spec/lib/rack/pact_broker/invalid_uri_protection_spec.rb
+++ b/spec/lib/rack/pact_broker/invalid_uri_protection_spec.rb
@@ -1,4 +1,6 @@
 require "rack/pact_broker/invalid_uri_protection"
+require "pact_broker/application_context"
+require "pact_broker/api/decorators/custom_error_problem_json_decorator"
 
 module Rack
   module PactBroker
@@ -7,7 +9,7 @@ module Rack
       let(:app) { InvalidUriProtection.new(target_app) }
       let(:path) { "/foo" }
 
-      subject { get(path) }
+      subject { get(path, {}, {"pactbroker.application_context" => ::PactBroker::ApplicationContext.default_application_context} ) }
 
       context "with a URI that the Ruby default URI library cannot parse" do
         let(:path) { "/badpath" }


### PR DESCRIPTION
Web machine accepts paths with missing path parameters, but we don't. We should consider this an invalid URI.