### PR TITLE
chore(ci): test maintained version of postgres

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres_docker_image_tag: ["17", "16", "15", "14", "9.6"]
+        postgres_docker_image_tag:
+          - "13"
+          - "14"
+          - "15"
+          - "16"
+          - "17"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: script/test/run-rake-on-docker-compose-postgres.sh


### PR DESCRIPTION
Postgres 17 and 13 were missing from the matrix, and no longer testing 9.6 as it has not beem maintained since November 2021.
