### PR TITLE
deps: update psych to 5.x

### DIFF
--- a/pact_broker.gemspec
+++ b/pact_broker.gemspec
@@ -50,7 +50,8 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.add_runtime_dependency "json", "~> 2.3"
-  gem.add_runtime_dependency "psych", "~> 4.0" # TODO identify breaking changes and see if we can use 5
+  # gem.add_runtime_dependency "psych", "~> 4.0" # TODO identify breaking changes and see if we can use 5
+  gem.add_runtime_dependency "psych", "~> 5.0" # TODO identify breaking changes and see if we can use 5
   gem.add_runtime_dependency "roar", "~> 1.1"
   gem.add_runtime_dependency "dry-validation", "~> 1.8"
   gem.add_runtime_dependency "reform", "~> 2.6"


### PR DESCRIPTION
Tests all pass and ok with a quick smoke test.

_note:_ need to remove unneeded comment about upgrade

cursory scan on the releases shows nothing marked as a breaking change to be aware of, so I thought I would upgrade and see how we go

https://github.com/ruby/psych/releases