### PR TITLE
fix: avoid N+1 cascade

### DIFF
--- a/lib/pact_broker/api/decorators/version_decorator.rb
+++ b/lib/pact_broker/api/decorators/version_decorator.rb
@@ -25,7 +25,7 @@ module PactBroker
         def self.eager_load_associations
           [
             :pacticipant,
-            :pact_publications,
+            { pact_publications: [:consumer, :provider, { pact_version: :latest_verification }, :tags, :head_pact_publications_for_tags] },
             { branch_versions: [:version, :branch_head, { branch: :pacticipant }] },
             { tags: :head_tag }
           ]

--- a/lib/pact_broker/pacts/repository.rb
+++ b/lib/pact_broker/pacts/repository.rb
@@ -149,7 +149,7 @@ module PactBroker
           query = query.overall_latest
         end
 
-        query.all.sort_by{ | p| p.consumer_name.downcase }.collect(&:to_head_pact)
+        query.all.sort.collect(&:to_head_pact)
       end
 
       def find_pacts_by_consumer_branch(provider_name, options = {})
@@ -179,7 +179,7 @@ module PactBroker
             query = query.for_branch_name(branch)
           end
         end
-        query.all.sort_by{ | p| p.consumer_name.downcase }.collect(&:to_head_pact)
+        query.all.sort.collect(&:to_head_pact)
       end
 
       def find_for_verification(provider_name, consumer_version_selectors)

--- a/spec/features/get_branch_versions_spec.rb
+++ b/spec/features/get_branch_versions_spec.rb
@@ -35,4 +35,113 @@ describe "Get versions for branch" do
 
     it_behaves_like "a paginated response"
   end
+
+  context "performance: should not generate N+1 queries with multiple versions and pacts" do
+    # This test checks that a single GET request to
+    # `/pacticipants/{name}/branches/{branch}/version` does not generate an
+    # excessive number of database queries when there are many versions on the
+    # branch, each with multiple pacts and tags.
+
+    before do
+      # Create test data that triggers N+1 issue:
+      # - 1 consumer with multiple versions on same branch
+      # - Each version has pacts to multiple providers
+      # - Each version has tags (triggers head_tag_names queries)
+      td.create_consumer("PerfConsumer")
+        .create_provider("Provider1")
+        .create_provider("Provider2")
+        .create_provider("Provider3")
+        .create_provider("Provider4")
+
+      # Create 50 versions, each with 4 pacts and 3 tags
+      # This should create 200 pact_publications total
+      50.times do |i|
+        td.create_consumer_version("#{i+1}", branch: "perf-test-branch")
+          .create_consumer_version_tag("prod")
+          .create_consumer_version_tag("test")
+          .create_consumer_version_tag("staging")
+          .use_provider("Provider1")
+          .create_pact
+          .use_provider("Provider2")
+          .create_pact
+          .use_provider("Provider3")
+          .create_pact
+          .use_provider("Provider4")
+          .create_pact
+      end
+
+      # Temporarily allow lazy loading for PactPublication so we can measure
+      # query count.
+      PactBroker::Pacts::PactPublication.class_eval do
+        alias_method :_orig_load_associated_objects, :_load_associated_objects
+        def _load_associated_objects(opts, *args, &block)
+          # Call allow_lazy_load to disable the restriction for this instance
+          allow_lazy_load
+          _orig_load_associated_objects(opts, *args, &block)
+        end
+      end
+
+      # Setup query counter in before block so it's active for the entire test
+      # We'll capture the count before and after the request to isolate request queries
+      # Use a local variable that will be captured in the closure
+      query_count = [0] # Array so it can be mutated in the closure
+      original_log_method = PactBroker::DB.connection.method(:log_connection_yield)
+
+      PactBroker::DB.connection.define_singleton_method(:log_connection_yield) do |sql, conn, args=nil, &block|
+        if sql.to_s.upcase.start_with?("SELECT") && !sql.to_s.include?("sqlite_master")
+          query_count[0] += 1
+        end
+        original_log_method.call(sql, conn, args, &block)
+      end
+
+      # Store in instance variables so they're accessible in after block and test
+      @query_count = query_count
+      @original_log_method = original_log_method
+    end
+
+    after do
+      # Restore original database logging method
+      if @original_log_method
+        PactBroker::DB.connection.define_singleton_method(:log_connection_yield, @original_log_method)
+      end
+
+      # Restore original _load_associated_objects method
+      PactBroker::Pacts::PactPublication.class_eval do
+        alias_method :_load_associated_objects, :_orig_load_associated_objects
+        remove_method :_orig_load_associated_objects
+      end
+    end
+
+    it "returns branch versions without excessive queries" do
+      # Get the branch created by the test data
+      perf_consumer = PactBroker::Domain::Pacticipant.find(name: "PerfConsumer")
+      consumer_branch = PactBroker::Versions::Branch.where(
+        name: "perf-test-branch",
+        pacticipant_id: perf_consumer.id
+      ).first
+      perf_path = PactBroker::Api::PactBrokerUrls.branch_versions_url(consumer_branch)
+
+      # Make request, capturing only queries made during this request
+      queries_before_request = @query_count[0]
+      response = get(perf_path, { "pageNumber" => "1", "pageSize" => "20" })
+      queries_during_request = @query_count[0] - queries_before_request
+
+      # Verify response is successful
+      expect(response.status).to eq(200)
+
+      body = JSON.parse(response.body)
+      versions = body.dig("_embedded", "versions") || []
+      pact_versions_links = versions.flat_map { |v| v.dig("_links", "pb:pact-versions") || [] }
+
+      # Verify we got data back
+      expect(versions.size).to eq(20)
+      expect(pact_versions_links.size).to eq(80) # 20 versions × 4 pacts each
+
+      # Without fix: 415 queries
+      # After fix: 24 queries
+      puts "Branch versions endpoint query count: #{queries_during_request}"
+      expect(queries_during_request).to be < 50,
+        "Expected fewer than 50 queries, got #{queries_during_request}"
+    end
+  end
 end

