### PR TITLE
chore: changed can-i-merge build badge text

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,7 +72,6 @@ Lint/EachWithObjectArgument:
 Lint/ElseLayout:
   Description: 'Check for odd code arrangement in an else block.'
   Enabled: true
-  EnforcedStyleAlignWith: variable
 
 Lint/EmptyEnsure:
   Description: 'Checks for empty ensure block.'

--- a/lib/pact_broker/api/resources/can_i_merge_badge.rb
+++ b/lib/pact_broker/api/resources/can_i_merge_badge.rb
@@ -8,7 +8,7 @@ module PactBroker
         include BadgeMethods # This module contains all necessary webmachine methods for badge implementation
 
         def badge_url 
-          if pacticipant.nil?
+          if pacticipant.nil? # pacticipant method is defined in BaseResource
             # if the pacticipant is nil, we return an error badge url
             badge_service.error_badge_url("pacticipant", "not found")
           elsif version.nil?
@@ -16,10 +16,7 @@ module PactBroker
             badge_service.error_badge_url("main branch version", "not found")
           else
             # we call badge_service to build the badge url
-            badge_service.can_i_merge_badge_url(
-              version_number: version.number,
-              deployable: results
-            )
+            badge_service.can_i_merge_badge_url(deployable: results)
           end
         end
         

--- a/lib/pact_broker/badges/service.rb
+++ b/lib/pact_broker/badges/service.rb
@@ -40,16 +40,20 @@ module PactBroker
         build_shield_io_uri(title, status, color)
       end
 
-      def can_i_merge_badge_url(version_number: nil, deployable: nil)
+      def can_i_merge_badge_url(deployable: nil)
         title = "can-i-merge"
-        status = deployable ? "yes" : "no"
-        if deployable.nil?
-          color = "lightgrey"
-          status = "unknown"
+        
+        # rubocop:disable Layout/EndAlignment
+        color, status = case deployable
+        when nil
+          [ "lightgrey", "unknown" ]
+        when true
+          [ "brightgreen", "success" ]
         else
-          color = deployable ? "brightgreen" : "red"
-          status = version_number
+          [ "red", "failed" ]
         end
+        # rubocop:enable Layout/EndAlignment
+
         # left text is "can-i-merge", right text is the version number
         build_shield_io_uri(title, status, color)
       end

--- a/spec/lib/pact_broker/api/resources/can_i_merge_badge_spec.rb
+++ b/spec/lib/pact_broker/api/resources/can_i_merge_badge_spec.rb
@@ -33,7 +33,7 @@ module PactBroker
           end
 
           it "return the badge URL" do
-            expect(badge_service). to receive(:can_i_merge_badge_url).with(version_number: "1", deployable: true)
+            expect(badge_service). to receive(:can_i_merge_badge_url).with(deployable: true)
             expect(subject.headers["Location"]).to eq "http://badge_url"
           end
         end

--- a/spec/lib/pact_broker/badges/service_spec.rb
+++ b/spec/lib/pact_broker/badges/service_spec.rb
@@ -33,14 +33,15 @@ module PactBroker
         let(:version_number) { "abcd1234" }
         let(:deployable) { true }
   
-        subject { Service.can_i_merge_badge_url(version_number: version_number, deployable: deployable) }
+        subject { Service.can_i_merge_badge_url(deployable: deployable) }
+        
         context "when deployable is true" do
-          it { is_expected.to eq URI("https://img.shields.io/badge/can--i--merge-abcd1234-brightgreen.svg") }
+          it { is_expected.to eq URI("https://img.shields.io/badge/can--i--merge-success-brightgreen.svg") }
         end
   
         context "when deployable is false" do
           let(:deployable) { false }
-          it { is_expected.to eq URI("https://img.shields.io/badge/can--i--merge-abcd1234-red.svg") }
+          it { is_expected.to eq URI("https://img.shields.io/badge/can--i--merge-failed-red.svg") }
         end
       end
 


### PR DESCRIPTION
changed build badge text to display "success" "failure" instead of version numbers