### PR TITLE
fix: lowercase x-pact-broker-version / cache-control headers for rack3

### DIFF
--- a/db/test/backwards_compatibility/spec/publish_pact_spec.rb
+++ b/db/test/backwards_compatibility/spec/publish_pact_spec.rb
@@ -29,7 +29,7 @@ describe "Code version #{CODE_VERSION} running against database version #{DATABA
 
   describe "tagging a consumer version" do
     let(:path) { "/pacticipants/Foo/versions/#{CONSUMER_VERSION}/tags/#{TAG}"}
-    subject { put path, nil, {"CONTENT_TYPE" => "application/json" }; last_response  }
+    subject { put path, nil, {"content-type" => "application/json" }; last_response  }
 
     it "returns a success status" do
       expect(subject.status.to_s).to match(/20\d/)
@@ -37,7 +37,7 @@ describe "Code version #{CODE_VERSION} running against database version #{DATABA
   end
 
   describe "publishing a pact" do
-    subject { put path, pact_content, {"CONTENT_TYPE" => "application/json" }; last_response  }
+    subject { put path, pact_content, {"content-type" => "application/json" }; last_response  }
 
     it "returns a success status" do
       expect(subject.status.to_s).to match(/20\d/)

--- a/docs/configuration.yml
+++ b/docs/configuration.yml
@@ -356,7 +356,7 @@ groups:
         default_value: https://img.shields.io
         more_info: https://shields.io
       badge_default_cache_setting:
-        description: Cache Control header value for the badge, this  sets the Cache-Control header for the badge image, for more information on header formats see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+        description: Cache Control header value for the badge, this  sets the cache-control header for the badge image, for more information on header formats see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/cache-control
         default_value: "max-age=30"
 
       badge_provider_mode:

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,10 +1,10 @@
 source "https://rubygems.org"
 
 gem "pact_broker", path: "../" # Would pin this to a known minor version when using properly eg. gem "pact_broker", "~> 2.90"
-gem "puma", "~> 6.6" # Can be replaced with your choice of application server
+gem "puma", "~> 6.6" # Can be replaced with your choice of application server such as 'webrick', 'thin, 'puma' etc
+# gem "webrick"
 gem "sqlite3", "~>2.0" # Sqlite is just for testing. Replace this with "pg" for production.
 # gem "pg" # Production database gem
 gem "padrino-core", ">= 0.16.0.pre3"
 gem "sinatra", "~> 4.0"
 
-gem "webrick" # webmachine loads this by default

--- a/lib/pact_broker/api/resources/badge.rb
+++ b/lib/pact_broker/api/resources/badge.rb
@@ -18,12 +18,12 @@ module PactBroker
         end
 
         def to_svg
-          response.headers["Cache-Control"] = "no-cache"
+          response.headers["cache-control"] = "no-cache"
           comment + badge_service.pact_verification_badge(pact, label, initials, pseudo_branch_verification_status, tags)
         end
 
         def moved_temporarily?
-          response.headers["Cache-Control"] = "no-cache"
+          response.headers["cache-control"] = "no-cache"
           badge_service.pact_verification_badge_url(pact, label, initials, pseudo_branch_verification_status, tags)
         end
 

--- a/lib/pact_broker/api/resources/badge_methods.rb
+++ b/lib/pact_broker/api/resources/badge_methods.rb
@@ -47,7 +47,7 @@ module PactBroker
         end
 
         def set_cache_control(cache_control_str)
-          response.headers["Cache-Control"] = cache_control_str
+          response.headers["cache-control"] = cache_control_str
         end
 
         private

--- a/lib/pact_broker/api/resources/error_handling_methods.rb
+++ b/lib/pact_broker/api/resources/error_handling_methods.rb
@@ -32,13 +32,13 @@ module PactBroker
         # @param [String] type
         # @param [Integer] status
         def set_json_error_message(detail, title: "Server error", type: "server-error", status: 500)
-          response.headers["Content-Type"] = error_response_content_type
+          response.headers["content-type"] = error_response_content_type
           response.body = error_response_body(detail, title, type, status)
         end
 
         # @param [Hash,Dry::Validation::MessageSet] errors
         def set_json_validation_error_messages(errors)
