### PR TITLE
Ci/add pg 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres_docker_image_tag: ["17", "16", "15", "14", "9.6"]
+        postgres_docker_image_tag: ["16", "15", "14", "9.6"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: script/test/run-rake-on-docker-compose-postgres.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres_docker_image_tag: ["15", "14", "9.6"]
+        postgres_docker_image_tag: ["17", "16", "15", "14", "9.6"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: script/test/run-rake-on-docker-compose-postgres.sh


### PR DESCRIPTION
Supersedes https://github.com/pact-foundation/pact_broker/pull/774

Tests Pact Broker against latest available versions of pg, missing from CI test matrix

https://endoflife.date/postgresql

Table correct on 30/01/2025

| Release | Released                              | Support Status                             | Latest |
| ------- | ------------------------------------- | ------------------------------------------ | ------ |
| 16      | 1 year and 4 months ago (14 Sep 2023) | Ends in 3 years and 9 months (09 Nov 2028) | 16.6   |

Relates to https://github.com/pact-foundation/pact-broker-chart/pull/105