### PR TITLE
feat: reduce contention when updating the contract_data_updated_at field for integrations

### DIFF
--- a/lib/pact_broker/dataset.rb
+++ b/lib/pact_broker/dataset.rb
@@ -101,18 +101,6 @@ module PactBroker
     def order_append_ignore_case column_name = :name
       order_append(Sequel.function(:lower, column_name))
     end
-
-    # Executes a SELECT query FOR UPDATE, with SKIP LOCKED if supported (postgres only).
-    # With FOR UPDATE SKIP LOCKED, the SELECT will run immediately, not waiting for any other transactions,
-    # and only return rows that are not already locked by another transaction.
-    # The FOR UPDATE is required to make it work this way - SKIP LOCKED on its own does not work.
-    def for_update_skip_locked_if_supported
-      if supports_skip_locked?
-        for_update.skip_locked
-      else
-        self
-      end
-    end
   end
 end
 

--- a/lib/pact_broker/dataset.rb
+++ b/lib/pact_broker/dataset.rb
@@ -101,6 +101,18 @@ module PactBroker
     def order_append_ignore_case column_name = :name
       order_append(Sequel.function(:lower, column_name))
     end
+
+    # Executes a SELECT query FOR UPDATE, with SKIP LOCKED if supported (postgres only).
+    # With FOR UPDATE SKIP LOCKED, the SELECT will run immediately, not waiting for any other transactions,
+    # and only return rows that are not already locked by another transaction.
+    # The FOR UPDATE is required to make it work this way - SKIP LOCKED on its own does not work.
+    def for_update_skip_locked_if_supported
+      if supports_skip_locked?
+        for_update.skip_locked
+      else
+        self
+      end
+    end
   end
 end
 

--- a/lib/pact_broker/integrations/repository.rb
+++ b/lib/pact_broker/integrations/repository.rb
@@ -50,18 +50,27 @@ module PactBroker
       # @param [PactBroker::Domain::Pacticipant, nil] consumer the consumer for the integration, or nil if for a provider-only event (eg. Pactflow provider contract published)
       # @param [PactBroker::Domain::Pacticipant] provider the provider for the integration
       def set_contract_data_updated_at(consumer, provider)
-        Integration
-          .where({ consumer_id: consumer&.id, provider_id: provider.id }.compact )
-          .update(contract_data_updated_at: Sequel.datetime_class.now)
+        set_contract_data_updated_at_for_multiple_integrations([OpenStruct.new(consumer: consumer, provider: provider)])
       end
 
 
-      # Sets the contract_data_updated_at for the integrations as specified by an array of objects which each have a consumer and provider
-      # @param [Array<Object>] where each object has a consumer and a provider
+      # Sets the contract_data_updated_at for the integrations as specified by an array of objects which each have a consumer and provider.
+      #
+      # The contract_data_updated_at attribute is only ever used for ordering the list of integrations on the index page of the *Pact Broker* UI,
+      # so that the most recently updated integrations (the ones you're likely working on) are showed at the top of the first page.
+      # There is often contention around updating it however, which can cause deadlocks, and slow down API responses.
+      # Because it's not a critical field (eg. it won't change any can-i-deploy results), the easiest way to reduce this contention
+      # is to just not update it if the row is locked, because if it is locked, the value of contract_data_updated_at is already
+      # going to be a date from a few seconds ago, which is perfectly fine for the purposes for which we are using the value.
+      # @param [Array<Object>] where each object MAY have a consumer and does have a provider (for Pactflow provider contract published there is no consumer)
       def set_contract_data_updated_at_for_multiple_integrations(objects_with_consumer_and_provider)
-        consumer_and_provider_ids = objects_with_consumer_and_provider.collect{ | object | [object.consumer.id, object.provider.id] }.uniq
+        consumer_and_provider_ids = objects_with_consumer_and_provider.collect{ | object | { consumer_id: object.consumer&.id, provider_id: object.provider.id }.compact }.uniq
+        integration_ids_to_update = Integration
+                                      .select(:id)
+                                      .where(Sequel.|(*consumer_and_provider_ids))
+                                      .for_update_skip_locked_if_supported
         Integration
-          .where([:consumer_id, :provider_id] => consumer_and_provider_ids)
+          .where(id: integration_ids_to_update)
           .update(contract_data_updated_at: Sequel.datetime_class.now)
       end
     end


### PR DESCRIPTION
Reduce contention updating the contract_data_updated_at for integrations, which is causing some responses to be slow while locks are waited for.

This is tricky to test in a unit test, especially as the database we use for our unit tests (Sqlite) doesn't support SKIP LOCKED, so I manually tested it using the following code.

```
script/docker/db-rm.sh # remove any existing db
script/docker/db-start.sh
script/dev/console.rb postgres://postgres:postgres@localhost/postgres

td = PactBroker::Test::TestDataBuilder.new
td.create_consumer("A").create_provider("B").create_integration
td.create_consumer("C").create_provider("D").create_integration
td.create_consumer("E").create_provider("F").create_integration

things1 = [
	OpenStruct.new(consumer: OpenStruct.new(id: 1), provider: OpenStruct.new(id: 2)),
	OpenStruct.new(consumer: OpenStruct.new(id: 3), provider: OpenStruct.new(id: 4))
]

connection.transaction do
       # update the first and second integrations
	PactBroker::Integrations::Repository.new.set_contract_data_updated_at_for_multiple_integrations(things1)
	sleep 15
end

PactBroker::Integrations::Integration.order(:id).all
```

In another shell, within 15 seconds:

```
script/dev/console.rb postgres://postgres:postgres@localhost/postgres

# attempt to update second and third integrations
# only the third integration will be updated, as the second one is locked by the first transaction
things2 = [
	OpenStruct.new(consumer: OpenStruct.new(id: 3), provider: OpenStruct.new(id: 4)),
	OpenStruct.new(consumer: OpenStruct.new(id: 5), provider: OpenStruct.new(id: 6))
]

connection.transaction do
	PactBroker::Integrations::Repository.new.set_contract_data_updated_at_for_multiple_integrations(things2)
end
```

The second script will complete immediately, without waiting for the first one to sleep its 15 seconds. The first script will update integrations 1 and 2, while the second script will attempt to update 2 and 3, but will only actually update 3.
