### PR TITLE
refactor: declare custom sequel models by excluding columns rather than including columns

### DIFF
--- a/lib/pact_broker/domain/version.rb
+++ b/lib/pact_broker/domain/version.rb
@@ -5,9 +5,7 @@ require "pact_broker/versions/eager_loaders"
 module PactBroker
   module Domain
     class Version < Sequel::Model
-
-      # do not include the branch column
-      VERSION_COLUMNS = Sequel::Model.db.schema(:versions).collect(&:first) - [:branch]
+      VERSION_COLUMNS = Sequel::Model.db.schema(:versions).collect(&:first) - [:branch] # do not include the branch column, as we now have a branches table
       set_dataset(Sequel::Model.db[:versions].select(*VERSION_COLUMNS.collect{ | column | Sequel.qualify(:versions, column) }))
 
       set_primary_key :id

--- a/lib/pact_broker/domain/version.rb
+++ b/lib/pact_broker/domain/version.rb
@@ -4,9 +4,12 @@ require "pact_broker/versions/eager_loaders"
 
 module PactBroker
   module Domain
-    VERSION_COLUMNS = [:id, :number, :repository_ref, :pacticipant_id, :order, :created_at, :updated_at, :build_url]
+    class Version < Sequel::Model
 
-    class Version < Sequel::Model(Sequel::Model.db[:versions].select(*VERSION_COLUMNS.collect{ | column | Sequel.qualify(:versions, column) }))
+      # do not include the branch column
+      VERSION_COLUMNS = Sequel::Model.db.schema(:versions).collect(&:first) - [:branch]
+      set_dataset(Sequel::Model.db[:versions].select(*VERSION_COLUMNS.collect{ | column | Sequel.qualify(:versions, column) }))
+
       set_primary_key :id
 
       plugin :timestamps, update_on_create: true

--- a/lib/pact_broker/integrations/integration.rb
+++ b/lib/pact_broker/integrations/integration.rb
@@ -14,7 +14,10 @@ module PactBroker
     # When the view was migrated to be a table (in db/migrations/20211102_create_table_temp_integrations.rb and the following migrations)
     # the columns had to be maintained for backwards compatiblity.
     # They are not used by the current code, however.
-    class Integration < Sequel::Model(Sequel::Model.db[:integrations].select(:id, :consumer_id, :provider_id, :created_at, :contract_data_updated_at))
+    class Integration < Sequel::Model
+      INTEGRATIONS_COLUMNS = Sequel::Model.db.schema(:integrations).collect(&:first) - [:consumer_name, :provider_name]
+      set_dataset(Sequel::Model.db[:integrations].select(*INTEGRATIONS_COLUMNS.collect{ | column | Sequel.qualify(:integrations, column) }))
+
       set_primary_key :id
       plugin :insert_ignore, identifying_columns: [:consumer_id, :provider_id]
       associate(:many_to_one, :consumer, :class => "PactBroker::Domain::Pacticipant", :key => :consumer_id, :primary_key => :id)

--- a/lib/pact_broker/integrations/integration.rb
+++ b/lib/pact_broker/integrations/integration.rb
@@ -15,8 +15,8 @@ module PactBroker
     # the columns had to be maintained for backwards compatiblity.
     # They are not used by the current code, however.
     class Integration < Sequel::Model
-      INTEGRATIONS_COLUMNS = Sequel::Model.db.schema(:integrations).collect(&:first) - [:consumer_name, :provider_name]
-      set_dataset(Sequel::Model.db[:integrations].select(*INTEGRATIONS_COLUMNS.collect{ | column | Sequel.qualify(:integrations, column) }))
+      INTEGRATION_COLUMNS = Sequel::Model.db.schema(:integrations).collect(&:first) - [:consumer_name, :provider_name]
+      set_dataset(Sequel::Model.db[:integrations].select(*INTEGRATION_COLUMNS))
 
       set_primary_key :id
       plugin :insert_ignore, identifying_columns: [:consumer_id, :provider_id]

--- a/lib/pact_broker/webhooks/execution.rb
+++ b/lib/pact_broker/webhooks/execution.rb
@@ -8,7 +8,7 @@ module PactBroker
       # If we ever release a major version where we drop unused columns, those columns could be deleted.
       EXECUTION_COLUMNS = Sequel::Model.db.schema(:webhook_executions).collect(&:first) - [:webhook_id, :pact_publication_id, :consumer_id, :provider_id]
 
-      set_dataset(Sequel::Model.db[:webhook_executions].select(*EXECUTION_COLUMNS.collect{ | column | Sequel.qualify(:webhook_executions, column) }))
+      set_dataset(Sequel::Model.db[:webhook_executions].select(*EXECUTION_COLUMNS))
 
       set_primary_key :id
       plugin :timestamps


### PR DESCRIPTION
Sequel creates its Model classes by inspecting the columns of the table, and dynamically creating the attributes.

Some Sequel Models have custom declarations because there are unused columns in the table that should no longer be included in the Models. We don't drop the the columns because our database migrations need to be backwards compatible during no-downtime deployments (ie. able to run both the previous and the new version of the code). The way the unused columns were removed from the Model was to provide a list of columns to *include* in the Model.

Pactflow adds a column `created_by_user_id` to most of the tables/domain objects. This column gets picked up automatically by Sequel for most models with the "auto column discovery" code when it starts up with a Pactflow database.

For the models with custom declarations that had a list of columns to *include* though, this column wasn't getting picked up, and it required us to do some yucky hacking to the OSS files.

This refactor changes the approach from having a hardcoded list of columns to *include* to a hardcoded list of columns to *exclude*. This means that even for the Models with custom declarations, the `created_by_user_id` column will get picked up automatically in Pactflow without having to hack the files.

One day, we may release a major version of the Pact Broker where we clean up all the old columns. But probably not 😆 