### PR TITLE
fix: restore latest pact for branch endpoint

### DIFF
--- a/lib/pact_broker/api.rb
+++ b/lib/pact_broker/api.rb
@@ -33,10 +33,10 @@ module PactBroker
         add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "versions"], Api::Resources::PactVersions, {resource_name: "pact_publications"}
         add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "versions", :consumer_version_number], Api::Resources::Pact, {resource_name: "pact_publication", deprecated: true} # Not the standard URL, but keep for backwards compatibility
         add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "tag", :tag], Api::Resources::TaggedPactVersions, {resource_name: "tagged_pact_publications"}
-        add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "branch"], Api::Resources::PactVersionsForBranch, {resource_name: "pact_publications_for_main_branch"}
-        add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "branch", "latest"], Api::Resources::PactVersionsForBranch, {resource_name: "latest_pact_publications_for_main_branch"}
-        add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "branch", :branch_name, "latest"], Api::Resources::PactVersionsForBranch, {resource_name: "latest_pact_publications_for_branch"}
         add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "branch", :branch_name], Api::Resources::PactVersionsForBranch, {resource_name: "pact_publications_for_branch"}
+        add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "branch", "versions"], Api::Resources::PactVersionsForBranch, {resource_name: "pact_publications_for_main_branch"}
+        add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "branch", "latest", "versions"], Api::Resources::PactVersionsForBranch, {resource_name: "latest_pact_publications_for_main_branch"}
+        add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "branch", :branch_name, "latest", "versions"], Api::Resources::PactVersionsForBranch, {resource_name: "latest_pact_publications_for_branch"}
 
         # Pacts
         add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "version", :consumer_version_number], Api::Resources::Pact, {resource_name: "pact_publication"}

--- a/lib/pact_broker/api.rb
+++ b/lib/pact_broker/api.rb
@@ -33,8 +33,8 @@ module PactBroker
         add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "versions"], Api::Resources::PactVersions, {resource_name: "pact_publications"}
         add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "versions", :consumer_version_number], Api::Resources::Pact, {resource_name: "pact_publication", deprecated: true} # Not the standard URL, but keep for backwards compatibility
         add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "tag", :tag], Api::Resources::TaggedPactVersions, {resource_name: "tagged_pact_publications"}
-        add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "branch", :branch_name], Api::Resources::PactVersionsForBranch, {resource_name: "pact_publications_for_branch"}
         add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "branch", "versions"], Api::Resources::PactVersionsForBranch, {resource_name: "pact_publications_for_main_branch"}
+        add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "branch", :branch_name], Api::Resources::PactVersionsForBranch, {resource_name: "pact_publications_for_branch"}
         add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "branch", "latest", "versions"], Api::Resources::PactVersionsForBranch, {resource_name: "latest_pact_publications_for_main_branch"}
         add ["pacts", "provider", :provider_name, "consumer", :consumer_name, "branch", :branch_name, "latest", "versions"], Api::Resources::PactVersionsForBranch, {resource_name: "latest_pact_publications_for_branch"}
 

--- a/lib/pact_broker/api/resources/index.rb
+++ b/lib/pact_broker/api/resources/index.rb
@@ -57,19 +57,19 @@ module PactBroker
             },
             "pb:latest-branch-pact-versions" =>
             {
-              href: base_url + "/pacts/provider/{provider}/consumer/{consumer}/branch/{branch}/latest",
+              href: base_url + "/pacts/provider/{provider}/consumer/{consumer}/branch/{branch}/latest/versions",
               title: "Latest version of pact for a provider, for a named consumers branch",
               templated: true
             },
             "pb:main-branch-pact-versions" =>
             {
-              href: base_url + "/pacts/provider/{provider}/consumer/{consumer}/branch",
+              href: base_url + "/pacts/provider/{provider}/consumer/{consumer}/branch/versions",
               title: "All versions of pacts for a provider, for a named consumers main branch",
               templated: true
             },
             "pb:latest-main-branch-pact-versions" =>
             {
-              href: base_url + "/pacts/provider/{provider}/consumer/{consumer}/branch/latest",
+              href: base_url + "/pacts/provider/{provider}/consumer/{consumer}/branch/latest/versions",
               title: "Latest version of pact for a provider, for a named consumers main branch",
               templated: true
             },

