### PR TITLE
feat: add tag_versions endpoint

### DIFF
--- a/lib/pact_broker/api.rb
+++ b/lib/pact_broker/api.rb
@@ -152,6 +152,8 @@ module PactBroker
         add ["integrations", "provider", :provider_name, "consumer", :consumer_name], Api::Resources::Integration, {resource_name: "integration"}
         add ["metrics"], Api::Resources::Metrics, {resource_name: "metrics"}
         add [], Api::Resources::Index, {resource_name: "index"}
+
+        add ["pacticipants", :pacticipant_name, "tags", :tag_name, "versions"], Api::Resources::TagVersions, {resource_name: "pacticipant_tag_versions"}
       end
     end
   end

--- a/lib/pact_broker/api/pact_broker_urls.rb
+++ b/lib/pact_broker/api/pact_broker_urls.rb
@@ -414,6 +414,10 @@ module PactBroker
         end
       end
 
+      def tag_versions_url(tag, base_url = "")
+        "#{pacticipant_url(base_url, tag.pacticipant)}/tags/#{tag.name}/versions"
+      end
+
       private
 
       def representable_pact pact

--- a/lib/pact_broker/api/resources/tag_versions.rb
+++ b/lib/pact_broker/api/resources/tag_versions.rb
@@ -1,0 +1,53 @@
+require "pact_broker/api/resources/base_resource"
+require "pact_broker/api/decorators/versions_decorator"
+require "pact_broker/api/resources/pagination_methods"
+
+module PactBroker
+  module Api
+    module Resources
+      class TagVersions < BaseResource
+        include PactBroker::Api::Resources::PaginationMethods
+
+        def allowed_methods
+          ["GET", "OPTIONS"]
+        end
+
+        def malformed_request?
+          super || request.get? && validation_errors_for_schema?(schema, request.query)
+        end
+
+        def content_types_provided
+          [["application/hal+json", :to_json]]
+        end
+
+        def policy_name
+          :'versions::versions'
+        end
+
+        def resource_exists?
+          !tags.empty?
+        end
+
+        def to_json
+          decorator_class(:versions_decorator).new(tag_versions).to_json(**decorator_options)
+        end
+
+        private
+
+        def tag_versions
+          @versions ||= version_service.find_by_ids_in_reverse_order(@tags.select_map(:version_id), pagination_options, decorator_class(:versions_decorator).eager_load_associations)
+        end
+
+        def tags
+          @tags ||= tag_service.find_all_by_pacticipant_name_and_tag(**identifier_from_path.slice(:pacticipant_name, :tag_name))
+        end
+
+        def schema
+          if request.get?
+            PactBroker::Api::Contracts::PaginationQueryParamsSchema
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pact_broker/tags/repository.rb
+++ b/lib/pact_broker/tags/repository.rb
@@ -1,8 +1,11 @@
 require "pact_broker/domain/tag"
+require "pact_broker/repositories"
 
 module PactBroker
   module Tags
     class Repository
