### PR TITLE
Revert "feat: PACT-4511/updated matrix decorator to return app instance for an env if present"

### DIFF
--- a/lib/pact_broker/api/decorators/embedded_environment_decorator.rb
+++ b/lib/pact_broker/api/decorators/embedded_environment_decorator.rb
@@ -9,7 +9,6 @@ module PactBroker
         property :name
         property :display_name, camelize: true
         property :production
-        property :application_instance, getter: ->(options) { options[:user_options].fetch(:application_instance, nil) }, writeable: false, camelize: true
 
         include Timestamps
 

--- a/lib/pact_broker/api/decorators/matrix_decorator.rb
+++ b/lib/pact_broker/api/decorators/matrix_decorator.rb
@@ -111,8 +111,8 @@ module PactBroker
         end
 
         def environments(deployed_versions, released_versions, base_url)
-          (deployed_versions + released_versions).sort_by(&:created_at).collect { |v| [v.environment, v.is_a?(Deployments::DeployedVersion) ? v.application_instance : nil] }.uniq.collect do | environment, application_instance |
-            environment_decorator_class.new(environment).to_hash(user_options: { base_url: base_url, application_instance: application_instance })
+          (deployed_versions + released_versions).sort_by(&:created_at).collect(&:environment).uniq.collect do | environment |
+            environment_decorator_class.new(environment).to_hash(user_options: { base_url: base_url })
           end
         end
 

--- a/spec/lib/pact_broker/api/decorators/matrix_decorator_spec.rb
+++ b/spec/lib/pact_broker/api/decorators/matrix_decorator_spec.rb
@@ -86,7 +86,16 @@ module PactBroker
 
                   }
                 ],
-                environments: environments,
+                environments: [
+                  {
+                    name: "test",
+                    displayName: "Test"
+                  },
+                  {
+                    name: "production",
+                    displayName: "Production"
+                  }
+                ],
                 _links: {
                   self: {
                     href: "http://example.org/pacticipants/Consumer/versions/1.0.0"
@@ -124,7 +133,16 @@ module PactBroker
                     latest: true
                   }
                 ],
-                environments: environments,
+                environments: [
+                  {
+                    name: "test",
+                    displayName: "Test"
+                  },
+                  {
+                    name: "production",
+                    displayName: "Production"
+                  }
+                ],
                 _links: {
                   self: {
                     href: "http://example.org/pacticipants/Provider/versions/4.5.6"
@@ -143,19 +161,6 @@ module PactBroker
                 ]
               }
             }
-          end
-
-          let(:environments) do
-            [
-              {
-                name: "test",
-                displayName: "Test"
-              },
-              {
-                name: "production",
-                displayName: "Production"
-              }
-            ]
           end
 
           let(:verification_hash) do
@@ -189,11 +194,9 @@ module PactBroker
 
           let(:deployed_versions) do
             [
-              instance_double("PactBroker::Deployments::DeployedVersion", environment: test_environment, created_at: DateTime.new(2021, 1, 1), application_instance: application_instance, is_a?: true)
+              instance_double("PactBroker::Deployments::DeployedVersion", environment: test_environment, created_at: DateTime.new(2021, 1, 1))
             ]
           end
-
-          let(:application_instance) { nil }
 
           let(:released_versions) do
             [
@@ -253,40 +256,12 @@ module PactBroker
           let(:json) { MatrixDecorator.new(query_results_with_deployment_status_summary).to_json(user_options: { base_url: "http://example.org" }) }
           let(:parsed_json) { JSON.parse(json, symbolize_names: true) }
 
-          context "when application instance is not set" do
-            it "includes the consumer details" do
-              expect(parsed_json[:matrix][0][:consumer]).to match_pact consumer_hash
-            end
-
-            it "includes the provider details" do
-              expect(parsed_json[:matrix][0][:provider]).to match_pact provider_hash
-            end
+          it "includes the consumer details" do
+            expect(parsed_json[:matrix][0][:consumer]).to match_pact consumer_hash
           end
 
-          context "when application instance is set" do
-            let(:environments) do
-              [
-                {
-                  name: "test",
-                  displayName: "Test",
-                  applicationInstance: "test-instance"
-                },
-                {
-                  name: "production",
-                  displayName: "Production"
-                }
-              ]
-            end
-
-            let(:application_instance) { "test-instance" }
-
-            it "includes the consumer details" do
-              expect(parsed_json[:matrix][0][:consumer]).to match_pact consumer_hash
-            end
-
-            it "includes the provider details" do
-              expect(parsed_json[:matrix][0][:provider]).to match_pact provider_hash
-            end
+          it "includes the provider details" do
+            expect(parsed_json[:matrix][0][:provider]).to match_pact provider_hash
           end
 
           it "includes the verification details" do


### PR DESCRIPTION
Reverts pact-foundation/pact_broker#838

The change can cause trouble in the future with respect to how the customer interprets the response. The key `application_instance` doesn't fit right under the `environments` node. Seems like `application_instance` is a column under `environments` table 