### PR TITLE
Fix/no method for pacticipant patch

### DIFF
--- a/lib/pact_broker/api/decorators/pacticipant_decorator.rb
+++ b/lib/pact_broker/api/decorators/pacticipant_decorator.rb
@@ -20,7 +20,7 @@ module PactBroker
         property :main_branch
 
         property :latest_version, as: :latestVersion, :class => PactBroker::Domain::Version, extend: PactBroker::Api::Decorators::EmbeddedVersionDecorator, embedded: true, writeable: false
-        collection :labels, :class => PactBroker::Domain::Label, extend: PactBroker::Api::Decorators::EmbeddedLabelDecorator, embedded: true
+        collection :labels, :class => PactBroker::Domain::Label, extend: PactBroker::Api::Decorators::EmbeddedLabelDecorator, embedded: true, writeable: false
 
         include Timestamps
 

--- a/spec/features/update_pacticipant_spec.rb
+++ b/spec/features/update_pacticipant_spec.rb
@@ -72,6 +72,35 @@ describe "Update a pacticipant" do
       it "returns a json body with the updated pacticipant" do
         expect(subject.headers["Content-Type"]).to eq "application/hal+json;charset=utf-8"
       end
+
+      context "when request body contains embedded labels" do
+        context "when labels has values" do
+          let(:request_body) { { "displayName": "Updated Consumer Name", "_embedded": { "labels": [{ "name": "ios" }, { "name": "consumer" }] } } }
+
+          it "returns a 200 response" do
+            expect(subject.status).to be 200
+          end
+
+          it "should not create the labels for the pacticipant" do 
+            expect(response_body_hash[:_embedded][:labels]).to be_empty
+          end
+
+          it "only updates pacticipant attribute ignoring the labels" do
+            expect(response_body_hash[:displayName]).to eq "Updated Consumer Name"
+            expect{ subject }.to change {
+              PactBroker::Domain::Label.where(name: "ios").count
+            }.by(0)
+          end
+        end
+
+        context "when labels is empty" do
+          let(:request_body) {{"displayName": "Updated Consumer Name", "_embedded": { "labels": []}}}
+
+          it "returns a 200 OK" do 
+            expect(subject.status).to be 200
+          end
+        end 
+      end 
     end
 
     context "with application/merge-patch+json" do

--- a/spec/lib/pact_broker/api/decorators/pacticipant_decorator_spec.rb
+++ b/spec/lib/pact_broker/api/decorators/pacticipant_decorator_spec.rb
@@ -12,12 +12,15 @@ module PactBroker
         end
 
         describe "from_json" do
-          let(:pacticipant) { OpenStruct.new }
+          let(:pacticipant) { OpenStruct.new(labels: [OpenStruct.new(name: "existing_label")]) }
           let(:decorator) { PacticipantDecorator.new(pacticipant) }
           let(:hash) do
             {
               name: "Foo",
-              mainBranch: "main"
+              mainBranch: "main",
+              labels: [
+                {name: "new_label"}
+              ]
             }
           end
 
@@ -25,6 +28,10 @@ module PactBroker
 
           its(:name) { is_expected.to eq "Foo" }
           its(:main_branch) { is_expected.to eq "main" }
+
+          it "does not modify the labels collection" do
+            expect(subject.labels.map(&:name)).to contain_exactly("existing_label")
+          end
         end
 
         describe "to_json" do


### PR DESCRIPTION
**Fix NoMethodError for Patch Requests with Embedded Labels in Pacticipant**

Description:
This pull request addresses a runtime error (NoMethodError) that occurs when a PATCH request is made to update a pacticipant and the request body contains embedded labels.

For more information, please review: PACT-1211
