### PR TITLE
feat: implemented basic cache of 30 sec in can-i-merge badges

### DIFF
--- a/docs/configuration.yml
+++ b/docs/configuration.yml
@@ -355,6 +355,10 @@ groups:
         description: The URL of the shields.io server used to generate the README badges.
         default_value: https://img.shields.io
         more_info: https://shields.io
+      badge_default_cache_setting:
+        description: Cache Control header value for the badge, this  sets the Cache-Control header for the badge image, for more information on header formats see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+        default_value: "max-age=30"
+
       badge_provider_mode:
         description: |-
           The method by which the badges are generated. When set to `redirect`, a request to the Pact Broker for a badge will be sent a redirect response

--- a/example/config/pact_broker.yml
+++ b/example/config/pact_broker.yml
@@ -7,3 +7,4 @@ basic_auth_password: "pass"
 basic_auth_read_only_username: "rouser"
 basic_auth_read_only_password: "ropass"
 database_url: sqlite:////tmp/pact_broker.sqlite3
+badge_default_cache_setting: "max-age=30"

--- a/lib/pact_broker/api/resources/badge_methods.rb
+++ b/lib/pact_broker/api/resources/badge_methods.rb
@@ -32,7 +32,7 @@ module PactBroker
         end
 
         def moved_temporarily?
-          response.headers["Cache-Control"] = "no-cache"
+          set_cache_control("no-cache")
           begin
             badge_url
           rescue StandardError => e
@@ -44,6 +44,10 @@ module PactBroker
 
         def badge_url
           raise NotImplementedError
+        end
+
+        def set_cache_control(cache_control_str)
+          response.headers["Cache-Control"] = cache_control_str
         end
 
         private

--- a/lib/pact_broker/api/resources/can_i_merge_badge.rb
+++ b/lib/pact_broker/api/resources/can_i_merge_badge.rb
@@ -15,12 +15,18 @@ module PactBroker
             # when there is no main branch version, we return an error badge url
             badge_service.error_badge_url("main branch version", "not found")
           else
+            # when badge is available, set cache based on configuration
+            set_cache_control(default_cache_for_succesful_badge)
             # we call badge_service to build the badge url
             badge_service.can_i_merge_badge_url(deployable: results)
           end
         end
         
         private
+
+        def default_cache_for_succesful_badge
+          PactBroker.configuration.badge_default_cache_setting
+        end
 
         def results
           # can_i_merge returns true or false if the main branch version is compatible with all the integrations

--- a/lib/pact_broker/config/runtime_configuration.rb
+++ b/lib/pact_broker/config/runtime_configuration.rb
@@ -76,6 +76,7 @@ module PactBroker
         badge_provider_mode: :redirect,
         enable_public_badge_access: false,
         shields_io_base_url: "https://img.shields.io",
+        badge_default_cache_setting: "max-age=30",
         use_case_sensitive_resource_names: true,
         pact_content_diff_timeout: 15
       )

--- a/spec/lib/pact_broker/api/resources/can_i_merge_badge_spec.rb
+++ b/spec/lib/pact_broker/api/resources/can_i_merge_badge_spec.rb
@@ -35,6 +35,7 @@ module PactBroker
           it "return the badge URL" do
             expect(badge_service). to receive(:can_i_merge_badge_url).with(deployable: true)
             expect(subject.headers["Location"]).to eq "http://badge_url"
+            expect(subject.headers["Cache-Control"]).to eq "max-age=30"
           end
         end
 
@@ -44,6 +45,7 @@ module PactBroker
           it "returns an error badge URL" do
             expect(badge_service).to receive(:error_badge_url).with("pacticipant", "not found")
             expect(subject.headers["Location"]).to eq "http://error_badge_url"
+            expect(subject.headers["Cache-Control"]).to eq "no-cache"  
           end
         end
 


### PR DESCRIPTION
* currently the can-i-merge badges are not cached at al
* if a badge is present it makes sense to have some basic cache (30sec) instead of none
