### PR TITLE
feat: support extended verification results

### DIFF
--- a/db/migrations/20240112_add_client_language_verified_by_to_verification.rb
+++ b/db/migrations/20240112_add_client_language_verified_by_to_verification.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    add_column(:verifications, :verified_by_client_implementation, String)
+    add_column(:verifications, :verified_by_client_version, String)
+    add_column(:verifications, :verified_by_client_test_framework, String)
+  end
+end

--- a/lib/pact_broker/api/decorators/verification_decorator.rb
+++ b/lib/pact_broker/api/decorators/verification_decorator.rb
@@ -18,6 +18,9 @@ module PactBroker
         nested :verifiedBy do
           property :verified_by_implementation, as: :implementation
           property :verified_by_version, as: :version
+          property :verified_by_client_implementation, as: :client_implementation
+          property :verified_by_client_test_framework, as: :client_test_framework
+          property :verified_by_client_version, as: :client_version
         end
 
         link :self do | options |

--- a/lib/pact_broker/doc/views/pact/publish-verification-results.markdown
+++ b/lib/pact_broker/doc/views/pact/publish-verification-results.markdown
@@ -11,3 +11,21 @@ Use a `POST` request to the `pb:publish-verification-results` link (`$['_links']
     }
 
 Multiple verification results may be published for the same pact resource. The most recently published one will be considered to reflect the current status of verification.
+
+Optionally the body can contain details about the Pact implementation which performed the verification, and test results, which support arbitrary json
+
+    {
+      "providerApplicationVersion": "1",
+      "success": true,
+      "buildUrl": "http://build-url",
+      "testResults": [],
+      "verifiedBy": {
+        "implementation": "Pact-Rust",
+        "version": "1.0.0",
+        "clientLanguage": {
+          "testFramework": "TEST",
+          "name": "TESTER",
+          "version": "1.2.3"
+        }
+      }
+    }

--- a/lib/pact_broker/domain/verification.rb
+++ b/lib/pact_broker/domain/verification.rb
@@ -259,6 +259,9 @@ end
 #  pact_pending                     | boolean                     |
 #  verified_by_implementation       | text                        |
 #  verified_by_version              | text                        |
+#  verified_by_client_implementation| text                        |
+#  verified_by_client_version       | text                        |
+#  verified_by_client_test_framework| text                        |
 # Indexes:
 #  verifications_pkey                          | PRIMARY KEY btree (id)
 #  verifications_pact_version_id_number_index  | UNIQUE btree (pact_version_id, number)

--- a/lib/pact_broker/verifications/service.rb
+++ b/lib/pact_broker/verifications/service.rb
@@ -46,6 +46,9 @@ module PactBroker
         verification.number = next_verification_number
         verification.verified_by_implementation = params.dig("verifiedBy", "implementation")
         verification.verified_by_version = params.dig("verifiedBy", "version")
+        verification.verified_by_client_implementation = params.dig("verifiedBy", "clientLanguage", "name")
+        verification.verified_by_client_version = params.dig("verifiedBy", "clientLanguage", "version")
+        verification.verified_by_client_test_framework = params.dig("verifiedBy", "clientLanguage", "testFramework")
         verification.consumer_version_selector_hashes = event_context[:consumer_version_selectors]
         pact_version = pact_repository.find_pact_version(first_verified_pact.consumer, first_verified_pact.provider, first_verified_pact.pact_version_sha)
         verification = verification_repository.create(verification, provider_version_number, pact_version)

--- a/spec/lib/pact_broker/api/decorators/verification_decorator_spec.rb
+++ b/spec/lib/pact_broker/api/decorators/verification_decorator_spec.rb
@@ -22,7 +22,10 @@ module PactBroker
             execution_date: DateTime.now,
             provider_version_tags: provider_version_tags,
             verified_by_implementation: "Ruby",
-            verified_by_version: "1234")
+            verified_by_version: "1234",
+            verified_by_client_implementation: "go test",
+            verified_by_client_version: "2.2.0",
+            verified_by_client_test_framework: "pact-go")
         end
 
         let(:pact) do

--- a/spec/lib/pact_broker/api/decorators/verification_summary_decorator_spec.rb
+++ b/spec/lib/pact_broker/api/decorators/verification_summary_decorator_spec.rb
@@ -23,7 +23,10 @@ module PactBroker
             execution_date: DateTime.now,
             provider_version_tags: provider_version_tags,
             verified_by_implementation: "Ruby",
-            verified_by_version: "1234")
+            verified_by_version: "1234",
+            verified_by_client_implementation: "go test",
+            verified_by_client_version: "2.2.0",
+            verified_by_client_test_framework: "pact-go")
         end
 
         let(:pact_version) do

--- a/spec/lib/pact_broker/verifications/service_spec.rb
+++ b/spec/lib/pact_broker/verifications/service_spec.rb
@@ -30,7 +30,12 @@ module PactBroker
             "testResults" => { "some" => "results" },
             "verifiedBy" => {
               "implementation" => "Ruby",
-              "version" => "1234"
+              "version" => "1234",
+              "clientLanguage" => {
+                "testFramework" => "go test",
+                "name" => "pact-go",
+                "version" => "2.2.0",
+              }
             }
           }
         end
@@ -61,6 +66,9 @@ module PactBroker
           expect(verification.tag_names).to eq ["dev"]
           expect(verification.verified_by_implementation).to eq "Ruby"
           expect(verification.verified_by_version).to eq "1234"
+          expect(verification.verified_by_client_implementation).to eq "pact-go"
+          expect(verification.verified_by_client_version).to eq "2.2.0"
+          expect(verification.verified_by_client_test_framework).to eq "go test"
         end
 
         it "sets the pact content for the verification" do


### PR DESCRIPTION
Optionally the body can contain details about the Pact implementation which performed the verification, and test results, which support arbitrary json

    {
      "providerApplicationVersion": "1",
      "success": true,
      "buildUrl": "http://build-url",
      "testResults": [],
      "verifiedBy": {
        "implementation": "Pact-Rust",
        "version": "1.0.0",
        "clientLanguage": {
          "testFramework": "TEST",
          "name": "TESTER",
          "version": "1.2.3"
        }
      }
    }

Relates to https://github.com/pact-foundation/pact-go/issues/499


Question - 

Would it be better to support arbitrary fields in `clientLanguage`, similar to `testResults, to better support extensibility.

<img width="659" alt="Screenshot 2025-02-12 at 15 58 01" src="https://github.com/user-attachments/assets/0715ec8a-6285-4546-bc6d-ea293dd37db3" />
