### PR TITLE
fix: make sure last_action_date always returns a DateTime object

### DIFF
--- a/lib/pact_broker/matrix/matrix_row_instance_methods.rb
+++ b/lib/pact_broker/matrix/matrix_row_instance_methods.rb
@@ -129,7 +129,13 @@ module PactBroker
       end
 
       def last_action_date
-        return_or_raise_if_not_set(:last_action_date)
+        date = return_or_raise_if_not_set(:last_action_date)
+
+        if date.class == String
+          DateTime.parse(date)
+        else
+          date
+        end
       end
 
       def has_verification?


### PR DESCRIPTION
* `last_action_date` seems to be returning a string in somecases, adding a check and parsing to makesure it is correct object