### PR TITLE
feat: support provider states by branch/env

### DIFF
--- a/lib/pact_broker/api.rb
+++ b/lib/pact_broker/api.rb
@@ -47,6 +47,8 @@ module PactBroker
         # Provider states
 
         add ["pacts", "provider", :provider_name, "provider-states"], Api::Resources::ProviderStates, { resource_name: "provider_states" }
+        add ["pacts", "provider", :provider_name, "provider-states", "branch", :branch_name], Api::Resources::ProviderStates, { resource_name: "provider_states_for_branch" }
+        add ["pacts", "provider", :provider_name, "provider-states", "environment", :environment_uuid], Api::Resources::ProviderStates, { resource_name: "provider_states_for_environment" }
 
 
         # Verifications

--- a/lib/pact_broker/api/resources/provider_states.rb
+++ b/lib/pact_broker/api/resources/provider_states.rb
@@ -25,12 +25,18 @@ module PactBroker
           :'pacts::pact'
         end
 
+        def environment_uuid
+          identifier_from_path[:environment_uuid]
+        end
+
+        def branch_name
+          identifier_from_path[:branch_name]
+        end
+
         private
 
-        # attr_reader :provider_states
-
         def provider_states
-          @provider_states ||= provider_state_service.list_provider_states(provider)
+          @provider_states ||= provider_state_service.list_provider_states(provider, branch_name, environment_uuid)
         end
       end
     end

--- a/lib/pact_broker/doc/views/pact/provider-states.markdown
+++ b/lib/pact_broker/doc/views/pact/provider-states.markdown
@@ -2,11 +2,19 @@
 
 Allowed methods: `GET`
 
-Path: `/pacts/provider/{provider}/provider-states`
-
 This resource returns a aggregated de-duplicated list of all provider states for a given provider.
 
+Path: `/pacts/provider/{provider}/provider-states`
+
 Provider states are collected from the latest pact on the main branch for any dependant consumers.
+
+Path: `/pacts/provider/{provider}/provider-states/branch/{branch_name}`
+
+Provider states are collected from the latest pacts on the specified branch for any dependant consumers.
+
+Path: `/pacts/provider/{provider}/provider-states/environment/{environment_name}`
+
+Provider states are collected from the latest pacts in the specified environment for any dependant consumers.
 
 Example response
 