+      include PactBroker::Repositories
+
       def create args
         params = {
           name: args.fetch(:name),
@@ -37,6 +40,14 @@ module PactBroker
         .distinct
         .collect{ |tag| tag[:name] }.sort
       end
+
+      def find_all_by_pacticipant_name_and_tag(pacticipant_name, tag_name)
+        pacticipant = pacticipant_repository.find_by_name(pacticipant_name)
+        return PactBroker::Domain::Tag.where(pacticipant_id: pacticipant.id, name: tag_name) if pacticipant
+
+        []
+      end
+
     end
   end
 end

--- a/lib/pact_broker/tags/service.rb
+++ b/lib/pact_broker/tags/service.rb
@@ -32,6 +32,10 @@ module PactBroker
       def find_all_tag_names_for_pacticipant pacticipant_name
         tag_repository.find_all_tag_names_for_pacticipant pacticipant_name
       end
+
+      def find_all_by_pacticipant_name_and_tag pacticipant_name:, tag_name:
+        tag_repository.find_all_by_pacticipant_name_and_tag pacticipant_name, tag_name
+      end
     end
   end
 end

--- a/lib/pact_broker/versions/repository.rb
+++ b/lib/pact_broker/versions/repository.rb
@@ -174,6 +174,15 @@ module PactBroker
           latest_from_main_branch || find_by_pacticipant_name_and_latest_tag(pacticipant.name, pacticipant.main_branch)
         end
       end
+
+      def find_by_ids_in_reverse_order version_ids, pagination_options = {}, eager_load_associations =[]
+        query = PactBroker::Domain::Version
+                  .where(id: version_ids)
+                  .eager(*eager_load_associations)
+                  .reverse_order(:order)
+
+        query.all_with_pagination_options(pagination_options)
+      end
     end
   end
 end

--- a/lib/pact_broker/versions/service.rb
+++ b/lib/pact_broker/versions/service.rb
@@ -66,6 +66,11 @@ module PactBroker
           PactBroker.configuration.use_first_tag_as_branch &&
           ((now - version.created_at.to_datetime) * 24 * 60 * 60) <= PactBroker.configuration.use_first_tag_as_branch_time_limit
       end
+
+      def self.find_by_ids_in_reverse_order version_ids, pagination_options = {}, eager_load_associations = []
+        version_repository.find_by_ids_in_reverse_order version_ids, pagination_options, eager_load_associations
+      end
+
       private_class_method :use_tag_as_branch?
 
       def self.now

--- a/spec/features/get_tag_versions_spec.rb
+++ b/spec/features/get_tag_versions_spec.rb
@@ -1,0 +1,40 @@
+describe "Get versions for Pacticipant Tag" do
+  before do
+    td.create_consumer("Boo")
+      .create_version("1.2.3")
+      .create_tag("prod")
+      .and_return(:tag)
+  end
+  let(:tag) { PactBroker::Domain::Tag.first }
+  let(:path) { PactBroker::Api::PactBrokerUrls.tag_versions_url(tag) }
+  let(:headers) { { "CONTENT_TYPE" => "application/json" } }
+
+  subject { get(path, {}, headers) }
+
+  it { is_expected.to be_a_hal_json_success_response }
+
+  it "returns the tags versions" do
+    expect(JSON.parse(subject.body).dig("_embedded", "versions").size).to eq 1
+  end
+
+  context "when the pacticipant does not exist" do 
+    let(:path) { "pacticipants/Foo/tags/#{tag.name}/versions" }
+
+    its(:status) { is_expected.to eq 404 }
+  end
+
+  context "when the tag does not exist" do
+    let(:path) { "pacticipants/Boo/tags/feature_tag/versions" }
+
+    its(:status) { is_expected.to eq 404 }
+  end
+
+  context "with pagination options" do
+    subject { get(path, { "size" => "1", "page" => "1" }) }
+
+    it "only returns the number of items specified in the size" do
+      expect(JSON.parse(subject.body).dig("_embedded", "versions").size).to eq 1
+    end
+
+  end
+end

--- a/spec/lib/pact_broker/tags/repository_spec.rb
+++ b/spec/lib/pact_broker/tags/repository_spec.rb
@@ -136,6 +136,23 @@ module PactBroker
           expect(subject).to eq ["dev", "master", "prod"]
         end
       end
+
+      describe ".find_all_by_pacticipant_name_and_tag" do 
+        before do
+          td.create_consumer("Boo")
+            .create_version("1.0.0")
+            .create_tag("prod")
+            .create_consumer("Bar")
+            .create_version("1.0.3")
+            .create_tag("main")
+        end
+
+        subject { Repository.new.find_all_by_pacticipant_name_and_tag("Boo", "prod") }
+
+        it "returns all the tags for that pacticipant" do
+          expect(subject.collect(&:name)).to eq ["prod"]
+        end
+      end
     end
   end
 end

--- a/spec/lib/pact_broker/versions/repository_spec.rb
+++ b/spec/lib/pact_broker/versions/repository_spec.rb
@@ -349,6 +349,31 @@ module PactBroker
           it { is_expected.to be_nil }
         end
       end
+
+      describe "#find_by_ids_in_reverse_order" do 
+        before do
+          td.create_consumer("Boo")
+            .create_version("1.0.0")
+            .create_tag("prod")
+            .create_version("1.0.3")
+            .create_tag("main")
+        end
+
+        let(:version_ids) { Domain::Version.all.collect(&:id) }
+        subject { Repository.new.find_by_ids_in_reverse_order(version_ids) }
+
+        it "returns all the application versions for given ids" do
+          expect(subject.collect(&:id).length).to eq 2
+        end
+
+        context "with pagination options" do
+          subject { Repository.new.find_by_ids_in_reverse_order version_ids, { page_number: 1, page_size: 1 } }
+
+          it "paginates the query" do
+            expect(subject.collect(&:id).length).to eq 1
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR introduces a new endpoint:

GET `/pacticipants/:pacticipant_name/tags/:tag_name/versions`

Returns all versions associated with a specific tag (:tag_name) for a given pacticipant (:pacticipant_name). This enhancement enables clients to efficiently query tagged versions for a pacticipant, improving tag-based filtering.