### PR TITLE
chore: bump rack to 3.1.11 to address CVE CVE-2025-27111

### DIFF
--- a/pact_broker.gemspec
+++ b/pact_broker.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "sequel", "~> 5.28"
   gem.add_runtime_dependency "webmachine", ">= 2.0.0.beta", "< 3.0"
   gem.add_runtime_dependency "semver2", "~> 3.4.2"
-  gem.add_runtime_dependency "rack", "~> 3.1", ">= 3.1.10"
+  gem.add_runtime_dependency "rack", "~> 3.1", ">= 3.1.11"
   gem.add_runtime_dependency "redcarpet", ">= 3.5.1", "~>3.5"
   gem.add_runtime_dependency "pact-support" , ">= 1.21.2", "~> 1.21"
   gem.add_runtime_dependency "haml", "~>5.0"


### PR DESCRIPTION

CVE-2025-27111