### PR TITLE
Add compound index on branch_versions(version_id, branch_name)

### DIFF
--- a/db/migrations/20251106_add_branch_versions_version_id_branch_name_index.rb
+++ b/db/migrations/20251106_add_branch_versions_version_id_branch_name_index.rb
@@ -1,0 +1,21 @@
+require_relative "migration_helper"
+
+include PactBroker::MigrationHelper
+
+Sequel.migration do
+  up do
+    if !mysql?
+      alter_table(:branch_versions) do
+        add_index([:version_id, :branch_name], name: "branch_versions_version_id_branch_name_idx")
+      end
+    end
+  end
+
+  down do
+    if !mysql?
+      alter_table(:branch_versions) do
+        drop_index([:version_id, :branch_name], name: "branch_versions_version_id_branch_name_idx")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a compound index on `branch_versions(version_id, branch_name)` to dramatically improve query performance when filtering verifications from the provider's main branch.

## Performance Impact

- **Before**: ~13.5 seconds (~330M row comparisons)
- **After**: ~6.5ms (direct index lookups)
- **Improvement**: ~2,000x faster

## Details

See #872 for complete performance analysis, query plans, and production data demonstrating the need for this index.

This migration:
- Follows existing migration patterns
- Skips MySQL (consistent with other index migrations)
- Addresses the `TODO optimise this` comment in `verification.rb:38`

Fixes #872