-          response.headers["Content-Type"] = error_response_content_type
+          response.headers["content-type"] = error_response_content_type
           response.body = validation_errors_response_body(errors)
         end
 

--- a/lib/pact_broker/api/resources/error_response_generator.rb
+++ b/lib/pact_broker/api/resources/error_response_generator.rb
@@ -68,9 +68,9 @@ module PactBroker
 
         private_class_method def self.headers(env)
           if problem_json?(env)
-            { "Content-Type" => "application/problem+json;charset=utf-8" }
+            { "content-type" => "application/problem+json;charset=utf-8" }
           else
-            { "Content-Type" => "application/hal+json;charset=utf-8" }
+            { "content-type" => "application/hal+json;charset=utf-8" }
           end
         end
 

--- a/lib/pact_broker/api/resources/pact_resource_methods.rb
+++ b/lib/pact_broker/api/resources/pact_resource_methods.rb
@@ -15,7 +15,7 @@ module PactBroker
             }
           end
           response.body = response_body.to_json
-          response.headers["Content-Type" => "application/hal+json;charset=utf-8"]
+          response.headers["content-type" => "application/hal+json;charset=utf-8"]
         end
       end
     end

--- a/lib/pact_broker/api/resources/pacticipant_resource_methods.rb
+++ b/lib/pact_broker/api/resources/pacticipant_resource_methods.rb
@@ -8,7 +8,7 @@ module PactBroker
             messages = pacticipant_service.messages_for_potential_duplicate_pacticipants pacticipant_names, base_url
             if messages.any?
               response.body = messages.join("\n")
-              response.headers["Content-Type"] = "text/plain"
+              response.headers["content-type"] = "text/plain"
             end
             messages.any?
           else

--- a/lib/pact_broker/api/resources/publish_contracts.rb
+++ b/lib/pact_broker/api/resources/publish_contracts.rb
@@ -97,7 +97,7 @@ module PactBroker
               contracts: conflict_notices.select(&:error?).collect(&:text)
             }
           }.to_json
-          response.headers["Content-Type"] = "application/json;charset=utf-8"
+          response.headers["content-type"] = "application/json;charset=utf-8"
         end
 
         def conflict_notices

--- a/lib/pact_broker/api/resources/webhook_execution.rb
+++ b/lib/pact_broker/api/resources/webhook_execution.rb
@@ -21,7 +21,7 @@ module PactBroker
 
         def process_post
           webhook_execution_result = webhook_trigger_service.test_execution(webhook, webhook_execution_configuration.webhook_context, webhook_execution_configuration)
-          response.headers["Content-Type"] = "application/hal+json;charset=utf-8"
+          response.headers["content-type"] = "application/hal+json;charset=utf-8"
           response.body = post_response_body(webhook_execution_result)
           true
         end

--- a/lib/pact_broker/app.rb
+++ b/lib/pact_broker/app.rb
@@ -197,7 +197,7 @@ module PactBroker
       @app_builder.use Rack::PactBroker::AddPactBrokerVersionHeader
       @app_builder.use Rack::PactBroker::AddVaryHeader
       @app_builder.use Rack::Static, :urls => ["/stylesheets", "/css", "/fonts", "/js", "/javascripts", "/images"], :root => PactBroker.project_root.join("public")
-      @app_builder.use Rack::Static, :urls => ["/favicon.ico"], :root => PactBroker.project_root.join("public/images"), header_rules: [[:all, {"Content-Type" => "image/x-icon"}]]
+      @app_builder.use Rack::Static, :urls => ["/favicon.ico"], :root => PactBroker.project_root.join("public/images"), header_rules: [[:all, {"content-type" => "image/x-icon"}]]
       @app_builder.use Rack::PactBroker::AddCacheHeader
       @app_builder.use Rack::PactBroker::ConvertFileExtensionToAcceptHeader
       # Rack::PactBroker::SetBaseUrl needs to be before the Rack::PactBroker::HalBrowserRedirect

