### PR TITLE
chore: revert make padrino sinatra optional. It breaks pactflow builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,6 @@ gem "rake", "~>12.3.3"
 gem "sqlite3", ">=2.0.0"
 gem "conventional-changelog", "~>1.3"
 gem "bump", "~> 0.5"
-gem "padrino-core", ">= 0.14.3", "~> 0.14", require: false
-gem "sinatra", "~> 3.0", require: false
 
 group :development do
   gem "pry-byebug"

--- a/pact_broker.gemspec
+++ b/pact_broker.gemspec
@@ -61,6 +61,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "rack", ">= 2.2.3", "~> 2.2" # TODO update to 3
   gem.add_runtime_dependency "redcarpet", ">= 3.5.1", "~>3.5"
   gem.add_runtime_dependency "pact-support" , "~> 1.16", ">= 1.16.4"
+  gem.add_runtime_dependency "padrino-core", ">= 0.14.3", "~> 0.14"
+  gem.add_runtime_dependency "sinatra", "~> 3.0"
   gem.add_runtime_dependency "haml", "~>5.0"
   gem.add_runtime_dependency "sucker_punch", "~>3.0"
   gem.add_runtime_dependency "rack-protection", "~> 3.0"


### PR DESCRIPTION
Reverting This change as it does not help with with the Sinatra CVE until we can replace padrino-core entirely.