### PR TITLE
fix: dashboard loading after zeitwerk rename prep

### DIFF
--- a/lib/pact_broker/ui/controllers/clusters.rb
+++ b/lib/pact_broker/ui/controllers/clusters.rb
@@ -18,7 +18,7 @@ module PactBroker
         end
 
         get "/" do
-          view_model = ViewModel::IndexItems.new(pacticipant_service.find_index_items, base_url: base_url)
+          view_model = PactBroker::UI::ViewModels::IndexItems.new(pacticipant_service.find_index_items, base_url: base_url)
           haml "clusters/show", locals: { relationships: view_model, base_url: base_url }, escape_html: true
         end
 

--- a/lib/pact_broker/ui/controllers/dashboard.rb
+++ b/lib/pact_broker/ui/controllers/dashboard.rb
@@ -44,7 +44,7 @@ module PactBroker
                           []
                         end
 
-          view_index_items = ViewModel::IndexItems.new(index_items, base_url: base_url, view: view)
+          view_index_items = PactBroker::UI::ViewModels::IndexItems.new(index_items, base_url: base_url, view: view)
 
           page = :'dashboard/show'
           locals = {


### PR DESCRIPTION
follow up from #661 

couple of missed imports that needed updating which impacted the dashboard view loading

https://github.com/pact-foundation/pact_broker/pull/661/files#diff-63d75cee09613316c6ef35a7d90a5e586c783f2925f17188e553fb7a00b29abbR36