### PR TITLE
chore(test): support pact-broker-cli pact verifications

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,9 +108,10 @@ jobs:
         with:
           bundler-cache: true
       - name: Verify pacts
-        run: "GIT_SHA=${GITHUB_SHA} GIT_BRANCH=${GITHUB_REF##*/} bundle exec rake pact:verify"
+        run: "GIT_SHA=${GITHUB_SHA} bundle exec rake pact:verify"
         env:
-          PACTFLOW_PACT_FOUNDATION_TOKEN: ${{ secrets.PACTFLOW_PACT_FOUNDATION_TOKEN }}
+          PACT_BROKER_TOKEN: ${{ secrets.PACTFLOW_PACT_FOUNDATION_TOKEN }}
+          PACT_BROKER_BASE_URL: https://pact-foundation.pactflow.io
 
   pact-v2-verify:
     runs-on: "ubuntu-latest"

--- a/spec/service_consumers/hal_relation_proxy_app.rb
+++ b/spec/service_consumers/hal_relation_proxy_app.rb
@@ -53,36 +53,44 @@ class HalRelationProxyApp
     "latestby=cvpv&q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bversion%5D=4.5.6" =>
       "q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Bversion%5D=4.5.6&latestby=cvpv",
     # pact-ruby-v2 pact (as v2) verified by pact-ruby-v1
-    "latestby=cvpv&q[][pacticipant]=Foo&q[][pacticipant]=Bar&q[][version]=1%2e2%2e3&q[][version]=4%2e5%2e6" =>
-      "q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Bversion%5D=4.5.6&latestby=cvpv",
+    # "latestby=cvpv&q[][pacticipant]=Foo&q[][pacticipant]=Bar&q[][version]=1%2e2%2e3&q[][version]=4%2e5%2e6" =>
+    #   "q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Bversion%5D=4.5.6&latestby=cvpv",
 
     # pact-ruby-v2 pact (as v2) verified by pact-ruby-v2
     "latestby=cvpv&q%5B%5D%5Bpacticipant%5D=Foo+Thing&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bversion%5D=4.5.6" =>
       "q%5B%5D%5Bpacticipant%5D=Foo%20Thing&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Bversion%5D=4.5.6&latestby=cvpv",
     # pact-ruby-v2 pact (as v2) verified by pact-ruby-v1
-    "latestby=cvpv&q[][pacticipant]=Foo+Thing&q[][pacticipant]=Bar&q[][version]=1%2e2%2e3&q[][version]=4%2e5%2e6" =>
-      "q%5B%5D%5Bpacticipant%5D=Foo%20Thing&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Bversion%5D=4.5.6&latestby=cvpv",
+    # "latestby=cvpv&q[][pacticipant]=Foo+Thing&q[][pacticipant]=Bar&q[][version]=1%2e2%2e3&q[][version]=4%2e5%2e6" =>
+    #   "q%5B%5D%5Bpacticipant%5D=Foo%20Thing&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Bversion%5D=4.5.6&latestby=cvpv",
 
     # pact-ruby-v2 pact (as v2) verified by pact-ruby-v2
     "latestby=cvpv&q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bversion%5D=9.9.9" =>
       "q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Bversion%5D=9.9.9&latestby=cvpv",
     # pact-ruby-v2 pact (as v2) verified by pact-ruby-v1
-    "latestby=cvpv&q[][pacticipant]=Foo&q[][pacticipant]=Bar&q[][version]=1%2e2%2e3&q[][version]=9%2e9%2e9" =>
-      "q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Bversion%5D=9.9.9&latestby=cvpv",
+    # "latestby=cvpv&q[][pacticipant]=Foo&q[][pacticipant]=Bar&q[][version]=1%2e2%2e3&q[][version]=9%2e9%2e9" =>
+    #   "q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Bversion%5D=9.9.9&latestby=cvpv",
 
     # pact-ruby-v2 pact (as v2) verified by pact-ruby-v2 
     "latestby=cvpv&q%5B%5D%5Blatest%5D=true&q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Btag%5D=prod&q%5B%5D%5Bversion%5D=1.2.3" => 
       "q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Blatest%5D=true&q%5B%5D%5Btag%5D=prod&latestby=cvpv",
     # pact-ruby-v2 pact (as v2) verified by pact-ruby-v1