--- a/lib/pact_broker/test/test_data_builder.rb
+++ b/lib/pact_broker/test/test_data_builder.rb
@@ -362,7 +362,7 @@ module PactBroker
                          params[:events] || [{ name: PactBroker::Webhooks::WebhookEvent::DEFAULT_EVENT_NAME }]
                        end
         events = event_params.collect{ |e| PactBroker::Webhooks::WebhookEvent.new(e) }
-        template_params = { method: "POST", url: "http://example.org", headers: {"Content-Type" => "application/json"}, username: params[:username], password: params[:password] }
+        template_params = { method: "POST", url: "http://example.org", headers: {"content-type" => "application/json"}, username: params[:username], password: params[:password] }
         request = PactBroker::Webhooks::WebhookRequestTemplate.new(template_params.merge(params))
         new_webhook = PactBroker::Domain::Webhook.new(
           request: request,

--- a/lib/pact_broker/ui/controllers/dashboard.rb
+++ b/lib/pact_broker/ui/controllers/dashboard.rb
@@ -70,7 +70,7 @@ module PactBroker
         private
 
         def set_headers
-          response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+          response.headers["cache-control"] = "no-cache, no-store, must-revalidate"
           response.headers["Pragma"] = "no-cache"
           response.headers["Expires"] = "0"
         end

--- a/lib/pact_broker/ui/controllers/index.rb
+++ b/lib/pact_broker/ui/controllers/index.rb
@@ -55,7 +55,7 @@ module PactBroker
         private
 
         def set_headers
-          response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+          response.headers["cache-control"] = "no-cache, no-store, must-revalidate"
           response.headers["Pragma"] = "no-cache"
           response.headers["Expires"] = "0"
         end

--- a/lib/rack/pact_broker/add_cache_header.rb
+++ b/lib/rack/pact_broker/add_cache_header.rb
@@ -7,7 +7,7 @@ module Rack
 
       def call(env)
         status, headers, body = @app.call(env)
-        [status, { "Cache-Control" => "no-cache" }.merge(headers || {}), body]
+        [status, { "cache-control" => "no-cache" }.merge(headers || {}), body]
       end
     end
   end

--- a/lib/rack/pact_broker/add_pact_broker_version_header.rb
+++ b/lib/rack/pact_broker/add_pact_broker_version_header.rb
@@ -4,7 +4,7 @@ module Rack
   module PactBroker
     class AddPactBrokerVersionHeader
 
-      X_PACT_BROKER_VERSION = "X-Pact-Broker-Version".freeze
+      X_PACT_BROKER_VERSION = "x-pact-broker-version".freeze
 
       def initialize app
         @app = app

--- a/lib/rack/pact_broker/add_vary_header.rb
+++ b/lib/rack/pact_broker/add_vary_header.rb
@@ -32,7 +32,7 @@ module Rack
 
       def call(env)
         status, headers, body = @app.call(env)
-        [status, { "Vary" => "Accept" }.merge(headers || {}), body]
+        [status, { "vary" => "Accept" }.merge(headers || {}), body]
       end
     end
   end

--- a/lib/rack/pact_broker/cascade.rb
+++ b/lib/rack/pact_broker/cascade.rb
@@ -18,7 +18,7 @@ module Rack
   module PactBroker
     class Cascade
       # deprecated, no longer used
-      NotFound = [404, { CONTENT_TYPE => "text/plain" }, []]
+      NotFound = [404, { "content-type" => "text/plain" }, []]
 
       # An array of applications to try in order.
       attr_reader :apps
@@ -41,7 +41,7 @@ module Rack
       # cascading, try the next app.  If all responses require cascading,
       # return the response from the last app.
       def call(env)
-        return [404, { CONTENT_TYPE => "text/plain" }, []] if @apps.empty?
+        return [404, { "content-type" => "text/plain" }, []] if @apps.empty?
         result = nil
         last_body = nil
 

--- a/lib/rack/pact_broker/invalid_uri_protection.rb
+++ b/lib/rack/pact_broker/invalid_uri_protection.rb
@@ -58,7 +58,7 @@ module Rack
       end
 
       def headers
-        {"Content-Type" => "application/problem+json"}
+        {"content-type" => "application/problem+json"}
       end
 
       def body(env, detail, title, type, status)

--- a/lib/rack/pact_broker/request_target.rb
+++ b/lib/rack/pact_broker/request_target.rb
@@ -20,7 +20,7 @@ module Rack
       private
 
       def body_is_json(env)
-        env["CONTENT_TYPE"]&.include?("json")
+        env["content-type"]&.include?("json")
       end
 
       def explicit_request_for_api(env)
@@ -32,7 +32,7 @@ module Rack
       end
 
       def body_is_api_content_type(env)
-        is_api_content_type((env["CONTENT_TYPE"]&.downcase) || "")
+        is_api_content_type((env["content-type"]&.downcase) || "")
       end
 
       def is_api_content_type(header)

--- a/lib/webmachine/adapters.rb
+++ b/lib/webmachine/adapters.rb
@@ -1,0 +1,9 @@
+require "webmachine/adapters/lazy_request_body"
+# require "webmachine/adapters/webrick" # Commenting out this line as our monkey patch
+
+module Webmachine
+  # Contains classes and modules that connect Webmachine to Ruby
+  # application servers.
+  module Adapters
+  end
+end

--- a/lib/webmachine/render_error_monkey_patch.rb
+++ b/lib/webmachine/render_error_monkey_patch.rb
@@ -36,7 +36,7 @@ module Webmachine
       message = options[:message] if options[:message]
 
       res.body = error_response_body(req, message, title, title.dasherize.gsub(/^\d+\-/, ""), code, req)
-      res.headers[CONTENT_TYPE] = error_response_content_type(req)
+      res.headers["content-type"] = error_response_content_type(req)
     end
     ensure_content_length(res)
     ensure_date_header(res)

--- a/spec/lib/pact_broker/api/resources/badge_spec.rb
+++ b/spec/lib/pact_broker/api/resources/badge_spec.rb
@@ -92,7 +92,7 @@ module PactBroker
             end
 
             it "does not allow caching" do
-              expect(subject.headers["Cache-Control"]).to eq "no-cache"
+              expect(subject.headers["cache-control"]).to eq "no-cache"
             end
 
             it "returns the badge" do
@@ -117,7 +117,7 @@ module PactBroker
             it "returns a 301 redirect to the badge URL" do
               expect(subject.status).to eq 307
               expect(subject.headers["Location"]).to eq "http://badge"
-              expect(subject.headers["Cache-Control"]).to eq "no-cache"
+              expect(subject.headers["cache-control"]).to eq "no-cache"
             end
           end
 

--- a/spec/lib/pact_broker/api/resources/can_i_merge_badge_spec.rb
+++ b/spec/lib/pact_broker/api/resources/can_i_merge_badge_spec.rb
@@ -35,7 +35,7 @@ module PactBroker
           it "return the badge URL" do
             expect(badge_service). to receive(:can_i_merge_badge_url).with(deployable: true)
             expect(subject.headers["Location"]).to eq "http://badge_url"
-            expect(subject.headers["Cache-Control"]).to eq "max-age=30"
+            expect(subject.headers["cache-control"]).to eq "max-age=30"
           end
         end
 
@@ -45,7 +45,7 @@ module PactBroker
           it "returns an error badge URL" do
             expect(badge_service).to receive(:error_badge_url).with("pacticipant", "not found")
             expect(subject.headers["Location"]).to eq "http://error_badge_url"
-            expect(subject.headers["Cache-Control"]).to eq "no-cache"  
+            expect(subject.headers["cache-control"]).to eq "no-cache"  
           end
         end
 

--- a/spec/lib/pact_broker/api/resources/error_response_generator_spec.rb
+++ b/spec/lib/pact_broker/api/resources/error_response_generator_spec.rb
@@ -21,7 +21,7 @@ module PactBroker
           subject { JSON.parse(headers_and_body.last) }
 
           it "returns headers" do
-            expect(headers).to eq("Content-Type" => "application/hal+json;charset=utf-8")
+            expect(headers).to eq("content-type" => "application/hal+json;charset=utf-8")
           end
 
           it "includes an error reference" do
@@ -40,7 +40,7 @@ module PactBroker
             let(:rack_env) { { "HTTP_ACCEPT" => "application/hal+json, application/problem+json", "pactbroker.base_url" => "http://example.org", "pactbroker.application_context" => PactBroker::ApplicationContext.default_application_context } }
 
             it "returns headers" do
-              expect(headers).to eq("Content-Type" => "application/problem+json;charset=utf-8")
+              expect(headers).to eq("content-type" => "application/problem+json;charset=utf-8")
             end
 
             it "returns a problem JSON body" do

--- a/spec/lib/pact_broker/app_spec.rb
+++ b/spec/lib/pact_broker/app_spec.rb
@@ -26,9 +26,9 @@ module PactBroker
       end
     end
 
-    it "adds the X-Pact-Broker-Version header" do
+    it "adds the x-pact-broker-version header" do
       get "/"
-      expect(last_response.headers["X-Pact-Broker-Version"]).to match(/\d/)
+      expect(last_response.headers["x-pact-broker-version"]).to match(/\d/)
     end
 
     class TestMiddleware

--- a/spec/lib/rack/pact_broker/add_pact_broker_version_header_spec.rb
+++ b/spec/lib/rack/pact_broker/add_pact_broker_version_header_spec.rb
@@ -8,7 +8,7 @@ module Rack
 
       it "adds the PactBroker version as a header" do
         get "/"
-        expect(last_response.headers["X-Pact-Broker-Version"]).to match(/\d/)
+        expect(last_response.headers["x-pact-broker-version"]).to match(/\d/)
       end
 
     end

--- a/spec/lib/webmachine/render_error_monkey_patch_spec.rb
+++ b/spec/lib/webmachine/render_error_monkey_patch_spec.rb
@@ -19,7 +19,7 @@ module Webmachine
       expect(JSON.parse(subject.body)).to eq "error" => "The requested document was not found on this server."
     end
 
-    its(:headers) { is_expected.to include("Content-Type" => "application/json;charset=utf-8") }
+    its(:headers) { is_expected.to include("content-type" => "application/json;charset=utf-8") }
 
     context "when the Accept header contains text/html" do
       let(:request_headers) { Webmachine::Headers.from_cgi("HTTP_ACCEPT" => "text/html") }
@@ -42,7 +42,7 @@ module Webmachine
         }
       end
 
