### PR TITLE
feat: only generate pact sha once

### DIFF
--- a/lib/pact_broker/api/decorators/publish_contract_decorator.rb
+++ b/lib/pact_broker/api/decorators/publish_contract_decorator.rb
@@ -11,8 +11,13 @@ module PactBroker
         property :provider_name
         property :specification
         property :content_type
-        property :decoded_content
+        property :decoded_content, setter: -> (fragment:, represented:, user_options:, **) {
+          represented.decoded_content = fragment
+          # Set the pact version sha when we set the content
+          represented.pact_version_sha = user_options.fetch(:sha_generator).call(fragment)
+        }
         property :on_conflict, default: "overwrite"
+
       end
     end
   end

--- a/lib/pact_broker/api/decorators/webhook_decorator.rb
+++ b/lib/pact_broker/api/decorators/webhook_decorator.rb
@@ -16,7 +16,7 @@ module PactBroker
           property :name
         end
 
-        property :uuid
+        property :uuid, writeable: false
 
         property :description, getter: lambda { |represented:, **| represented.display_description }
 

--- a/lib/pact_broker/api/resources/publish_contracts.rb
+++ b/lib/pact_broker/api/resources/publish_contracts.rb
@@ -53,7 +53,7 @@ module PactBroker
         private
 
         def parsed_contracts
-          @parsed_contracts ||= decorator_class(:publish_contracts_decorator).new(PactBroker::Contracts::ContractsToPublish.new).from_hash(params)
+          @parsed_contracts ||= decorator_class(:publish_contracts_decorator).new(PactBroker::Contracts::ContractsToPublish.new).from_hash(params, { user_options: { sha_generator: PactBroker.configuration.sha_generator } } )
         end
 
         def params

--- a/lib/pact_broker/contracts/contract_to_publish.rb
+++ b/lib/pact_broker/contracts/contract_to_publish.rb
@@ -1,11 +1,10 @@
 module PactBroker
   module Contracts
-    ContractToPublish = Struct.new(:consumer_name, :provider_name, :decoded_content, :content_type, :specification, :on_conflict) do
-      # rubocop: disable Metrics/ParameterLists
-      def self.from_hash(consumer_name: nil, provider_name: nil, decoded_content: nil, content_type: nil, specification: nil, on_conflict: nil)
-        new(consumer_name, provider_name, decoded_content, content_type, specification, on_conflict)
+    ContractToPublish = Struct.new(:consumer_name, :provider_name, :decoded_content, :content_type, :specification, :on_conflict, :pact_version_sha, keyword_init: true) do
+
+      def self.from_hash(hash)
+        new(**hash)
       end
-      # rubocop: enable Metrics/ParameterLists
 
       def pact?
         specification == "pact"

--- a/lib/pact_broker/contracts/service.rb
+++ b/lib/pact_broker/contracts/service.rb
@@ -57,7 +57,7 @@ module PactBroker
         parsed_contracts.contracts.collect do | contract_to_publish |
           pact_params = create_pact_params(parsed_contracts, contract_to_publish)
           existing_pact = pact_service.find_pact(pact_params)
-          if existing_pact && pact_service.disallowed_modification?(existing_pact, contract_to_publish.decoded_content)
+          if existing_pact && pact_service.disallowed_modification?(existing_pact, contract_to_publish.pact_version_sha)
             add_pact_conflict_notice(notices, parsed_contracts, contract_to_publish, existing_pact.json_content, contract_to_publish.decoded_content)
           end
         end
@@ -134,7 +134,7 @@ module PactBroker
           pact_params = create_pact_params(parsed_contracts, contract_to_publish)
           existing_pact = pact_service.find_pact(pact_params)
           listener = TriggeredWebhooksCreatedListener.new
-          created_pact = create_or_merge_pact(contract_to_publish.merge?, existing_pact, pact_params, listener)
+          created_pact = create_or_merge_pact(contract_to_publish.merge?, existing_pact, pact_params.merge(pact_version_sha: contract_to_publish.pact_version_sha), listener)
           notices.concat(notices_for_pact(parsed_contracts, contract_to_publish, existing_pact, created_pact, listener, base_url))
           created_pact
         end

--- a/lib/pact_broker/pacts/pact_params.rb
+++ b/lib/pact_broker/pacts/pact_params.rb
@@ -20,7 +20,7 @@ module PactBroker
         )
       end
 
-      def self.from_request request, path_info
+      def self.from_request(request, path_info)
         json_content = request.body.to_s
         parsed_content = begin
           parsed = JSON.parse(json_content, PACT_PARSING_OPTIONS)