--- a/spec/features/get_tag_versions_spec.rb
+++ b/spec/features/get_tag_versions_spec.rb
@@ -57,4 +57,102 @@ describe "Get versions for Pacticipant Tag" do
     end
 
   end
+
+  context "performance: should not generate N+1 queries with multiple versions and pacts" do
+    before do
+      # Create test data that triggers N+1 issue:
+      # - 1 consumer with multiple versions
+      # - All versions tagged with same tag
+      # - Each version has pacts to multiple providers
+      td.create_consumer("PerfTagConsumer")
+        .create_provider("Provider1")
+        .create_provider("Provider2")
+        .create_provider("Provider3")
+        .create_provider("Provider4")
+
+      50.times do |i|
+        td.create_consumer_version("#{i+1}")
+          .create_consumer_version_tag("perf-tag")
+          .create_consumer_version_tag("test")
+          .create_consumer_version_tag("staging")
+          .use_provider("Provider1")
+          .create_pact
+          .use_provider("Provider2")
+          .create_pact
+          .use_provider("Provider3")
+          .create_pact
+          .use_provider("Provider4")
+          .create_pact
+      end
+
+      # Temporarily allow lazy loading for PactPublication so we can measure query count
+      PactBroker::Pacts::PactPublication.class_eval do
+        alias_method :_orig_load_associated_objects, :_load_associated_objects
+        def _load_associated_objects(opts, *args, &block)
+          allow_lazy_load
+          _orig_load_associated_objects(opts, *args, &block)
+        end
+      end
+
+      # Setup query counter
+      query_count = [0]  # Array so it can be mutated in the closure
+      original_log_method = PactBroker::DB.connection.method(:log_connection_yield)
+
+      PactBroker::DB.connection.define_singleton_method(:log_connection_yield) do |sql, conn, args=nil, &block|
+        if sql.to_s.upcase.start_with?("SELECT") && !sql.to_s.include?("sqlite_master")
+          query_count[0] += 1
+        end
+        original_log_method.call(sql, conn, args, &block)
+      end
+
+      @query_count = query_count
+      @original_log_method = original_log_method
+    end
+
+    after do
+      # Restore original database logging method
+      if @original_log_method
+        PactBroker::DB.connection.define_singleton_method(:log_connection_yield, @original_log_method)
+      end
+
+      # Restore original _load_associated_objects method
+      PactBroker::Pacts::PactPublication.class_eval do
+        alias_method :_load_associated_objects, :_orig_load_associated_objects
+        remove_method :_orig_load_associated_objects
+      end
+    end
+
+    it "returns tag versions without excessive queries" do
+      perf_consumer = PactBroker::Domain::Pacticipant.find(name: "PerfTagConsumer")
+      perf_tag = PactBroker::Domain::Tag.where(
+        name: "perf-tag",
+        pacticipant_id: perf_consumer.id
+      ).first
+      perf_path = PactBroker::Api::PactBrokerUrls.tag_versions_url(perf_tag)
+
+      # Query counting is done inside the test (not in before/after hooks) because:
+      # 1. We only want to count queries during the actual HTTP request
+      # 2. We don't want to count queries from test setup (finding consumer, tag, etc.)
+      # 3. The counter must be reset for each test run
+
+      queries_before_request = @query_count[0]
+      response = get(perf_path, { "pageNumber" => "1", "pageSize" => "20" })
+      queries_during_request = @query_count[0] - queries_before_request
+
+      expect(response.status).to eq(200)
+
+      body = JSON.parse(response.body)
+      versions = body.dig("_embedded", "versions") || []
+      pact_versions_links = versions.flat_map { |v| v.dig("_links", "pb:pact-versions") || [] }
+
+      expect(versions.size).to eq(20)
+      expect(pact_versions_links.size).to eq(80)
+
+      # Without fix: 411 queries
+      # After fix: 20 queries
+      puts "Tag versions endpoint query count: #{queries_during_request}"
+      expect(queries_during_request).to be < 50,
+        "Expected fewer than 50 queries, got #{queries_during_request}"
+    end
+  end
 end

