### PR TITLE
Feat/aggregate provider states by consumers

### DIFF
--- a/lib/pact_broker/api/decorators/provider_states_decorator.rb
+++ b/lib/pact_broker/api/decorators/provider_states_decorator.rb
@@ -6,13 +6,30 @@ module PactBroker
       class ProviderStateDecorator < BaseDecorator
         camelize_property_names
 
-        property :name
-        property :params
-
+        property :name, getter: -> (context) { context[:represented][:name] }
+        property :params, getter: -> (context) { context[:represented][:params] }
+        property :consumers, getter: -> (context) { context[:represented][:consumers] }
       end
 
       class ProviderStatesDecorator < BaseDecorator
-        collection :providerStates, getter: -> (context) { context[:represented].sort_by(&:name) }, :extend => PactBroker::Api::Decorators::ProviderStateDecorator
+        collection :providerStates, getter: -> (context) { 
+          consumers_map = {}
+            
+            context[:represented].each do |item|
+              item["providerStates"].each do |provider_state|
+                provider_state = provider_state.to_h
+                provider_state[:consumers] ||= []
+                provider_state[:consumers] << item["consumer"]
+                consumers_map[[provider_state[:name], provider_state[:params]]] ||= []
+                consumers_map[[provider_state[:name], provider_state[:params]]] += provider_state[:consumers]
+              end
+            end
+
+            consumers_map.map do |(name, params), consumers|
+              { name: name, params: params, consumers: consumers.uniq }.transform_keys(&:to_sym)
+            end
+          .sort_by { |provider_state| provider_state[:name] }
+        }, :extend => PactBroker::Api::Decorators::ProviderStateDecorator
       end
     end
   end

--- a/lib/pact_broker/pacts/provider_state_service.rb
+++ b/lib/pact_broker/pacts/provider_state_service.rb
@@ -15,7 +15,7 @@ module PactBroker
         query = scope_for(PactPublication).eager_for_domain_with_content.for_provider_and_consumer_version_selector(provider, PactBroker::Pacts::Selector.latest_for_main_branch)
         query.all.flat_map do | pact_publication |
           pact_publication.to_domain.content_object.provider_states
-        end
+        end.uniq
       end
     end
   end

--- a/lib/pact_broker/pacts/provider_state_service.rb
+++ b/lib/pact_broker/pacts/provider_state_service.rb
@@ -14,8 +14,8 @@ module PactBroker
       def self.list_provider_states(provider)
         query = scope_for(PactPublication).eager_for_domain_with_content.for_provider_and_consumer_version_selector(provider, PactBroker::Pacts::Selector.latest_for_main_branch)
         query.all.flat_map do | pact_publication |
-          pact_publication.to_domain.content_object.provider_states
-        end.uniq
+          { "providerStates" => pact_publication.to_domain.content_object.provider_states, "consumer" => pact_publication.to_domain.consumer.name }
+        end
       end
     end
   end

--- a/spec/features/list_provider_states_spec.rb
+++ b/spec/features/list_provider_states_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "listing the provider states without params" do
 
   let(:path) { "/pacts/provider/Bar/provider-states" }
 
