### PR TITLE
fix: make clean_task.rb log the results properly

### DIFF
--- a/lib/pact_broker/tasks/clean_task.rb
+++ b/lib/pact_broker/tasks/clean_task.rb
@@ -105,7 +105,7 @@ module PactBroker
 
       def output(string, payload = {})
         prefix = dry_run ? "[DRY RUN] " : ""
-        logger ? logger.info("#{prefix}#{string}") : puts("#{prefix}#{string} #{payload.to_json}")
+        logger ? logger.info("#{prefix}#{string}", payload) : puts("#{prefix}#{string} #{payload.to_json}")
       end
 
       def add_defaults_to_keep_selectors


### PR DESCRIPTION
Was missing the payload. 
It's scary to run a deletion task without knowing what's gonna get deleted.