-    "latestby=cvpv&q[][latest]=true&q[][pacticipant]=Foo&q[][pacticipant]=Bar&q[][tag]=prod&q[][version]=1%2e2%2e3" => 
-      "q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Blatest%5D=true&q%5B%5D%5Btag%5D=prod&latestby=cvpv",
+    # "latestby=cvpv&q[][latest]=true&q[][pacticipant]=Foo&q[][pacticipant]=Bar&q[][tag]=prod&q[][version]=1%2e2%2e3" => 
+    #   "q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bversion%5D=1.2.3&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Blatest%5D=true&q%5B%5D%5Btag%5D=prod&latestby=cvpv",
 
     # pact-ruby-v2 pact (as v2) verified by pact-ruby-v2
     "latestby=cvpv&q%5B%5D%5Blatest%5D=true&q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Bversion%5D=1.2.4" => 
       "q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bversion%5D=1.2.4&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Blatest%5D=true&latestby=cvpv",
     # pact-ruby-v2 pact (as v2) verified by pact-ruby-v1
-    "latestby=cvpv&q[][latest]=true&q[][pacticipant]=Foo&q[][pacticipant]=Bar&q[][version]=1%2e2%2e4" => 
-      "q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bversion%5D=1.2.4&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Blatest%5D=true&latestby=cvpv",
+    # "latestby=cvpv&q[][latest]=true&q[][pacticipant]=Foo&q[][pacticipant]=Bar&q[][version]=1%2e2%2e4" => 
+    #   "q%5B%5D%5Bpacticipant%5D=Foo&q%5B%5D%5Bversion%5D=1.2.4&q%5B%5D%5Bpacticipant%5D=Bar&q%5B%5D%5Blatest%5D=true&latestby=cvpv",
+    # pact-broker-cli rust rewrite (unordered query params)
+   "latestby=cvpv&q[][latest]=true&q[][pacticipant]=Foo&q[][tag]=prod&q[][version]=1%2e2%2e3&q[][pacticipant]=Bar" => "q[][pacticipant]=Foo&q[][version]=1%2e2%2e3&q[][pacticipant]=Bar&q[][latest]=true&q[][tag]=prod&latestby=cvpv",
+   "latestby=cvpv&q[][latest]=true&q[][pacticipant]=Foo&q[][version]=1%2e2%2e4&q[][pacticipant]=Bar" => "q[][pacticipant]=Foo&q[][version]=1%2e2%2e4&q[][pacticipant]=Bar&q[][latest]=true&latestby=cvpv",
+   "latestby=cvpv&q[][pacticipant]=Foo+Thing&q[][pacticipant]=Bar&q[][version]=1%2e2%2e3&q[][version]=4%2e5%2e6" => "q[][pacticipant]=Foo+Thing&q[][version]=1%2e2%2e3&q[][pacticipant]=Bar&q[][version]=4%2e5%2e6&latestby=cvpv",
+   "latestby=cvpv&q[][pacticipant]=Foo&q[][pacticipant]=Bar&q[][version]=1%2e2%2e3&q[][version]=4%2e5%2e6" => "q[][pacticipant]=Foo&q[][version]=1%2e2%2e3&q[][pacticipant]=Bar&q[][version]=4%2e5%2e6&latestby=cvpv",
+   "latestby=cvpv&q[][latest]=true&q[][pacticipant]=Foo&q[][pacticipant]=Bar&q[][tag]=prod&q[][version]=1%2e2%2e3" => "q[][pacticipant]=Foo&q[][version]=1%2e2%2e3&q[][pacticipant]=Bar&q[][latest]=true&q[][tag]=prod&latestby=cvpv",
+   "latestby=cvpv&q[][latest]=true&q[][pacticipant]=Foo&q[][pacticipant]=Bar&q[][version]=1%2e2%2e4" => "q[][pacticipant]=Foo&q[][version]=1%2e2%2e4&q[][pacticipant]=Bar&q[][latest]=true&latestby=cvpv",
+   "latestby=cvpv&q[][pacticipant]=Foo&q[][pacticipant]=Bar&q[][version]=1%2e2%2e3&q[][version]=9%2e9%2e9" => "q[][pacticipant]=Foo&q[][version]=1%2e2%2e3&q[][pacticipant]=Bar&q[][version]=9%2e9%2e9&latestby=cvpv"
   }
 
   def initialize(app)

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -41,14 +41,21 @@ Pact.service_provider "Pact Broker" do
 
   app { HalRelationProxyApp.new(app_to_verify) }
   app_version ENV["GIT_SHA"] if ENV["GIT_SHA"]
-  app_version_tags [ENV["GIT_BRANCH"]] if ENV["GIT_BRANCH"]
+  branch = `git rev-parse --abbrev-ref HEAD`.strip
+  if branch.start_with?("refs/pull/") || branch.start_with?("HEAD")
+    branch = ENV["GITHUB_HEAD_REF"] || branch.split("/").last
+  end
+  if branch.nil? || branch.empty?
+    branch = ENV["GIT_BRANCH"]
+  end
+  app_version_branch branch
   publish_verification_results ENV["CI"] == "true"
 
