### PR TITLE
feat: search pacticipants by display_name

### DIFF
--- a/lib/pact_broker/pacticipants/repository.rb
+++ b/lib/pact_broker/pacticipants/repository.rb
@@ -102,7 +102,16 @@ module PactBroker
 
       def search_by_name(pacticipant_name)
         terms = pacticipant_name.split.map { |v| v.gsub("_", "\\_") }
-        string_match_query = Sequel.|( *terms.map { |term| Sequel.ilike(Sequel[:pacticipants][:name], "%#{term}%") })
+        columns = [:name, :display_name]
+        string_match_query = Sequel.|(
+          *terms.map do |term|
+            Sequel.|(
+              *columns.map do |column|
+                Sequel.ilike(Sequel[:pacticipants][column], "%#{term}%")
+              end
+            )
+          end
+        )
         scope_for(PactBroker::Domain::Pacticipant).where(string_match_query)
       end
 

--- a/spec/lib/pact_broker/pacticipants/repository_spec.rb
+++ b/spec/lib/pact_broker/pacticipants/repository_spec.rb
@@ -216,8 +216,8 @@ module PactBroker
 
         before do
           td
-            .create_consumer(consumer_name)
-            .create_consumer(provider_name)
+            .create_consumer(consumer_name, { display_name: "Pretty Consumer" })
+            .create_consumer(provider_name, { display_name: "Fancy Provider" })
         end
 
         context "when there is a consumer/provider name which matches the search term" do
@@ -241,6 +241,14 @@ module PactBroker
           it "searches case insentively" do
             searched_dataset =  Repository.new.search_by_name "TEST"
             expect(searched_dataset.collect(&:name)).to include(*[consumer_name, provider_name])
+          end
+
+          it "searches by display_name" do
+            searched_dataset =  Repository.new.search_by_name "Pretty"
+            expect(searched_dataset.collect(&:name)).to eq([consumer_name])
+
+            searched_dataset =  Repository.new.search_by_name "Fancy"
+            expect(searched_dataset.collect(&:name)).to eq([provider_name])
           end
         end
 


### PR DESCRIPTION
It can be confusing to search pacticipants if the `display_name` is substantially different than the `name`. Why not do both?