### PR TITLE
fix: use batch delete to speed up deletion

### DIFF
--- a/db/migrations/20260210_add_index_on_pact_version_id_to_latest_pact_publication.rb
+++ b/db/migrations/20260210_add_index_on_pact_version_id_to_latest_pact_publication.rb
@@ -1,0 +1,18 @@
+Sequel.migration do
+  up do
+    if !mysql?
+      alter_table(:latest_pact_publication_ids_for_consumer_versions) do
+        add_index :pact_version_id, name: :latest_pp_ids_for_cons_ver_pact_version_id_index
+      end
+    end
+  end
+
+  down do
+    if !mysql?
+      alter_table(:latest_pact_publication_ids_for_consumer_versions) do
+        drop_index :pact_version_id, name: :latest_pp_ids_for_cons_ver_pact_version_id_index
+      end
+    end
+  end
+end
+

--- a/lib/pact_broker/domain/pacticipant.rb
+++ b/lib/pact_broker/domain/pacticipant.rb
@@ -55,9 +55,24 @@ module PactBroker
         PactBroker::Pacts::PactPublication.where(provider: self).delete
         PactBroker::Domain::Verification.where(consumer: self).or(provider: self).delete
         PactBroker::Domain::Version.where(pacticipant: self).delete
-        PactBroker::Pacts::PactVersion.where(consumer: self).or(provider: self).delete
+        delete_pact_versions_in_batches
         PactBroker::Domain::Label.where(pacticipant: self).destroy
         super
+      end
+
+      BATCH_DELETE_SIZE = 500
+      def delete_pact_versions_in_batches
+        dataset = PactBroker::Pacts::PactVersion.where(consumer: self).or(provider: self)
+        total_deleted = 0
+
+        loop do
+          ids = dataset.limit(BATCH_DELETE_SIZE).select_map(:id)
+          break if ids.empty?
+
+          total_deleted += PactBroker::Pacts::PactVersion.where(id: ids).delete
+        end
+
+        total_deleted
       end
 
       def before_save


### PR DESCRIPTION
- Use batched deletes to reduce the risk of timeouts when deleting a pacticipant.
- The new index significantly improves delete performance, but it is not sufficient to fully resolve the issue on its own.