-      its(:headers) { is_expected.to include("Content-Type" => "application/problem+json;charset=utf-8") }
+      its(:headers) { is_expected.to include("content-type" => "application/problem+json;charset=utf-8") }
 
       it "returns a JSON body in problem json format" do
         expect(JSON.parse(subject.body)).to eq expected_body


### PR DESCRIPTION
The Rack3 upgrade #784 was released in https://github.com/pact-foundation/pact_broker/releases/tag/v2.113.1

However in trying to consume in the pact-broker-docker project, I am getting errors

```
pact-broker-1  | 2025-03-04 14:22:47 +0000 Rack app ("GET /diagnostic/status/heartbeat" - (172.18.0.4)): #<LoadError: cannot load such file -- webrick>
```

I also noted the example project was included in the repo fails when run, and invoked

https://github.com/pact-foundation/pact-broker-docker/actions/runs/13654993034/job/38171882397#step:9:779

it shows the same `cannot load such file -- webrick` error, if webrick (which has explicitly been added in the example project as part of the Rack 3 PR) is removed.

When the example project is run `bundle exec rackup`, it will return errors.

```
Rack::Lint::LintError: uppercase character in header name: Vary (Rack::Lint::LintError)
```

and for other headers (`X-Pact-Broker-Version` / `Cache-Control`)

This resolves it for the example project to at least load the broker index via a curl call. I haven't done any further smoke testing


Pulled in this branch to the pact-broker-docker repo to test 

https://github.com/pact-foundation/pact-broker-docker/pull/241/commits/8fa77b472efd298c249af9c6f43a9cf36d691846

test run here 

https://github.com/pact-foundation/pact-broker-docker/actions/runs/13656421029