@@ -25,4 +33,3 @@ Example response
     ]
 }
 ```
-

--- a/lib/pact_broker/pacts/provider_state_service.rb
+++ b/lib/pact_broker/pacts/provider_state_service.rb
@@ -11,8 +11,16 @@ module PactBroker
       extend PactBroker::Services
       extend PactBroker::Repositories::Scopes
 
-      def self.list_provider_states(provider)
-        query = scope_for(PactPublication).eager_for_domain_with_content.for_provider_and_consumer_version_selector(provider, PactBroker::Pacts::Selector.latest_for_main_branch)
+      def self.list_provider_states(provider, branch_name = nil, environment_name = nil)
+        selector =
+          if branch_name
+            PactBroker::Pacts::Selector.latest_for_branch(branch_name)
+          elsif environment_name
+            PactBroker::Pacts::Selector.for_environment(environment_name)
+          else
+            PactBroker::Pacts::Selector.latest_for_main_branch
+          end
+        query = scope_for(PactPublication).eager_for_domain_with_content.for_provider_and_consumer_version_selector(provider, selector)
         query.all.flat_map do | pact_publication |
           { "providerStates" => pact_publication.to_domain.content_object.provider_states, "consumer" => pact_publication.to_domain.consumer.name }
         end

--- a/spec/lib/pact_broker/api/resources/provider_states_spec.rb
+++ b/spec/lib/pact_broker/api/resources/provider_states_spec.rb
@@ -12,7 +12,7 @@ module PactBroker
         end
 
         let(:provider) { double("Example API") }
-        let(:path) { "/pacts/provider/Example%20API/provider-states" }
+        let(:base_path) { "/pacts/provider/Example%20API/provider-states" }
         let(:json) { 
           { "providerStates":
           [
@@ -40,12 +40,82 @@ module PactBroker
             }
           ]
         end
+        describe "GET - provider states" do
 
-        describe "GET - provider states where they exist" do
-          subject { get path; last_response }
+          describe "GET - provider states where they exist" do
+            subject { get base_path; last_response }
 
-          it "attempts to find the ProviderStates" do
-            expect(PactBroker::Pacts::ProviderStateService).to receive(:list_provider_states)
+            it "attempts to find the ProviderStates" do
+              expect(PactBroker::Pacts::ProviderStateService).to receive(:list_provider_states)
+              subject
+            end
+
+            it "returns a 200 response status" do
+              expect(subject.status).to eq 200
+            end
+
+            it "returns the correct JSON body" do
+              expect(subject.body).to eq json
+            end
+
+            it "returns the correct content type" do
+              expect(subject.headers["Content-Type"]).to include("application/hal+json")
+            end
+          end
+
+        describe "GET - provider states where do not exist" do
+          let(:provider_states) { [] }
+          let(:json) { { "providerStates": [] }.to_json }
+          subject { get base_path; last_response }
+
+          it "returns a 200 response status" do
+            expect(subject.status).to eq 200
+          end
+
+          it "returns the correct JSON body" do
+            expect(subject.body).to eq json
+          end
+
+          it "returns the correct content type" do
+            expect(subject.headers["Content-Type"]).to include("application/hal+json")
+          end
+        end
+
+        describe "GET - where provider does not exist" do
+          let(:provider) { nil }
+          let(:json) { {"error":"No provider with name 'Example API' found"}.to_json }
+          subject { get base_path; last_response }
+
+          it "returns a 404 response status" do
+            expect(subject.status).to eq 404
+          end
+
+          it "returns the correct JSON error body" do
+            expect(subject.body).to eq json
+          end
+
+          it "returns the correct content type" do
+            expect(subject.headers["Content-Type"]).to include("application/hal+json")
+          end
+        end
+        end
+
+        describe "GET - provider states for environment" do
+          let(:environment) { "test-env" }
+          let(:env_path) { "#{base_path}/environment/#{environment}" }
+          let(:json) { 
+            { "providerStates":
+            [
+              {"name":"an error occurs retrieving an alligator", "consumers":["foo"]},
+              {"name":"there is an alligator named Mary", "consumers":["bar","foo"]},
+              {"name":"there is not an alligator named Mary", "consumers":["bar"]}
+            ]}.to_json
+          }
+
+          subject { get env_path; last_response }
+
+          it "calls list_provider_states with environment" do
+            expect(PactBroker::Pacts::ProviderStateService).to receive(:list_provider_states).with(provider, nil, environment)
             subject
           end
 
@@ -60,17 +130,52 @@ module PactBroker
           it "returns the correct content type" do
             expect(subject.headers["Content-Type"]).to include("application/hal+json")
           end
-        end
-        describe "GET - provider states where do not exist" do
-          let(:provider_states) do
-            []
+
+          context "when provider states do not exist for environment" do
+            let(:provider_states) { [] }
+            let(:json) { { "providerStates": [] }.to_json }
+
+            it "returns a 200 response status" do
+              expect(subject.status).to eq 200
+            end
+
+            it "returns the correct JSON body" do
+              expect(subject.body).to eq json
+            end
           end
+
+          context "when provider does not exist" do
+            let(:provider) { nil }
+            let(:json) { {"error":"No provider with name 'Example API' found"}.to_json }
+
+            it "returns a 404 response status" do
+              expect(subject.status).to eq 404
+            end
+
+            it "returns the correct JSON error body" do
+              expect(subject.body).to eq json
+            end
+          end
+        end
+
+        describe "GET - provider states for branch" do
+          let(:branch) { "main" }
+          let(:branch_path) { "#{base_path}/branch/#{branch}" }
           let(:json) { 
             { "providerStates":
-            []}.to_json 
+            [
+              {"name":"an error occurs retrieving an alligator", "consumers":["foo"]},
+              {"name":"there is an alligator named Mary", "consumers":["bar","foo"]},
+              {"name":"there is not an alligator named Mary", "consumers":["bar"]}
+            ]}.to_json
           }
-  
-          subject { get path; last_response }
+
+          subject { get branch_path; last_response }
+
+          it "calls list_provider_states with branch" do
+            expect(PactBroker::Pacts::ProviderStateService).to receive(:list_provider_states).with(provider, branch, nil)
+            subject
+          end
 
           it "returns a 200 response status" do
             expect(subject.status).to eq 200
@@ -83,24 +188,31 @@ module PactBroker
           it "returns the correct content type" do
             expect(subject.headers["Content-Type"]).to include("application/hal+json")
           end
-        end
-        describe "GET - where provider does not exist" do
 
-          let(:provider) { nil }
-          let(:json) { {"error":"No provider with name 'Example API' found"}.to_json }
+          context "when provider states do not exist for branch" do
+            let(:provider_states) { [] }
+            let(:json) { { "providerStates": [] }.to_json }
 
-          subject { get path; last_response }
+            it "returns a 200 response status" do
+              expect(subject.status).to eq 200
+            end
 
-          it "returns a 404 response status" do
-            expect(subject.status).to eq 404
+            it "returns the correct JSON body" do
+              expect(subject.body).to eq json
+            end
           end
 
-          it "returns the correct JSON error body" do
-            expect(subject.body).to eq json
-          end
+          context "when provider does not exist" do
+            let(:provider) { nil }
+            let(:json) { {"error":"No provider with name 'Example API' found"}.to_json }
 
-          it "returns the correct content type" do
-            expect(subject.headers["Content-Type"]).to include("application/hal+json")
+            it "returns a 404 response status" do
+              expect(subject.status).to eq 404
+            end
+
+            it "returns the correct JSON error body" do
+              expect(subject.body).to eq json
+            end
           end
         end
       end


### PR DESCRIPTION
Add the following endpoints to allow scoping of returned provider states, based on a named consumer branch or environment

`/pacts/provider/{provider}/provider-states/environment/{environment_name}`
`/pacts/provider/{provider}/provider-states/branch/{branch_name}`

