### PR TITLE
fix: fix performance issues due to contention in the integrations table when publishing a large number of contracts (> 20) per request, in parallel

### DIFF
--- a/lib/pact_broker/api.rb
+++ b/lib/pact_broker/api.rb
@@ -5,7 +5,6 @@ require "pact_broker/api/decorators"
 require "pact_broker/api/contracts"
 require "pact_broker/application_context"
 require "pact_broker/feature_toggle"
-require "pact_broker/initializers/subscriptions"
 
 module Webmachine
   class Request

--- a/lib/pact_broker/api/resources/event_methods.rb
+++ b/lib/pact_broker/api/resources/event_methods.rb
@@ -1,0 +1,15 @@
+require "pact_broker/events/subscriber"
+
+module PactBroker
+  module Api
+    module Resources
+      module EventMethods
+        def subscribe(listener)
+          PactBroker::Events.subscribe(listener) do
+            yield
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pact_broker/contracts/service.rb
+++ b/lib/pact_broker/contracts/service.rb
@@ -35,6 +35,7 @@ module PactBroker
         version, version_notices = create_version(parsed_contracts)
         tags = create_tags(parsed_contracts, version)
         pacts, pact_notices = create_pacts(parsed_contracts, base_url)
+        update_integrations(pacts)
         notices = version_notices + pact_notices
         ContractsPublicationResults.from_hash(
           pacticipant: version.pacticipant,
@@ -301,6 +302,10 @@ module PactBroker
 
       def url_for_triggered_webhook(triggered_webhook, base_url)
         PactBroker::Api::PactBrokerUrls.triggered_webhook_logs_url(triggered_webhook, base_url)
+      end
+
+      def update_integrations(pacts)
+        integration_service.handle_bulk_contract_data_published(pacts)
       end
 
       private :url_for_triggered_webhook

--- a/lib/pact_broker/initializers/subscriptions.rb
+++ b/lib/pact_broker/initializers/subscriptions.rb
@@ -1,4 +1,0 @@
-require "pact_broker/events/subscriber"
-require "pact_broker/integrations/event_listener"
-
-PactBroker::Events.subscribe(PactBroker::Integrations::EventListener.new)

--- a/lib/pact_broker/integrations/repository.rb
+++ b/lib/pact_broker/integrations/repository.rb
@@ -21,7 +21,8 @@ module PactBroker
           Integration.new(
             consumer_id: consumer_id,
             provider_id: provider_id,
-            created_at: Sequel.datetime_class.now
+            created_at: Sequel.datetime_class.now,
+            contract_data_updated_at: Sequel.datetime_class.now
           ).insert_ignore
         end
         nil
@@ -37,6 +38,16 @@ module PactBroker
       def set_contract_data_updated_at(consumer, provider)
         Integration
           .where({ consumer_id: consumer&.id, provider_id: provider.id }.compact )
+          .update(contract_data_updated_at: Sequel.datetime_class.now)
+      end
+
+
+      # Sets the contract_data_updated_at for the integrations as specified by an array of objects which each have a consumer and provider
+      # @param [Array<Object>] where each object has a consumer and a provider
+      def set_contract_data_updated_at_for_multiple_integrations(objects_with_consumer_and_provider)
+        consumer_and_provider_ids = objects_with_consumer_and_provider.collect{ | object | [object.consumer.id, object.provider.id] }.uniq
+        Integration
+          .where([:consumer_id, :provider_id] => consumer_and_provider_ids)
           .update(contract_data_updated_at: Sequel.datetime_class.now)
       end
     end

--- a/lib/pact_broker/integrations/service.rb
+++ b/lib/pact_broker/integrations/service.rb
@@ -24,6 +24,13 @@ module PactBroker
         integration_repository.set_contract_data_updated_at(consumer, provider)
       end
 
+
+      # Callback to invoke when a batch of contract data is published (eg. the publish contracts endpoint)
+      # @param [Array<Object>] where each object has a consumer and a provider
+      def self.handle_bulk_contract_data_published(objects_with_consumer_and_provider)
+        integration_repository.set_contract_data_updated_at_for_multiple_integrations(objects_with_consumer_and_provider)
+      end
+
       def self.delete(consumer_name, provider_name)
         consumer = pacticipant_service.find_pacticipant_by_name!(consumer_name)
         provider = pacticipant_service.find_pacticipant_by_name!(provider_name)

--- a/spec/lib/pact_broker/integrations/repository_spec.rb
+++ b/spec/lib/pact_broker/integrations/repository_spec.rb
@@ -129,9 +129,9 @@ module PactBroker
         it "sets the contract_data_updated_at of the specified integrations" do
           subject
           integrations = Integration.order(:id).all
-          expect(integrations[0].contract_data_updated_at).to eq date_2
-          expect(integrations[1].contract_data_updated_at).to eq date_2
-          expect(integrations[2].contract_data_updated_at).to eq date_1
+          expect(integrations[0].contract_data_updated_at).to be_date_time(date_2)
+          expect(integrations[1].contract_data_updated_at).to be_date_time(date_2)
+          expect(integrations[2].contract_data_updated_at).to be_date_time(date_1)
         end
       end
     end

--- a/spec/lib/pact_broker/integrations/repository_spec.rb
+++ b/spec/lib/pact_broker/integrations/repository_spec.rb
@@ -22,10 +22,11 @@ module PactBroker
             td.create_verification(provider_version: "2")
           end
 
-          # No contract data date
+          # Nil contract data date
           td.create_consumer("Dog")
             .create_provider("Cat")
             .create_integration
+          Integration.order(:id).last.update(contract_data_updated_at: nil)
         end
 
         subject { Repository.new.find }
@@ -91,6 +92,46 @@ module PactBroker
             expect(integrations.first.contract_data_updated_at).to be_date_time(now)
             expect(integrations.last.contract_data_updated_at).to be_date_time(now)
           end
+        end
+      end
+
+      describe "#set_contract_data_updated_at_for_multiple_integrations" do
+        before do
+          Timecop.freeze(date_1) do
+            td.create_consumer("Foo1")
+              .create_provider("Bar1")
+              .create_integration
+              .create_consumer("Foo2")
+              .create_provider("Bar2")
+              .create_integration
+              .create_consumer("Foo3")
+              .create_provider("Bar3")
+              .create_integration
+          end
+        end
+
+        let(:date_1) { Time.new(2023, 1, 1).utc.to_datetime }
+        let(:date_2) { Time.new(2023, 1, 2).utc.to_datetime }
+
+        let(:objects_with_consumer_and_provider) do
+          [
+            OpenStruct.new(consumer: td.find_pacticipant("Foo1"), provider: td.find_pacticipant("Bar1")),
+            OpenStruct.new(consumer: td.find_pacticipant("Foo2"), provider: td.find_pacticipant("Bar2"))
+          ]
+        end
+
+        subject do
+          Timecop.freeze(date_2) do
+            Repository.new.set_contract_data_updated_at_for_multiple_integrations(objects_with_consumer_and_provider)
+          end
+        end
+
+        it "sets the contract_data_updated_at of the specified integrations" do
+          subject
+          integrations = Integration.order(:id).all
+          expect(integrations[0].contract_data_updated_at).to eq date_2
+          expect(integrations[1].contract_data_updated_at).to eq date_2
+          expect(integrations[2].contract_data_updated_at).to eq date_1
         end
       end
     end


### PR DESCRIPTION
For a particular customer who was publishing 19 contracts at a time with requests that overlapped, we were seeing that the lock on the integrations table was causing each subsequent request to take longer and longer as each waited for the lock on the integrations table to be released. The problem has been fixed by updating the integration rows all at once at the end of the request, rather than updating them one at a time when each pact gets saved.

Problematic way:

create/update pact 1
update integration 1
create/update pact 2
update integration 2
create/update pact 3
update integration 3
create/update pact 4
update integration 4


New way:

create/update pact 1
create/update pact 2
create/update pact 3
create/update pact 4
update integrations 1, 2, 3, 4

The code uses a pub/sub pattern using the Wisper library to update the `contract_data_updated_at` field on the integration when a consumer contract or a provider contract is published. The subscribed functions get invoked *synchronously* - the pub/sub is just a way to decouple the repositories so that the pacts/verifications repositories don't need to know about calling the integrations respository. It's possible that this layer of indirection is overkill 🤷🏽 

The problem with this pattern is that it was causing the integration to be updated every time the pact was published, and because we now have an endpoint that allows the publication of multiple pacts at once, this was leading to the problem described above.

The new code only subscribes the integration listener to the individual resource endpoints (PUT pact, and POST verification), and manually batch updates the integrations in one go in the Contract Service, which was designed to handle the batch contract publications.