-  if ENV.fetch("PACTFLOW_PACT_FOUNDATION_TOKEN", "") != ""
+  if ENV.fetch("PACT_BROKER_TOKEN", "") != ""
     honours_pacts_from_pact_broker do
-      pact_broker_base_url "https://pact-foundation.pactflow.io", token: ENV["PACTFLOW_PACT_FOUNDATION_TOKEN"]
+      pact_broker_base_url ENV.fetch("PACT_BROKER_BASE_URL", ""), token: ENV["PACT_BROKER_TOKEN"]
       consumer_version_selectors [
-          { tag: "master", latest: true }
+          { mainBranch: true }, { deployed: true },
         ]
       enable_pending true
       include_wip_pacts_since "2000-01-01"

--- a/spec/service_consumers/provider_states_for_pact-broker-cli.rb
+++ b/spec/service_consumers/provider_states_for_pact-broker-cli.rb
@@ -1,0 +1,58 @@
+require "spec/support/test_data_builder"
+require_relative "shared_provider_states"
+
+Pact.provider_states_for "pact-broker-cli" do
+  shared_provider_states
+  shared_noop_provider_states
+
+
+
+
+  provider_state "a pact between Condor and the Pricing Service exists with branch main" do
+    set_up do
+      TestDataBuilder.new
+        .create_condor
+        .create_consumer_version("1.3.0", branch: "main")
+        .create_pricing_service
+        .create_pact
+    end
+  end
+
+  provider_state "a pact between Condor and the Pricing Service exists with branch feature" do
+    set_up do
+      TestDataBuilder.new
+        .create_condor
+        .create_consumer_version("1.3.0", branch: "feature")
+        .create_pricing_service
+        .create_pact
+    end
+  end
+
+  provider_state "version 5556b8149bf8bac76bc30f50a8a2dd4c22c85f30 of pacticipant Foo exists with a test environment available for release" do
+    set_up do
+      TestDataBuilder.new
+        .create_environment("test", uuid: "16926ef3-590f-4e3f-838e-719717aa88c9")
+        .create_consumer("Foo")
+        .create_consumer_version("5556b8149bf8bac76bc30f50a8a2dd4c22c85f30")
+    end
+  end
+
+  provider_state "version 5556b8149bf8bac76bc30f50a8a2dd4c22c85f30 of pacticipant Foo exists with a test environment is released with id ff3adecf-cfc5-4653-a4e3-f1861092f8e0" do
+    set_up do
+      TestDataBuilder.new
+        .create_environment("test", uuid: "16926ef3-590f-4e3f-838e-719717aa88c9")
+        .create_consumer("Foo")
+        .create_consumer_version("5556b8149bf8bac76bc30f50a8a2dd4c22c85f30")
+        .create_released_version_for_consumer_version(uuid: "ff3adecf-cfc5-4653-a4e3-f1861092f8e0", environment_name: "test")
+    end
+  end
+
+  provider_state "version 5556b8149bf8bac76bc30f50a8a2dd4c22c85f30 of pacticipant Foo exists with a test environment available for deployment" do
+    set_up do
+      TestDataBuilder.new
+        .create_consumer("Foo")
+        .create_consumer_version("5556b8149bf8bac76bc30f50a8a2dd4c22c85f30")
+        .create_environment("test", uuid: "16926ef3-590f-4e3f-838e-719717aa88c9")
+    end
+  end
+end

--- a/spec/service_consumers/shared_provider_states.rb
+++ b/spec/service_consumers/shared_provider_states.rb
@@ -400,4 +400,20 @@
       no_op
     end
 
+    provider_state "the pb:latest-pact-versions relation exists in the index resource" do
+      no_op
+    end
+
+    provider_state "the pb:pacticipants relation exists in the index resource" do
+      no_op
+    end
+
+    provider_state "the pb:pacticipant relation exists in the index resource" do
+      no_op
+    end
+    
+    provider_state "a webhook with uuid non-existent-uuid does not exist" do
+      no_op
+    end
+    
   end


### PR DESCRIPTION
- Add support for verifying pacts from [pact-broker-cli](https://github.com/pact-foundation/pact-broker-cli) rewrite in rust.
  - pact-broker-cli is downgrading pacts to v2 spec, for compat with the pact-ruby core. 
  - This could now be replaced, as the v1 pact-ruby core tests removed, as superceded by #843 
- Update to use `mainBranch` and `deployed` selectors, over the `tag` main
- publish verification results with `branch` rather than `tag`