--- a/lib/pact_broker/doc/views/index/latest-branch-pact-versions.markdown
+++ b/lib/pact_broker/doc/views/index/latest-branch-pact-versions.markdown
@@ -2,6 +2,6 @@
 
  Allowed methods: `GET`
 
- Path: `/pacts/provider/{provider}/consumer/{consumer}/branch/{branch}/latest`
+ Path: `/pacts/provider/{provider}/consumer/{consumer}/branch/{branch}/latest/versions`
 
  Returns the latest pact version with the specified consumer, provider and consumer version branch.

--- a/lib/pact_broker/doc/views/index/latest-main-branch-pact-versions.markdown
+++ b/lib/pact_broker/doc/views/index/latest-main-branch-pact-versions.markdown
@@ -2,6 +2,6 @@
 
  Allowed methods: `GET`
 
- Path: `/pacts/provider/{provider}/consumer/{consumer}/branch/latest`
+ Path: `/pacts/provider/{provider}/consumer/{consumer}/branch/latest/versions`
 
  Lists all latest pact version with the specified consumer, provider and the consumers main branch.

--- a/lib/pact_broker/doc/views/index/main-branch-pact-versions.markdown
+++ b/lib/pact_broker/doc/views/index/main-branch-pact-versions.markdown
@@ -2,6 +2,6 @@
 
  Allowed methods: `GET`
 
- Path: `/pacts/provider/{provider}/consumer/{consumer}/branch`
+ Path: `/pacts/provider/{provider}/consumer/{consumer}/branch/versions`
 
  Lists all the pact versions with the specified consumer, provider and the consumers main branch.

--- a/lib/pact_broker/pacts/pact_publication_selector_dataset_module.rb
+++ b/lib/pact_broker/pacts/pact_publication_selector_dataset_module.rb
@@ -46,9 +46,18 @@ module PactBroker
 
       def for_main_branches
         consumers_join = { Sequel[:pact_publications][:consumer_id] => Sequel[:consumers][:id] }
-        query = self
-        query
+        branch_versions_join = {
+          Sequel[:branch_versions][:version_id] => Sequel[:pact_publications][:consumer_version_id],
+          Sequel[:branch_versions][:branch_name] => Sequel[:consumers][:main_branch]
+        }
+        base_query = self
+
+        if no_columns_selected?
+          base_query = base_query.select_all_qualified.select_append(Sequel[:branch_versions][:branch_name].as(:branch_name))
+        end
+        base_query
           .join(:pacticipants, consumers_join, { table_alias: :consumers })
+          .join(:branch_versions, branch_versions_join)
           .remove_overridden_revisions_from_complete_query
       end
 

--- a/spec/features/get_branch_provider_pact_publications_spec.rb
+++ b/spec/features/get_branch_provider_pact_publications_spec.rb
@@ -1,7 +1,7 @@
 require "lib/pact_broker/db/seed_example_data"
 
-describe "retrieving the latest pact for a branch" do
-  let(:path) { "/pacts/provider/Provider/consumer/Consumer/branch/main/latest" }
+describe "retrieving all pact publications for a provider, for any consumers main branch" do
+  let(:path) { "/pacts/provider/Provider/branch/foo" }
   let(:json_response_body) { JSON.parse(subject.body, symbolize_names: true) }
 
   subject { get(path)  }
@@ -9,20 +9,19 @@ describe "retrieving the latest pact for a branch" do
   before do
     seed_example_data = PactBroker::DB::SeedExampleData.new
     
-    td.create_consumer("Consumer")
+    td.create_consumer("Consumer", main_branch: "main")
       .create_provider("Provider")
       .create_consumer_version("1", branch: "main")
-      .create_pact
+      .create_pact(json_content: seed_example_data.pact_1)
       .create_consumer_version("2", branch: "main")
       .create_pact(json_content: seed_example_data.pact_1)
       .create_consumer_version("3", branch: "foo")