-  subject { get(path, nil, rack_headers).tap { |it| puts it.body } }
+  subject { get(path, nil, rack_headers) }
 
   it { 
     is_expected.to be_a_hal_json_success_response
@@ -120,7 +120,7 @@ RSpec.describe "listing the provider states with params" do
 
   let(:path) { "/pacts/provider/Bar/provider-states" }
 
-  subject { get(path, nil, rack_headers).tap { |it| puts it.body } }
+  subject { get(path, nil, rack_headers) }
 
   it { 
     is_expected.to be_a_hal_json_success_response

--- a/spec/features/list_provider_states_spec.rb
+++ b/spec/features/list_provider_states_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe "listing the provider states without params" do
 
   let(:expected_hash) do
     {
-      "providerStates" => [ 
-        { "name" => "state 1" }, 
-        { "name" => "state 2" }, 
-        { "name" => "state 3" }, 
-        { "name" => "state 4" }, 
-        { "name" => "state 5" } 
+      "providerStates" => [
+        { "consumers" => ["Foo"], "name" => "state 1" },
+        { "consumers" => ["Foo"], "name" => "state 2" },
+        { "consumers" => ["Waffle"], "name" => "state 3" },
+        { "consumers" => ["Waffle"], "name" => "state 4" },
+        { "consumers" => ["Waffle"], "name" => "state 5" }
       ]
     }
   end
@@ -108,9 +108,10 @@ RSpec.describe "listing the provider states with params" do
 
   let(:expected_hash) do
     {
-      "providerStates" => [ 
-        { "name" => "product details", "params"=>{"product_id"=>"058925f7-1763-4dd9-a057-50ee265e33a0"}  }, 
-        { "name" => "product list" },
+      "providerStates" => [
+        { "consumers" => ["Foo", "Foo2", "Foo3", "Foo4", "Foo5"], "name" => "product details", "params" => { "product_id" => "058925f7-1763-4dd9-a057-50ee265e33a0" } },
+        { "consumers" => ["Waffle", "Waffle2"], "name" => "product list" },
+        { "consumers" => ["Foo6"], "name" => "some other product list" }
       ]
     }
   end

--- a/spec/features/list_provider_states_spec.rb
+++ b/spec/features/list_provider_states_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "listing the provider states" do
+RSpec.describe "listing the provider states without params" do
   before do
     td.create_consumer("Foo", main_branch: "main")
       .publish_pact(consumer_name: "Foo", provider_name: "Bar", consumer_version_number: "1", branch: "main", json_content: pact_content_1.to_json)
@@ -35,10 +35,95 @@ RSpec.describe "listing the provider states" do
     }
   end
 
+  let(:expected_hash) do
+    {
+      "providerStates" => [ 
+        { "name" => "state 1" }, 
+        { "name" => "state 2" }, 
+        { "name" => "state 3" }, 
+        { "name" => "state 4" }, 
+        { "name" => "state 5" } 
+      ]
+    }
+  end
+
+  let(:response_body_hash) { JSON.parse(subject.body) }
+
   let(:path) { "/pacts/provider/Bar/provider-states" }
 
   subject { get(path, nil, rack_headers).tap { |it| puts it.body } }
 
-  it { is_expected.to be_a_hal_json_success_response }
+  it { 
+    is_expected.to be_a_hal_json_success_response
+    expect(response_body_hash).to eq expected_hash
+  }
+
+end
+
+RSpec.describe "listing the provider states with params" do
+  before do
+    td.create_consumer("Foo", main_branch: "main")
+      .publish_pact(consumer_name: "Foo", provider_name: "Bar", consumer_version_number: "1", branch: "main", json_content: pact_content_1.to_json)
+      .publish_pact(consumer_name: "Foo2", provider_name: "Bar", consumer_version_number: "1", branch: "main", json_content: pact_content_1.to_json)
+      .publish_pact(consumer_name: "Foo3", provider_name: "Bar", consumer_version_number: "1", branch: "main", json_content: pact_content_1.to_json)
+      .publish_pact(consumer_name: "Foo4", provider_name: "Bar", consumer_version_number: "1", branch: "main", json_content: pact_content_1.to_json)
+      .publish_pact(consumer_name: "Foo5", provider_name: "Bar", consumer_version_number: "1", branch: "main", json_content: pact_content_1.to_json)
+      .publish_pact(consumer_name: "Foo6", provider_name: "Bar", consumer_version_number: "1", branch: "main", json_content: pact_content_3.to_json)
+      .publish_pact(consumer_name: "Foo", provider_name: "Bar", consumer_version_number: "2", branch: "not-main").create_consumer("Waffle", main_branch: "main")
+      .publish_pact(consumer_name: "Waffle", provider_name: "Bar", consumer_version_number: "1", branch: "main", json_content: pact_content_2.to_json)
+      .publish_pact(consumer_name: "Waffle2", provider_name: "Bar", consumer_version_number: "1", branch: "main", json_content: pact_content_2.to_json)
+  end
+
+  let(:rack_headers) { { "HTTP_ACCEPT" => "application/hal+json" } }
+
+  let(:pact_content_1) do
+    {
+      interactions: [
+        {
+          providerStates: [ { name: "product details", params: { product_id: "058925f7-1763-4dd9-a057-50ee265e33a0" } } ]
+        },
+      ]
+    }
+  end
+
+  let(:pact_content_2) do
+    {
+      interactions: [
+        {
+          providerStates: [ { name: "product list" } ]
+        }
+      ]
+    }
+  end
+
+  let(:pact_content_3) do
+    {
+      interactions: [
+        {
+          providerStates: [ { name: "some other product list" } ]
+        }
+      ]
+    }
+  end
+
+  let(:expected_hash) do
+    {
+      "providerStates" => [ 
+        { "name" => "product details", "params"=>{"product_id"=>"058925f7-1763-4dd9-a057-50ee265e33a0"}  }, 
+        { "name" => "product list" },
+      ]
+    }
+  end
+
+  let(:response_body_hash) { JSON.parse(subject.body) }
+
+  let(:path) { "/pacts/provider/Bar/provider-states" }
+
+  subject { get(path, nil, rack_headers).tap { |it| puts it.body } }
+
+  it { 
+    is_expected.to be_a_hal_json_success_response
+    expect(response_body_hash).to eq expected_hash
+  }
 
 end

--- a/spec/lib/pact_broker/api/resources/provider_states_spec.rb
+++ b/spec/lib/pact_broker/api/resources/provider_states_spec.rb
@@ -16,17 +16,28 @@ module PactBroker
         let(:json) { 
           { "providerStates":
           [
-            {"name":"an error occurs retrieving an alligator"},
-            {"name":"there is an alligator named Mary"},
-            {"name":"there is not an alligator named Mary"}
-          ]}.to_json 
+            {"name":"an error occurs retrieving an alligator", "consumers":["foo"]},
+            {"name":"there is an alligator named Mary", "consumers":["bar","foo"]},
+            {"name":"there is not an alligator named Mary", "consumers":["bar"]}
+          ]}.to_json
         }
 
         let(:provider_states) do
           [
-            PactBroker::Pacts::ProviderState.new(name: "there is an alligator named Mary", params: nil),
-            PactBroker::Pacts::ProviderState.new(name: "there is not an alligator named Mary", params: nil),
-            PactBroker::Pacts::ProviderState.new(name: "an error occurs retrieving an alligator", params: nil)
+            { "providerStates" =>
+              [
+                PactBroker::Pacts::ProviderState.new(name: "there is an alligator named Mary", params: nil),
+                PactBroker::Pacts::ProviderState.new(name: "there is not an alligator named Mary", params: nil),
+              ],
+              "consumer" => "bar"
+            },
+            { "providerStates" =>
+              [
+                PactBroker::Pacts::ProviderState.new(name: "there is an alligator named Mary", params: nil),
+                PactBroker::Pacts::ProviderState.new(name: "an error occurs retrieving an alligator", params: nil)
+              ],
+              "consumer" => "foo"
+            }
           ]
         end
 


### PR DESCRIPTION
[feat: group provider states by consumers](https://github.com/pact-foundation/pact_broker/commit/ad66c2ab064fb85c09c23a82718fbacebf640117) 

```ruby
    {
      "providerStates" => [
        { "consumers" => ["Foo", "Foo2", "Foo3", "Foo4", "Foo5"], "name" => "product details", "params" => { "product_id" => "058925f7-1763-4dd9-a057-50ee265e33a0" } },
        { "consumers" => ["Waffle", "Waffle2"], "name" => "product list" },
        { "consumers" => ["Foo6"], "name" => "some other product list" }
      ]
    }
```

Fixes #789