### PR TITLE
fix: restore pact-support back to rubygems rather than git pre-release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,6 @@ gem "conventional-changelog", "~>1.3"
 gem "bump", "~> 0.5"
 gem "padrino-core", ">= 0.16.0.pre3", require: false
 gem "rackup", "~> 2.2"
-# TODO: using release-candidate of pact-support is release remove this and restore to gemspec.
-gem "pact-support", github: "pact-foundation/pact-support", branch: "release-1.21.3.rc1"
 
 group :development do
   gem "pry-byebug"

--- a/pact_broker.gemspec
+++ b/pact_broker.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "redcarpet", ">= 3.5.1", "~>3.5"
   # TODO: restore this with when latest master is released as 1.21.3
   # remove the Gemfile entry pointing to master
-  # gem.add_runtime_dependency "pact-support" , ">= 1.21.3", "~> 1.21"
+  gem.add_runtime_dependency "pact-support" , ">= 1.21.3", "~> 1.21"
   gem.add_runtime_dependency "haml", "~>5.0"
   gem.add_runtime_dependency "sucker_punch", "~>3.0"
   gem.add_runtime_dependency "rack-protection", "~> 4.1"


### PR DESCRIPTION
Revert to using pact-support now that the release candidate 1.21.3 rc1 has been released.