### PR TITLE
feat: use SemanticLogger for Padrino

### DIFF
--- a/lib/pact_broker/app.rb
+++ b/lib/pact_broker/app.rb
@@ -1,8 +1,3 @@
-# Must be defined before loading Padrino
-PADRINO_LOGGER ||= {
-  ENV.fetch("RACK_ENV", "production").to_sym =>  { log_level: :error, stream: :stdout, format_datetime: "%Y-%m-%dT%H:%M:%S.000%:z" }
-}
-
 require "pact_broker/configuration"
 require "pact_broker/db"
 require "pact_broker/initializers/database_connection"

--- a/lib/pact_broker/ui.rb
+++ b/lib/pact_broker/ui.rb
@@ -1,14 +1,9 @@
-require "pact_broker/configuration"
+# Must be defined before loading Padrino
 # Stop Padrino creating a log file, as it will try to create it in the gems directory
 # http://www.padrinorb.com/api/Padrino/Logger.html
-unless defined? PADRINO_LOGGER
-  log_path = File.join(PactBroker.configuration.log_dir, "ui.log")
-  PADRINO_LOGGER = {
-    production:  { log_level: :error, stream: :to_file, log_path: log_path },
-    staging:     { log_level: :error, stream: :to_file, log_path: log_path },
-    test:        { log_level: :warn,  stream: :to_file, log_path: log_path },
-    development: { log_level: :warn,  stream: :to_file, log_path: log_path }
-  }
-end
+# This configuration will be replaced by the SemanticLogger later on.
+PADRINO_LOGGER ||= {
+  ENV.fetch("RACK_ENV", "production").to_sym =>  { stream: :stdout }
+}
 
 require "pact_broker/ui/app"

--- a/lib/pact_broker/ui.rb
+++ b/lib/pact_broker/ui.rb
@@ -6,4 +6,20 @@ PADRINO_LOGGER ||= {
   ENV.fetch("RACK_ENV", "production").to_sym =>  { stream: :stdout }
 }
 
+require "padrino-core"
+
+class PactBrokerPadrinoLogger < SemanticLogger::Logger
+  include Padrino::Logger::Extensions
+
+  # Padrino expects level to return an integer, not a symbol
+  def level
+    Padrino::Logger::Levels[SemanticLogger.default_level]
+  end
+end
+
+Padrino.logger = PactBrokerPadrinoLogger.new("Padrino")
+# Log a test message to ensure that the logger works properly, as it only
+# seems to be used in production.
+Padrino.logger.info("Padrino has been configured with SemanticLogger")
+
 require "pact_broker/ui/app"

--- a/lib/pact_broker/ui/controllers/base_controller.rb
+++ b/lib/pact_broker/ui/controllers/base_controller.rb
@@ -3,20 +3,6 @@ require "haml"
 require "pact_broker/services"
 require "pact_broker/string_refinements"
 
-class PactBrokerPadrinoLogger < SemanticLogger::Logger
-  include Padrino::Logger::Extensions
-
-  # Padrino expects level to return an integer, not a symbol
-  def level
-    Padrino::Logger::Levels[SemanticLogger.default_level]
-  end
-end
-
-Padrino.logger = PactBrokerPadrinoLogger.new("Padrino")
-# Log a test message to ensure that the logger works properly, as it only
-# seems to be used in production.
-Padrino.logger.info("Padrino has been configured with SemanticLogger")
-
 module PactBroker
   module UI
     module Controllers

--- a/spec/lib/pact_broker/ui/controllers/index_spec.rb
+++ b/spec/lib/pact_broker/ui/controllers/index_spec.rb
@@ -40,7 +40,7 @@ module PactBroker
 
             context "when pagination parameters are present" do
               it "passes through pagination parameters to the search" do
-                expect(PactBroker::Index::Service).to receive(:find_index_items).with(hash_including(page_number: 2, page_size: 40))
+                expect(PactBroker::Index::Service).to receive(:find_index_items).with(hash_including(page_number: 2, page_size: 40)).and_call_original
                 get "/", { page: "2", pageSize: "40" }
               end
             end
@@ -48,14 +48,14 @@ module PactBroker
             context "when pagination parameters are not present" do
               context "when tags=true" do
                 it "passes through default pagination parameters to the search with page_size=30" do
-                  expect(PactBroker::Index::Service).to receive(:find_index_items).with(hash_including(page_number: 1, page_size: 30))
+                  expect(PactBroker::Index::Service).to receive(:find_index_items).with(hash_including(page_number: 1, page_size: 30)).and_call_original
                   get "/", { tags: "true" }
                 end
               end
 
               context "when not tags=true" do
                 it "passes through default pagination parameters to the search with page_size=100" do
-                  expect(PactBroker::Index::Service).to receive(:find_index_items).with(hash_including(page_number: 1, page_size: 100))
+                  expect(PactBroker::Index::Service).to receive(:find_index_items).with(hash_including(page_number: 1, page_size: 100)).and_call_original
                   get "/"
                 end
               end


### PR DESCRIPTION
Prior to this PR, any errors raised in the UI get printed without formatting to stdout. This PR configures Padrino to use Semantic Logger, so that it respects the `PACT_BROKER_LOG_FORMAT` configuration (ie. it will print error logs in JSON).

This change is irrelevant to PF, as we don't use the server side rendered UI.