--- a/spec/features/get_versions_spec.rb
+++ b/spec/features/get_versions_spec.rb
@@ -47,4 +47,98 @@ describe "Get versions" do
       expect(subject).to be_a_404_response
     end
   end
+
+  context "performance: should not generate N+1 queries with multiple versions and pacts" do
+    before do
+      # Create test data that triggers N+1 issue:
+      # - 1 consumer with multiple versions
+      # - Each version has pacts to multiple providers
+      # - Each version has tags (triggers head_tag_names queries)
+      td.create_consumer("PerfConsumer")
+        .create_provider("Provider1")
+        .create_provider("Provider2")
+        .create_provider("Provider3")
+        .create_provider("Provider4")
+
+      50.times do |i|
+        td.create_consumer_version("#{i+1}")
+          .create_consumer_version_tag("prod")
+          .create_consumer_version_tag("test")
+          .create_consumer_version_tag("staging")
+          .use_provider("Provider1")
+          .create_pact
+          .use_provider("Provider2")
+          .create_pact
+          .use_provider("Provider3")
+          .create_pact
+          .use_provider("Provider4")
+          .create_pact
+      end
+
+      # Temporarily allow lazy loading for PactPublication so we can measure query count
+      PactBroker::Pacts::PactPublication.class_eval do
+        alias_method :_orig_load_associated_objects, :_load_associated_objects
+        def _load_associated_objects(opts, *args, &block)
+          allow_lazy_load
+          _orig_load_associated_objects(opts, *args, &block)
+        end
+      end
+
+      # Setup query counter
+      query_count = [0]  # Array so it can be mutated in the closure
+      original_log_method = PactBroker::DB.connection.method(:log_connection_yield)
+
+      PactBroker::DB.connection.define_singleton_method(:log_connection_yield) do |sql, conn, args=nil, &block|
+        if sql.to_s.upcase.start_with?("SELECT") && !sql.to_s.include?("sqlite_master")
+          query_count[0] += 1
+        end
+        original_log_method.call(sql, conn, args, &block)
+      end
+
+      @query_count = query_count
+      @original_log_method = original_log_method
+    end
+
+    after do
+      # Restore original database logging method
+      if @original_log_method
+        PactBroker::DB.connection.define_singleton_method(:log_connection_yield, @original_log_method)
+      end
+
+      # Restore original _load_associated_objects method
+      PactBroker::Pacts::PactPublication.class_eval do
+        alias_method :_load_associated_objects, :_orig_load_associated_objects
+        remove_method :_orig_load_associated_objects
+      end
+    end
+
+    it "returns versions without excessive queries" do
+      perf_consumer = PactBroker::Domain::Pacticipant.find(name: "PerfConsumer")
+      perf_path = "/pacticipants/#{perf_consumer.name}/versions"
+
+      # Query counting is done inside the test (not in before/after hooks) because:
+      # 1. We only want to count queries during the actual HTTP request
+      # 2. We don't want to count queries from test setup (finding consumer, etc.)
+      # 3. The counter must be reset for each test run
+
+      queries_before_request = @query_count[0]
+      response = get(perf_path, { "pageNumber" => "1", "pageSize" => "20" })
+      queries_during_request = @query_count[0] - queries_before_request
+
+      expect(response.status).to eq(200)
+
+      body = JSON.parse(response.body)
+      versions = body.dig("_embedded", "versions") || []
+      pact_versions_links = versions.flat_map { |v| v.dig("_links", "pb:pact-versions") || [] }
+
+      expect(versions.size).to eq(20)
+      expect(pact_versions_links.size).to eq(80)
+
+      # Without fix: 410 queries
+      # After fix: 19 queries
+      puts "Versions endpoint query count: #{queries_during_request}"
+      expect(queries_during_request).to be < 50,
+        "Expected fewer than 50 queries, got #{queries_during_request}"
+    end
+  end
 end


### PR DESCRIPTION
This eagerly loads data, thereby avoiding an N+1 cascade. The unit tests show a reduction in the number of SQL queries from ~400 to ~20. Testing in our dev environment also showed a 10x decrease in the response.

The only concern with this change is that this may result in too much data being eagerly loaded. Having said that:

- The data is required _at some point_ anyway, otherwise, it wouldn't be fetching all the data. A sequential loading may mean that less data is handled at any one time though.
- All endpoints which use this decorator are impacted by the same N+1 cascade, so this change will not result in excessive data in endpoints which may not need it.
