### PR TITLE
fix: Pacticipant API returning undeployed versions in pacticipant deployed-environments endpoint

### DIFF
--- a/lib/pact_broker/deployments/deployed_version_service.rb
+++ b/lib/pact_broker/deployments/deployed_version_service.rb
@@ -68,6 +68,7 @@ module PactBroker
 
       def self.find_all_deployed_versions_for_pacticipant(pacticipant)
         scope_for(DeployedVersion)
+          .currently_deployed
           .where(pacticipant_id: pacticipant.id)
           .eager(:environment)
           .all


### PR DESCRIPTION
### Problem
The `/pacticipants/{name}` endpoint was returning all deployed_versions records including those marked as undeployed (with undeployed_at timestamp set). This caused the pb:deployed-environments link to show historical deployment records rather than only currently active deployments.

### Root Cause
`DeployedVersionService.find_all_deployed_versions_for_pacticipant` was not filtering by deployment status:

### Solution
Added `.currently_deployed`  filter which joins with the currently_deployed_version_ids index table: