### PR TITLE
chore: drop branch_versions_branch_name_index

### DIFF
--- a/db/migrations/20260123_drop_branch_versions_branch_name_index.rb
+++ b/db/migrations/20260123_drop_branch_versions_branch_name_index.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table(:branch_versions) do
+      drop_index :branch_versions_branch_name_index
+    end
+  end
+
+  down do
+    alter_table(:branch_versions_branch_name_index) do
+      add_index :branch_versions_branch_name_index, :branch_name
+    end
+  end
+end

--- a/db/migrations/20260123_drop_branch_versions_branch_name_index.rb
+++ b/db/migrations/20260123_drop_branch_versions_branch_name_index.rb
@@ -1,13 +1,17 @@
 Sequel.migration do
   up do
-    alter_table(:branch_versions) do
-      drop_index :branch_versions_branch_name_index
+    if !mysql?
+      alter_table(:branch_versions) do
+        drop_index([:branch_name], name: "branch_versions_branch_name_index")
+      end
     end
   end
 
   down do
-    alter_table(:branch_versions_branch_name_index) do
-      add_index :branch_versions_branch_name_index, :branch_name
+    if !mysql?
+      alter_table(:branch_versions) do
+        add_index([:branch_name], name: "branch_versions_branch_name_index")
+      end
     end
   end
 end


### PR DESCRIPTION
Removes an index that prevents a new index from being used by the PG query planner. This appears safe to remove.
See this [issue](https://github.com/pact-foundation/pact_broker/issues/872) for context
