### PR TITLE
chore: remove redundant CSS

### DIFF
--- a/lib/pact_broker/doc/views/layouts/main.haml
+++ b/lib/pact_broker/doc/views/layouts/main.haml
@@ -1,5 +1,3 @@
 %html
-  %head
-    %link{rel: 'stylesheet', href: "#{base_url}/css/bootstrap.min.css"}
   %body{style: 'margin:20px'}
     != yield

--- a/spec/lib/pact_broker/doc/controllers/app_spec.rb
+++ b/spec/lib/pact_broker/doc/controllers/app_spec.rb
@@ -26,20 +26,6 @@ module PactBroker
               subject
               expect(last_response.body).to include "<html>"
             end
-
-            context "with the base_url not set" do
-              it "returns relative links" do
-                expect(subject.body).to include "href='/css"
-              end
-            end
-
-            context "with the base_url set" do
-              let(:rack_env) { { "pactbroker.base_url" => "http://example.org/pact-broker"} }
-
-              it "returns absolute links" do
-                expect(subject.body).to include "href='http://example.org/pact-broker/css"
-              end
-            end
           end
 
           context "when the resource does not exist" do


### PR DESCRIPTION
All of the docs are written in markdown *without* any bootstrap styles anyway.