--- a/lib/pact_broker/test/test_data_builder.rb
+++ b/lib/pact_broker/test/test_data_builder.rb
@@ -256,7 +256,13 @@ module PactBroker
       def publish_pact(consumer_name:, provider_name:, consumer_version_number: , tags: nil, branch: nil, build_url: nil, json_content: nil)
         json_content = json_content || random_json_content(consumer_name, provider_name)
         contracts = [
-          PactBroker::Contracts::ContractToPublish.from_hash(consumer_name: consumer_name, provider_name: provider_name, decoded_content: json_content, content_type: "application/json", specification: "pact")
+          PactBroker::Contracts::ContractToPublish.from_hash(
+            consumer_name: consumer_name,
+            provider_name: provider_name,
+            decoded_content: json_content,
+            content_type: "application/json",
+            specification: "pact",
+            pact_version_sha: PactBroker::Pacts::GenerateSha.call(json_content))
         ]
         contracts_to_publish = PactBroker::Contracts::ContractsToPublish.from_hash(
           pacticipant_name: consumer_name,

--- a/spec/lib/pact_broker/contracts/service_spec.rb
+++ b/spec/lib/pact_broker/contracts/service_spec.rb
@@ -18,10 +18,11 @@ module PactBroker
         let(:branch) { "main" }
         let(:contracts) { [contract_1] }
         let(:contract_1) do
-          ContractToPublish.from_hash(
+          ContractToPublish.new(
             consumer_name: "Foo",
             provider_name: "Bar",
             decoded_content: decoded_contract,
+            pact_version_sha: PactBroker::Pacts::GenerateSha.call(decoded_contract),
             specification: "pact",
             on_conflict: on_conflict
           )
@@ -149,17 +150,19 @@ module PactBroker
         let(:branch) { "main" }
         let(:contracts) { [contract_1] }
         let(:contract_1) do
-          ContractToPublish.from_hash(
+          ContractToPublish.new(
             consumer_name: "Foo",
             provider_name: "Bar",
             decoded_content: decoded_contract,
             specification: "pact",
-            on_conflict: on_conflict
+            on_conflict: on_conflict,
+            pact_version_sha: new_pact_version_sha
           )
         end
 
         let(:contract_hash) { { consumer: { name: "Foo" }, provider: { name: "Bar" }, interactions: [{a: "b"}] } }
         let(:decoded_contract) { contract_hash.to_json }
+        let(:new_pact_version_sha) { PactBroker::Pacts::GenerateSha.call(decoded_contract) }
 
         subject { Service.conflict_notices(contracts_to_publish, base_url: "base_url") }
 

--- a/spec/lib/pact_broker/pacts/service_spec.rb
+++ b/spec/lib/pact_broker/pacts/service_spec.rb
@@ -31,7 +31,8 @@ module PactBroker
             consumer_name: "Foo",
             provider_name: "Bar",
             consumer_version_number: "1",
-            json_content: json_content
+            json_content: json_content,
+            pact_version_sha: PactBroker::Pacts::GenerateSha.call(json_content)
           }
         end
         let(:content) { double("content") }
@@ -48,12 +49,6 @@ module PactBroker
         subject { Service.create_or_update_pact(params) }
 
         context "when no pact exists with the same params" do
-          it "creates the sha before adding the interaction ids" do
-            expect(PactBroker::Pacts::GenerateSha).to receive(:call).ordered
-            expect(content).to receive(:with_ids).ordered
-            subject
-          end
-
           it "saves the pact interactions/messages with ids added to them" do
             expect(pact_repository).to receive(:create).with hash_including(json_content: json_content_with_ids)
             subject
@@ -134,12 +129,6 @@ module PactBroker
           let(:pact_version_sha) { "1" }
 
           let(:expected_event_context) { { consumer_version_tags: ["dev"] } }
-
-          it "creates the sha before adding the interaction ids" do
-            expect(PactBroker::Pacts::GenerateSha).to receive(:call).ordered
-            expect(content).to receive(:with_ids).ordered
-            subject
-          end
 
           it "saves the pact interactions/messages with ids added to them" do
             expect(pact_repository).to receive(:update).with(anything, hash_including(json_content: json_content_with_ids))

--- a/spec/migrations/23_pact_versions_spec.rb
+++ b/spec/migrations/23_pact_versions_spec.rb
@@ -65,12 +65,14 @@ describe "migrate to pact versions (migrate 22-31)", migration: true do
   it "allows a new pact to be inserted with no duplicate ID error" do
     subject
 
+    json_content = load_fixture("a_consumer-a_provider.json")
     PactBroker::Pacts::Service.create_or_update_pact(
       {
         consumer_name: consumer[:name],
         provider_name: provider[:name],
         consumer_version_number: "1.2.3",
-        json_content: load_fixture("a_consumer-a_provider.json")
+        json_content: json_content,
+        pact_version_sha: PactBroker::Pacts::GenerateSha.call(json_content)
       }
     )
   end


### PR DESCRIPTION
Some very large pacts are causing performance problems when the SHA is calculated. This PR updates the code to ensure that the SHA for each pact content is calculated only once per request.