### PR TITLE
chore: allow passing pattern when redacting logs

### DIFF
--- a/lib/pact_broker/webhooks/redact_logs.rb
+++ b/lib/pact_broker/webhooks/redact_logs.rb
@@ -7,12 +7,12 @@ module PactBroker
 
       using PactBroker::StringRefinements
 
-      def redact_logs(logs, values)
-        RedactLogs.call(logs, values)
+      def redact_logs(logs, values, pattern_substitutions = [])
+        RedactLogs.call(logs, values, pattern_substitutions)
       end
 
-      def self.call logs, values
-        substitutions = HEADER_SUBSTITUTIONS + value_substitutions(values)
+      def self.call logs, values, pattern_substitutions = []
+        substitutions = HEADER_SUBSTITUTIONS + pattern_substitutions + value_substitutions(values)
 
         substitutions.reduce(logs) do | agg_logs, (find, replace) |
           agg_logs.gsub(find, replace)

--- a/spec/lib/pact_broker/webhooks/redact_logs_spec.rb
+++ b/spec/lib/pact_broker/webhooks/redact_logs_spec.rb
@@ -54,6 +54,69 @@ module PactBroker
             expect(RedactLogs.call(string, values)).to eq "blah********\n******** wiffle"
           end
         end
+
+        context "with pattern_substitutions" do
+          context "with pattern matching JSON keys" do
+            let(:pattern_substitutions) { [[/("apiKey":\s*")([^"]+)/, '\1[REDACTED]']] }
+            let(:string) { '{"apiKey": "abc123", "userId": "123"}' }
+
+            it "redacts JSON values" do
+              expect(RedactLogs.call(string, values, pattern_substitutions)).to eq '{"apiKey": "[REDACTED]", "userId": "123"}'
+            end
+          end
+
+          context "with empty pattern_substitutions array" do
+            let(:pattern_substitutions) { [] }
+            let(:string) { "Authorization: secret\nOther: data" }
+
+            it "still applies default HEADER_SUBSTITUTIONS" do
+              expect(RedactLogs.call(string, values, pattern_substitutions)).to eq "Authorization: [REDACTED]\nOther: data"
+            end
+          end
+        end
+
+        context "with combined redactions (values + pattern_substitutions)" do
+          let(:values) { ["supersecret"] }
+          let(:pattern_substitutions) { [[/(api_token=)([^&\s]+)/, '\1[REDACTED]']] }
+          let(:string) do
+            "Authorization: Bearer supersecret\n" \
+            "Request: /api?api_token=abc123\n" \
+            "Token: xyz789"
+          end
+
+          it "applies all three types of redactions (HEADER_SUBSTITUTIONS, values, pattern_substitutions)" do
+            expected = "Authorization: [REDACTED]\n" \
+                      "Request: /api?api_token=[REDACTED]\n" \
+                      "Token: [REDACTED]"
+            expect(RedactLogs.call(string, values, pattern_substitutions)).to eq expected
+          end
+        end
+
+        context "with complex real-world webhook scenarios" do
+          let(:values) { ["mytoken123", "mysecret456"] }
+          let(:pattern_substitutions) do
+            [
+              [/(client_secret=)([^&\s]+)/, '\1[REDACTED]'],
+              [/("password":\s*")([^"]+)/, '\1[REDACTED]']
+            ]
+          end
+          let(:string) do
+            "POST /webhook HTTP/1.1\n" \
+            "Authorization: Bearer mytoken123\n" \
+            "X-Custom-Token: mysecret456\n" \
+            'Body: {"username": "admin", "password": "pass123"}\n' \
+            "Callback: https://example.com/oauth?client_secret=secret789"
+          end
+
+          it "redacts all sensitive information from webhook logs" do
+            expected = "POST /webhook HTTP/1.1\n" \
+                      "Authorization: [REDACTED]\n" \
+                      "X-Custom-Token: [REDACTED]\n" \
+                      'Body: {"username": "admin", "password": "[REDACTED]"}\n' \
+                      "Callback: https://example.com/oauth?client_secret=[REDACTED]"
+            expect(RedactLogs.call(string, values, pattern_substitutions)).to eq expected
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Adds support for custom redaction patterns, similar to HEADER_SUBSTITUTIONS, allowing more fine-grained control over what is redacted in the logs.