### PR TITLE
feat: add application/hal+json content type for webhook logs

### DIFF
--- a/lib/pact_broker/api/decorators/triggered_webhook_logs_decorator.rb
+++ b/lib/pact_broker/api/decorators/triggered_webhook_logs_decorator.rb
@@ -1,0 +1,38 @@
+require_relative "base_decorator"
+
+module PactBroker
+  module Api
+    module Decorators
+      class TriggeredWebhookLogsDecorator < BaseDecorator
+        class WebhookExecutionDecorator < BaseDecorator
+          property  :success
+          property  :logs
+          property  :created_at, as: :createdAt
+        end
+
+
+        nested :triggeredWebhook, embedded: true do
+          property :uuid
+        end
+
+        collection :webhook_executions, as: :executions, :class => PactBroker::Webhooks::Execution, :extend => WebhookExecutionDecorator
+
+        link :self do | options |
+          {
+            title: "Triggered webhook logs",
+            href: options[:resource_url]
+          }
+        end
+
+        link :'pb:webhook' do | context |
+          if represented.webhook
+            {
+              href: webhook_url(represented.webhook.uuid, context[:base_url]),
+              title: "Webhook"
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pact_broker/api/resources/triggered_webhook_logs.rb
+++ b/lib/pact_broker/api/resources/triggered_webhook_logs.rb
@@ -7,7 +7,7 @@ module PactBroker
       class TriggeredWebhookLogs < BaseResource
 
         def content_types_provided
-          [["text/plain", :to_text]]
+          [["text/plain", :to_text], ["application/hal+json", :to_json]]
         end
 
         def allowed_methods
@@ -25,6 +25,10 @@ module PactBroker
           else
             "Webhook has not executed yet. Please retry in a few seconds."
           end
+        end
+
+        def to_json
+          decorator_class(:triggered_webhook_logs_decorator).new(triggered_webhook).to_json(**decorator_options)
         end
 
         def policy_name

--- a/spec/fixtures/approvals/docs_webhooks_logs_of_triggered_webhook_get.approved.json
+++ b/spec/fixtures/approvals/docs_webhooks_logs_of_triggered_webhook_get.approved.json
@@ -13,7 +13,8 @@
   "response": {
     "status": 200,
     "headers": {
-      "Content-Type": "text/plain;charset=utf-8"
+      "Content-Type": "text/plain;charset=utf-8",
+      "Vary": "Accept"
     },
     "body": "logs"
   }

--- a/spec/fixtures/approvals/triggered_webhook_logs_decorator.approved.json
+++ b/spec/fixtures/approvals/triggered_webhook_logs_decorator.approved.json
@@ -1,0 +1,24 @@
+{
+  "executions": [
+    {
+      "success": true,
+      "logs": "foo",
+      "createdAt": "2024-01-01T00:00:00+00:00"
+    }
+  ],
+  "_embedded": {
+    "triggeredWebhook": {
+      "uuid": "1234"
+    }
+  },
+  "_links": {
+    "self": {
+      "title": "Triggered webhook logs",
+      "href": null
+    },
+    "pb:webhook": {
+      "href": "http://example.org/webhooks/1234",
+      "title": "Webhook"
+    }
+  }
+}

--- a/spec/lib/pact_broker/api/decorators/triggered_webhook_logs_decorator_spec.rb
+++ b/spec/lib/pact_broker/api/decorators/triggered_webhook_logs_decorator_spec.rb
@@ -1,0 +1,31 @@
+require "pact_broker/api/decorators/triggered_webhook_logs_decorator"
+
+module PactBroker
+  module Api
+    module Decorators
+      describe TriggeredWebhookLogsDecorator do
+        let(:triggered_webhook) do
+          double("PactBroker::Webhooks::TriggeredWebhook",
+            uuid: "1234",
+            webhook_executions: [webhook_execution],
+            webhook: webhook
+          )
+        end
+
+        let(:webhook) { double("webhook", uuid: "1234") }
+
+        let(:webhook_execution) do
+          instance_double(PactBroker::Webhooks::Execution, logs: "foo", success: true, created_at: td.in_utc { DateTime.new(2024, 1, 1) }  )
+        end
+
+        let(:user_options) { { base_url: "http://example.org" } }
+
+        subject { TriggeredWebhookLogsDecorator.new(triggered_webhook).to_json(user_options: user_options) }
+
+        it {
+          Approvals.verify(subject, :name => "triggered_webhook_logs_decorator", format: :json)
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for application/hal+json content type for triggered webhook logs for use in pactflow.