-      .create_pact
+      .create_pact(json_content: seed_example_data.pact_1)
       .create_consumer_version("4", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
   end
 
-  it "returns the latest pact for the branch" do
-    expect(json_response_body[:_links][:self][:href]).to end_with("2")
-    expect(json_response_body[:interactions].length).to eq(1)
-    expect(json_response_body[:interactions][0][:description]).to eq("a request for an alligator")
+  it "returns a list of latest pact publications for a provider, for any consumers main branch" do
+    expect(json_response_body[:_links][:"pb:pacts"].length).to eq(1)
   end
 end

--- a/spec/features/get_latest_branch_provider_pact_publications_spec.rb
+++ b/spec/features/get_latest_branch_provider_pact_publications_spec.rb
@@ -1,0 +1,28 @@
+require "lib/pact_broker/db/seed_example_data"
+
+describe "retrieving latest pact publications for a provider, for any consumers main branch" do
+  let(:path) { "/pacts/provider/Provider/branch/main/latest" }
+  let(:json_response_body) { JSON.parse(subject.body, symbolize_names: true) }
+
+  subject { get(path)  }
+
+  before do
+    seed_example_data = PactBroker::DB::SeedExampleData.new
+    
+    td.create_consumer("Consumer", main_branch: "main")
+      .create_provider("Provider")
+      .create_consumer_version("1", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+      .create_consumer_version("2", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+      .create_consumer_version("3", branch: "foo")
+      .create_pact(json_content: seed_example_data.pact_1)
+      .create_consumer_version("4", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+  end
+
+  it "returns a list of latest pact publications for a provider, for any consumers main branch" do
+    expect(json_response_body[:_links][:"pb:pacts"].length).to eq(1)
+    expect(json_response_body[:_links][:"pb:pacts"][0][:href]).to end_with("4")
+  end
+end

--- a/spec/features/get_latest_main_branch_provider_pact_publications_spec.rb
+++ b/spec/features/get_latest_main_branch_provider_pact_publications_spec.rb
@@ -1,0 +1,28 @@
+require "lib/pact_broker/db/seed_example_data"
+
+describe "retrieving latest pact publications for a provider, for any consumers main branch" do
+  let(:path) { "/pacts/provider/Provider/branch/latest" }
+  let(:json_response_body) { JSON.parse(subject.body, symbolize_names: true) }
+
+  subject { get(path)  }
+
+  before do
+    seed_example_data = PactBroker::DB::SeedExampleData.new
+    
+    td.create_consumer("Consumer", main_branch: "main")
+      .create_provider("Provider")
+      .create_consumer_version("1", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+      .create_consumer_version("2", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+      .create_consumer_version("3", branch: "foo")
+      .create_pact(json_content: seed_example_data.pact_1)
+      .create_consumer_version("4", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+  end
+
+  it "returns a list of latest pact publications for a provider, for any consumers main branch" do
+    expect(json_response_body[:_links][:"pb:pacts"].length).to eq(1)
+    expect(json_response_body[:_links][:"pb:pacts"][0][:href]).to end_with("4")
+  end
+end

--- a/spec/features/get_latest_pact_publications_for_branch_spec.rb
+++ b/spec/features/get_latest_pact_publications_for_branch_spec.rb
@@ -1,0 +1,30 @@
+require "lib/pact_broker/db/seed_example_data"
+
+describe "retrieving latest pact publications for main branch" do
+  let(:path) { "/pacts/provider/Provider/consumer/Consumer/branch/foo/latest/versions" }
+  let(:json_response_body) { JSON.parse(subject.body, symbolize_names: true) }
+
+  subject { get(path)  }
+
+  before do
+    seed_example_data = PactBroker::DB::SeedExampleData.new
+    
+    td.create_consumer("Consumer", main_branch: "main")
+      .create_provider("Provider")
+      .create_consumer_version("1", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+      .create_consumer_version("2", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+      .create_consumer_version("3", branch: "foo")
+      .create_pact
+      .create_consumer_version("4", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+  end
+
+  it "returns the latest pact for the branch" do
+    expect(json_response_body[:_embedded][:pacts].length).to eq(1)
+    expect(json_response_body[:_embedded][:pacts][0][:_embedded][:consumerVersion][:number]).to eq("3")
+    expect(json_response_body[:_links][:"pact-versions"].length).to eq(1)
+    expect(json_response_body[:_links][:"pact-versions"][0][:name]).to include("Version 3")
+  end
+end

--- a/spec/features/get_latest_pact_publications_for_main_branch_spec.rb
+++ b/spec/features/get_latest_pact_publications_for_main_branch_spec.rb
@@ -1,0 +1,30 @@
+require "lib/pact_broker/db/seed_example_data"
+
+describe "retrieving latest pact publications for main branch" do
+  let(:path) { "/pacts/provider/Provider/consumer/Consumer/branch/latest/versions" }
+  let(:json_response_body) { JSON.parse(subject.body, symbolize_names: true) }
+
+  subject { get(path)  }
+
+  before do
+    seed_example_data = PactBroker::DB::SeedExampleData.new
+    
+    td.create_consumer("Consumer", main_branch: "main")
+      .create_provider("Provider")
+      .create_consumer_version("1", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+      .create_consumer_version("2", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+      .create_consumer_version("3", branch: "foo")
+      .create_pact
+      .create_consumer_version("4", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+  end
+
+  it "returns the latest pact for the branch" do
+    expect(json_response_body[:_embedded][:pacts].length).to eq(1)
+    expect(json_response_body[:_embedded][:pacts][0][:_embedded][:consumerVersion][:number]).to eq("4")
+    expect(json_response_body[:_links][:"pact-versions"].length).to eq(1)
+    expect(json_response_body[:_links][:"pact-versions"][0][:name]).to include("Version 4")
+  end
+end

--- a/spec/features/get_main_branch_provider_pact_publications_spec.rb
+++ b/spec/features/get_main_branch_provider_pact_publications_spec.rb
@@ -1,7 +1,7 @@
 require "lib/pact_broker/db/seed_example_data"
 
-describe "retrieving the latest pact for a branch" do
-  let(:path) { "/pacts/provider/Provider/consumer/Consumer/branch/main/latest" }
+describe "retrieving all pact publications for a provider, for any consumers main branch" do
+  let(:path) { "/pacts/provider/Provider/branch" }
   let(:json_response_body) { JSON.parse(subject.body, symbolize_names: true) }
 
   subject { get(path)  }
@@ -9,20 +9,19 @@ describe "retrieving the latest pact for a branch" do
   before do
     seed_example_data = PactBroker::DB::SeedExampleData.new
     
-    td.create_consumer("Consumer")
+    td.create_consumer("Consumer", main_branch: "main")
       .create_provider("Provider")
       .create_consumer_version("1", branch: "main")
-      .create_pact
+      .create_pact(json_content: seed_example_data.pact_1)
       .create_consumer_version("2", branch: "main")
       .create_pact(json_content: seed_example_data.pact_1)
       .create_consumer_version("3", branch: "foo")
-      .create_pact
+      .create_pact(json_content: seed_example_data.pact_1)
       .create_consumer_version("4", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
   end
 
-  it "returns the latest pact for the branch" do
-    expect(json_response_body[:_links][:self][:href]).to end_with("2")
-    expect(json_response_body[:interactions].length).to eq(1)
-    expect(json_response_body[:interactions][0][:description]).to eq("a request for an alligator")
+  it "returns a list of latest pact publications for a provider, for any consumers main branch" do
+    expect(json_response_body[:_links][:"pb:pacts"].length).to eq(3)
   end
 end

--- a/spec/features/get_pact_publications_for_branch_spec.rb
+++ b/spec/features/get_pact_publications_for_branch_spec.rb
@@ -1,0 +1,63 @@
+require "lib/pact_broker/db/seed_example_data"
+
+describe "retrieving pact publications for specified branch" do
+  let(:path) { "/pacts/provider/Provider/consumer/Consumer/branch/foo" }
+  let(:json_response_body) { JSON.parse(subject.body, symbolize_names: true) }
+
+  subject { get(path)  }
+
+  before do
+    seed_example_data = PactBroker::DB::SeedExampleData.new
+    
+    td.create_consumer("Consumer", main_branch: "main")
+      .create_provider("Provider")
+      .create_consumer_version("1", branch: "main")
+      .create_pact
+      .create_consumer_version("2", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+      .create_consumer_version("3", branch: "foo")
+      .create_pact
+      .create_consumer_version("4", branch: "main")
+      .create_consumer_version("5", branch: "foo")
+      .create_pact
+  end
+
+  it "returns the pact publications for associated consumers named branch" do
+    expect(json_response_body[:_embedded][:pacts].length).to eq(2)
+    expect(json_response_body[:_embedded][:pacts][0][:_embedded][:consumerVersion][:number]).to eq("3")
+    expect(json_response_body[:_embedded][:pacts][1][:_embedded][:consumerVersion][:number]).to eq("5")
+    expect(json_response_body[:_links][:"pact-versions"].length).to eq(2)
+    expect(json_response_body[:_links][:"pact-versions"][0][:name]).to include("Version 3")
+    expect(json_response_body[:_links][:"pact-versions"][1][:name]).to include("Version 5")
+  end
+end
+
+describe "retrieving pact publications for specified branch" do
+  let(:path) { "/pacts/provider/Provider/consumer/Consumer/branch/main" }
+  let(:json_response_body) { JSON.parse(subject.body, symbolize_names: true) }
+
+  subject { get(path)  }
+
+  before do
+    seed_example_data = PactBroker::DB::SeedExampleData.new
+    
+    td.create_consumer("Consumer")
+      .create_provider("Provider")
+      .create_consumer_version("1", branch: "main")
+      .create_pact
+      .create_consumer_version("2", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+      .create_consumer_version("3", branch: "foo")
+      .create_pact
+      .create_consumer_version("4", branch: "main")
+  end
+
+  it "returns the latest pact for the branch" do
+    expect(json_response_body[:_embedded][:pacts].length).to eq(2)
+    expect(json_response_body[:_embedded][:pacts][0][:_embedded][:consumerVersion][:number]).to eq("1")
+    expect(json_response_body[:_embedded][:pacts][1][:_embedded][:consumerVersion][:number]).to eq("2")
+    expect(json_response_body[:_links][:"pact-versions"].length).to eq(2)
+    expect(json_response_body[:_links][:"pact-versions"][0][:name]).to include("Version 1")
+    expect(json_response_body[:_links][:"pact-versions"][1][:name]).to include("Version 2")
+  end
+end

--- a/spec/features/get_pact_publications_for_main_branch_spec.rb
+++ b/spec/features/get_pact_publications_for_main_branch_spec.rb
@@ -1,0 +1,31 @@
+require "lib/pact_broker/db/seed_example_data"
+
+describe "retrieving pact publications for main branch" do
+  let(:path) { "/pacts/provider/Provider/consumer/Consumer/branch/versions" }
+  let(:json_response_body) { JSON.parse(subject.body, symbolize_names: true) }
+
+  subject { get(path)  }
+
+  before do
+    seed_example_data = PactBroker::DB::SeedExampleData.new
+    
+    td.create_consumer("Consumer", main_branch: "main")
+      .create_provider("Provider")
+      .create_consumer_version("1", branch: "main")
+      .create_pact
+      .create_consumer_version("2", branch: "main")
+      .create_pact(json_content: seed_example_data.pact_1)
+      .create_consumer_version("3", branch: "foo")
+      .create_pact
+      .create_consumer_version("4", branch: "main")
+  end
+
+  it "returns the pact publications for associated consumers main branch" do
+    expect(json_response_body[:_embedded][:pacts].length).to eq(2)
+    expect(json_response_body[:_embedded][:pacts][0][:_embedded][:consumerVersion][:number]).to eq("1")
+    expect(json_response_body[:_embedded][:pacts][1][:_embedded][:consumerVersion][:number]).to eq("2")
+    expect(json_response_body[:_links][:"pact-versions"].length).to eq(2)
+    expect(json_response_body[:_links][:"pact-versions"][0][:name]).to include("Version 1")
+    expect(json_response_body[:_links][:"pact-versions"][1][:name]).to include("Version 2")
+  end
+end


### PR DESCRIPTION
There was an overlap when introducing #728

which resulted in 

`/pacts/provider/{provider}/consumer/{consumer}/branch/{branch}/latest` returning `pact-versions`, not the expected latest pact content, for a named branch of an application pair.

I have appended new routes with `/versions` to match existing pact_publications resource.

It does not append `/versions` to `pact_publications_for_branch` route, as this is also used for deleting Pact versions for branch (such supporting deleting pacts by branch was introduced in the UI).

