### PR TITLE
feat: add branch-pact-versions & latest-branch-pact-version

### DIFF
--- a/lib/pact_broker/api/resources/index.rb
+++ b/lib/pact_broker/api/resources/index.rb
@@ -49,6 +49,18 @@ module PactBroker
               title: "All versions of a pact for a given consumer, provider and consumer version tag",
               templated: false
             },
+            "pb:latest-branch-pact-version" =>
+            {
+              href: base_url + "/pacts/provider/{provider}/consumer/{consumer}/branch/{branch}/latest",
+              title: "Latest version of a pact for a given consumer, provider and consumer version branch",
+              templated: false
+            },
+            "pb:branch-pact-versions" =>
+            {
+              href: base_url + "/pacts/provider/{provider}/consumer/{consumer}/branch/{branch}",
+              title: "All versions of a pact for a given consumer, provider and consumer version branch",
+              templated: false
+            },
             "pb:pacticipants" =>
             {
               href: base_url + "/pacticipants",

--- a/lib/pact_broker/api/resources/pact_versions_for_branch.rb
+++ b/lib/pact_broker/api/resources/pact_versions_for_branch.rb
@@ -1,7 +1,7 @@
 require "pact_broker/api/resources/base_resource"
 require "pact_broker/configuration"
-require "pact_broker/api/decorators/tagged_pact_versions_decorator"
 require "pact_broker/api/resources/pact_resource_methods"
+require "pact_broker/api/decorators/pact_versions_decorator"
 
 module PactBroker
   module Api
@@ -14,11 +14,19 @@ module PactBroker
         end
 
         def allowed_methods
-          ["DELETE", "OPTIONS"]
+          ["GET", "DELETE", "OPTIONS"]
         end
 
         def resource_exists?
           consumer && provider
+        end
+
+        def to_json
+          decorator_class(:pact_versions_decorator).new(pacts).to_json(**decorator_options(identifier_from_path))
+        end
+
+        def pacts
+          @pacts ||= pact_service.find_pact_versions_for_provider_and_consumer provider_name, consumer_name, branch_name: identifier_from_path[:branch_name]
         end
 
         def delete_resource

--- a/lib/pact_broker/doc/views/index/branch-pact-versions.markdown
+++ b/lib/pact_broker/doc/views/index/branch-pact-versions.markdown
@@ -1,0 +1,7 @@
+# Branch pact versions
+
+Allowed methods: `GET`
+
+Path: `/pacts/provider/{provider}/consumer/{consumer}/branch/{branch}`
+
+Lists all the pact versions with the specified consumer, provider and consumer version branch.

--- a/lib/pact_broker/doc/views/index/latest-branch-pact-version.markdown
+++ b/lib/pact_broker/doc/views/index/latest-branch-pact-version.markdown
@@ -1,0 +1,7 @@
+# Latest Branch pact versions
+
+Allowed methods: `GET`
+
+Path: `/pacts/provider/{provider}/consumer/{consumer}/branch/{branch}/latest`
+
+Returns the latest pact version with the specified consumer, provider and consumer version branch.

--- a/lib/pact_broker/pacts/repository.rb
+++ b/lib/pact_broker/pacts/repository.rb
@@ -168,6 +168,19 @@ module PactBroker
         query.all.collect(&:to_domain).sort
       end
 
+      def find_pact_versions_for_provider_and_consumer provider_name, consumer_name, branch_name = nil
+        query = scope_for(PactPublication)
+          .eager_for_domain_with_content
+          .select_all_qualified
+          .for_consumer_name(consumer_name)
+          .for_provider_name(provider_name)
+          .remove_overridden_revisions
+        if branch_name
+          query = query.old_latest_for_consumer_branch(branch_name)
+        end
+        query.latest_by_consumer_version_order.all.collect(&:to_domain_with_content)
+      end
+  
       # Returns latest pact version for the consumer_version_number
       def find_by_consumer_version consumer_name, consumer_version_number
         scope_for(PactPublication)

--- a/lib/pact_broker/pacts/service.rb
+++ b/lib/pact_broker/pacts/service.rb
@@ -99,6 +99,10 @@ module PactBroker
         pact_repository.find_pact_versions_for_provider provider_name, options[:tag]
       end
 
+      def find_pact_versions_for_provider_and_consumer provider_name, consumer_name, options = {}
+        pact_repository.find_pact_versions_for_provider_and_consumer provider_name, consumer_name, options[:branch_name]
+      end
+
       def find_previous_distinct_pact_version params
         pact = find_pact params
         return nil if pact.nil?


### PR DESCRIPTION
fixes #619 

# Branch pact versions

Allowed methods: `GET`

Path: `/pacts/provider/{provider}/consumer/{consumer}/branch/{branch}`

Lists all the pact versions with the specified consumer, provider and consumer version branch.

# Latest Branch pact versions

Allowed methods: `GET`

Path: `/pacts/provider/{provider}/consumer/{consumer}/branch/{branch}/latest`

Returns the latest pact version with the specified consumer, provider and consumer version branch.

