### PR TITLE
Ci/add pg 17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres_docker_image_tag: ["16", "15", "14", "9.6"]
+        postgres_docker_image_tag: ["17", "16", "15", "14", "9.6"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: script/test/run-rake-on-docker-compose-postgres.sh

--- a/lib/pact_broker/labels/repository.rb
+++ b/lib/pact_broker/labels/repository.rb
@@ -5,7 +5,7 @@ module PactBroker
     class Repository
 
       def get_all_unique_labels pagination_options = {}
-        PactBroker::Domain::Label.distinct.select(:name).all_with_pagination_options(pagination_options)
+        PactBroker::Domain::Label.distinct.select(:name).order(:name).all_with_pagination_options(pagination_options)
       end
 
       def create args

--- a/spec/lib/pact_broker/labels/repository_spec.rb
+++ b/spec/lib/pact_broker/labels/repository_spec.rb
@@ -19,8 +19,8 @@ module PactBroker
         context "when there are no pagination options" do
           subject { labels_repository.get_all_unique_labels }
 
-          it "returns all the unique labels" do
-            expect(subject.collect(&:name)).to contain_exactly("ios", "android")
+          it "returns all the unique ordered labels" do
+            expect(subject.collect(&:name)).to contain_exactly("android", "ios")
           end
         end
 
@@ -33,8 +33,8 @@ module PactBroker
           end
           subject { labels_repository.get_all_unique_labels pagination_options }
 
-          it "returns paginated unique labels" do
-            expect(subject.collect(&:name)).to contain_exactly("ios")
+          it "returns paginated unique ordered labels" do
+            expect(subject.collect(&:name)).to contain_exactly("android")
           end
         end
       end


### PR DESCRIPTION
Supersedes https://github.com/pact-foundation/pact_broker/pull/774

Tests Pact Broker against latest available versions of pg, missing from CI test matrix

https://endoflife.date/postgresql

Table correct on 30/01/2025

| Release | Released                              | Support Status                             | Latest |
| ------- | ------------------------------------- | ------------------------------------------ | ------ |
| 17      | 4 months ago (26 Sep 2024)            | Ends in 4 years and 9 months (08 Nov 2029) | 17.2   |

Relates to https://github.com/pact-foundation/pact-broker-chart/pull/105