### PR TITLE
feat: Optimize WIP Query Performance to Prevent Timeouts on Large Datasets

### DIFF
--- a/db/migrations/20260217_add_wip_query_optimization_indexes.rb
+++ b/db/migrations/20260217_add_wip_query_optimization_indexes.rb
@@ -27,12 +27,16 @@ Sequel.migration do
   end
 
   down do
-    alter_table(:pact_publications) do
-      drop_index([:provider_id, :created_at], name: "idx_pp_provider_created", if_exists: true)
-    end
+    if PactBroker::MigrationHelper.postgres?
+      alter_table(:pact_publications) do
+        drop_index([:provider_id, :created_at], name: "idx_pp_provider_created", if_exists: true)
+      end
 
-    alter_table(:verifications) do
-      drop_index([:provider_id, :provider_version_id, :success, :wip, :pact_version_id], name: "idx_verifications_provider_lookup", if_exists: true)
+      alter_table(:verifications) do
+        drop_index([:provider_id, :provider_version_id, :success, :wip, :pact_version_id], name: "idx_verifications_provider_lookup", if_exists: true)
+      end
+    else
+      # These indexes are safe to leave in place and don't change the test behaviour
     end
   end
 end

--- a/db/migrations/20260217_add_wip_query_optimization_indexes.rb
+++ b/db/migrations/20260217_add_wip_query_optimization_indexes.rb
@@ -4,7 +4,7 @@ include PactBroker::MigrationHelper
 
 Sequel.migration do
   # Disable transaction wrapper so we can use CONCURRENTLY for PostgreSQL
-  no_transaction
+  no_transaction if postgres?
   
   up do
     alter_table(:pact_publications) do

--- a/db/migrations/20260217_add_wip_query_optimization_indexes.rb
+++ b/db/migrations/20260217_add_wip_query_optimization_indexes.rb
@@ -4,7 +4,7 @@ include PactBroker::MigrationHelper
 
 Sequel.migration do
   # Disable transaction wrapper so we can use CONCURRENTLY for PostgreSQL
-  no_transaction if postgres?
+  no_transaction if PactBroker::MigrationHelper.postgres?
   
   up do
     alter_table(:pact_publications) do

--- a/db/migrations/20260217_add_wip_query_optimization_indexes.rb
+++ b/db/migrations/20260217_add_wip_query_optimization_indexes.rb
@@ -3,40 +3,29 @@ require_relative "migration_helper"
 include PactBroker::MigrationHelper
 
 Sequel.migration do
-  # Disable transaction wrapper so we can use CONCURRENTLY for PostgreSQL
   no_transaction if PactBroker::MigrationHelper.postgres?
-  
+
   up do
-    if PactBroker::MigrationHelper.postgres?
+    if !mysql?
       alter_table(:pact_publications) do
-        add_index([:provider_id, :created_at], name: "idx_pp_provider_created", concurrently: true)
+        add_index([:provider_id, :created_at], name: "idx_pp_provider_created", concurrently: postgres?)
       end
-      
+
       alter_table(:verifications) do
-        add_index([:provider_id, :provider_version_id, :success, :wip, :pact_version_id], name: "idx_verifications_provider_lookup", concurrently: true)
-      end
-    else
-      alter_table(:pact_publications) do
-        add_index([:provider_id, :created_at], name: "idx_pp_provider_created")
-      end
-      
-      alter_table(:verifications) do
-        add_index([:provider_id, :provider_version_id, :success, :wip, :pact_version_id], name: "idx_verifications_provider_lookup")
+        add_index([:provider_id, :provider_version_id, :success, :wip, :pact_version_id], name: "idx_verifications_provider_lookup", concurrently: postgres?)
       end
     end
   end
 
   down do
-    if PactBroker::MigrationHelper.postgres?
+    if !mysql?
       alter_table(:pact_publications) do
-        drop_index([:provider_id, :created_at], name: "idx_pp_provider_created", if_exists: true)
+        drop_index([:provider_id, :created_at], name: "idx_pp_provider_created")
       end
 
       alter_table(:verifications) do
-        drop_index([:provider_id, :provider_version_id, :success, :wip, :pact_version_id], name: "idx_verifications_provider_lookup", if_exists: true)
+        drop_index([:provider_id, :provider_version_id, :success, :wip, :pact_version_id], name: "idx_verifications_provider_lookup")
       end
-    else
-      # These indexes are safe to leave in place and don't change the test behaviour
     end
   end
 end

--- a/db/migrations/20260217_add_wip_query_optimization_indexes.rb
+++ b/db/migrations/20260217_add_wip_query_optimization_indexes.rb
@@ -1,0 +1,28 @@
+require_relative "migration_helper"
+
+include PactBroker::MigrationHelper
+
+Sequel.migration do
+  # Disable transaction wrapper so we can use CONCURRENTLY for PostgreSQL
+  no_transaction
+  
+  up do
+    alter_table(:pact_publications) do
+      add_index([:provider_id, :created_at], name: "idx_pp_provider_created", concurrently: postgres?)
+    end
+    
+    alter_table(:verifications) do
+      add_index([:provider_id, :provider_version_id, :success, :wip, :pact_version_id], name: "idx_verifications_provider_lookup", concurrently: postgres?)
+    end
+  end
+
+  down do
+    alter_table(:pact_publications) do
+      drop_index([:provider_id, :created_at], name: "idx_pp_provider_created", if_exists: true)
+    end
+
+    alter_table(:verifications) do
+      drop_index([:provider_id, :provider_version_id, :success, :wip, :pact_version_id], name: "idx_verifications_provider_lookup", if_exists: true)
+    end
+  end
+end

--- a/db/migrations/20260217_add_wip_query_optimization_indexes.rb
+++ b/db/migrations/20260217_add_wip_query_optimization_indexes.rb
@@ -7,12 +7,22 @@ Sequel.migration do
   no_transaction if PactBroker::MigrationHelper.postgres?
   
   up do
-    alter_table(:pact_publications) do
-      add_index([:provider_id, :created_at], name: "idx_pp_provider_created", concurrently: postgres?)
-    end
-    
-    alter_table(:verifications) do
-      add_index([:provider_id, :provider_version_id, :success, :wip, :pact_version_id], name: "idx_verifications_provider_lookup", concurrently: postgres?)
+    if PactBroker::MigrationHelper.postgres?
+      alter_table(:pact_publications) do
+        add_index([:provider_id, :created_at], name: "idx_pp_provider_created", concurrently: true)
+      end
+      
+      alter_table(:verifications) do
+        add_index([:provider_id, :provider_version_id, :success, :wip, :pact_version_id], name: "idx_verifications_provider_lookup", concurrently: true)
+      end
+    else
+      alter_table(:pact_publications) do
+        add_index([:provider_id, :created_at], name: "idx_pp_provider_created")
+      end
+      
+      alter_table(:verifications) do
+        add_index([:provider_id, :provider_version_id, :success, :wip, :pact_version_id], name: "idx_verifications_provider_lookup")
+      end
     end
   end
 

--- a/lib/pact_broker/configuration.rb
+++ b/lib/pact_broker/configuration.rb
@@ -215,6 +215,13 @@ module PactBroker
       ENV["PACT_BROKER_MIN_WIP_WINDOW_DAYS"]&.to_i || 7
     end
 
+    # Lookback window (days) for checking if a pact was verified by another branch before this branch was created.
+    # Uses verification execution_date to find recent branch activity, avoiding false negatives when old
+    # version numbers are reused across branches.
+    def verified_by_other_branch_before_this_branch_look_back
+      ENV["PACT_BROKER_VERIFIED_BY_OTHER_BRANCH_LOOKBACK_DAYS"]&.to_i || 30
+    end
+
     # Default WIP window (days) used when dynamic calculation fails or no unverified pacts exist.
     def default_wip_window_days
       ENV["PACT_BROKER_DEFAULT_WIP_WINDOW_DAYS"]&.to_i || 7

--- a/lib/pact_broker/pacts/pact_publication_dataset_module.rb
+++ b/lib/pact_broker/pacts/pact_publication_dataset_module.rb
@@ -287,9 +287,13 @@ module PactBroker
       # NEW LOGIC
       # @return [Sequel::Dataset<PactBroker::Pacts::PactPublication>]
       def for_all_tag_heads
+        # Optimization: Only aggregate tags for consumers that have pacts for this provider.
+        relevant_consumer_ids = self.select(:consumer_id).distinct
+
         head_tags = PactBroker::Domain::Tag
                       .select_group(:pacticipant_id, :name)
-                      .select_append{ max(version_order).as(:latest_version_order) }
+                      .select_append{ max(:version_order).as(:latest_version_order) }
+                      .where(pacticipant_id: relevant_consumer_ids)
 
         head_tags_join = {
           Sequel[:pact_publications][:consumer_id] => Sequel[:head_tags][:pacticipant_id],

--- a/lib/pact_broker/pacts/pact_publication_wip_dataset_module.rb
+++ b/lib/pact_broker/pacts/pact_publication_wip_dataset_module.rb
@@ -19,13 +19,19 @@ module PactBroker
           end
 
           def join_branch_versions_excluding_branch(provider_id, branch_name)
+            # Only check branches that have been active in the last N days
+            # to avoid old stale branches causing cartesian explosion.
+            # Filter by verification execution_date rather than version created_at
+            # to avoid incorrectly excluding old versions with recent verifications.
+            recent_branch_cutoff = DateTime.now - PactBroker.configuration.verified_by_other_branch_before_this_branch_look_back
+
             branch_versions_join = {
               Sequel[:verifications][:provider_version_id] => Sequel[:branch_versions][:version_id],
               Sequel[:branch_versions][:pacticipant_id] => provider_id
             }
-            join(:branch_versions, branch_versions_join) do
-              Sequel.lit("branch_versions.branch_name != ?", branch_name)
-            end
+            join(:branch_versions, branch_versions_join)
+              .where { Sequel[:verifications][:execution_date] >= recent_branch_cutoff }
+              .where { Sequel.lit("branch_versions.branch_name != ?", branch_name) }
           end
 
           def join_provider_versions_for_provider_id_and_branch(provider_id, provider_version_branch)
@@ -45,10 +51,13 @@ module PactBroker
       end
 
       def successfully_verified_by_provider_branch_when_not_wip(provider_id, provider_version_branch)
+        # Only check verifications from last N days (old verifications unlikely relevant for WIP)
+        recent_cutoff = DateTime.now - PactBroker.configuration.verified_by_other_branch_before_this_branch_look_back
         successful_verifications = VerificationForWipCalculations
                                      .select(:pact_version_id)
                                      .distinct
                                      .successful_non_wip_by_provider(provider_id)
+                                     .where { Sequel[:verifications][:execution_date] >= recent_cutoff }
                                      .join_provider_versions_for_provider_id_and_branch(provider_id, provider_version_branch)
 
 
@@ -65,8 +74,8 @@ module PactBroker
                                      .select(:pact_version_id)
                                      .distinct
                                      .successful_non_wip_by_provider(provider_id)
-                                     .join_branch_versions_excluding_branch(provider_id, provider_version_branch)
                                      .verified_before_creation_date_of(first_version_for_branch)
+                                     .join_branch_versions_excluding_branch(provider_id, provider_version_branch)
 
         from_self(alias: :pp)
           .select(Sequel[:pp].*)

--- a/spec/lib/pact_broker/pacts/repository_find_wip_pact_versions_for_provider_branch_spec.rb
+++ b/spec/lib/pact_broker/pacts/repository_find_wip_pact_versions_for_provider_branch_spec.rb
@@ -282,6 +282,47 @@ module PactBroker
             expect(subject.first.provider_branch).to eq provider_version_branch
           end
         end
+
+        # Query optimization tests
+        context "when there are tags for consumers without pacts for this provider" do
+          before do
+            td.create_pact_with_hierarchy("foo", "1", "bar")
+              .create_consumer_version_tag("main")
+              .create_pact_with_hierarchy("other-consumer", "1", "different-provider")
+              .create_consumer_version_tag("main")
+              .create_consumer_version_tag("feat-1")
+          end
+
+          it "only includes consumers with pacts for this provider" do
+            expect(subject.map(&:consumer_name)).to eq ["foo"]
+          end
+        end
+
+        context "when there are verifications older than 30 days on same branch" do
+          before do
+            td.create_pact_with_hierarchy("foo", "1", "bar")
+              .create_consumer_version_tag("main")
+              .subtract_days(31)
+              .create_verification(provider_version: "1", branch: provider_version_branch, success: true, wip: false)
+          end
+
+          it "ignores old verifications and includes pact as WIP" do
+            expect(subject.length).to eq 1
+          end
+        end
+
+        context "when there are verifications from branches inactive for 30+ days" do
+          before do
+            td.create_pact_with_hierarchy("foo", "1", "bar")
+              .create_consumer_version_tag("main")
+              .subtract_days(35)
+              .create_verification(provider_version: "1", branch: "old-branch", success: true, wip: false)
+          end
+
+          it "ignores verifications from stale branches" do
+            expect(subject.length).to eq 1
+          end
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,9 +16,8 @@ require "rspec/pact/matchers"
 require "sucker_punch/testing/inline"
 require "webmock/rspec"
 require "pact_broker/policies"
-
+require "openapi_first"
 if ENV["OAS_COVERAGE_CHECK_ENABLED"] == "true"
-  require "openapi_first"
   OpenapiFirst::Test.setup do |test|
     test.register("pact_broker_oas.yaml")
   end


### PR DESCRIPTION
#### Problem: 
WIP pact queries timing out on large datasets due to unbounded lookback windows and inefficient table scans.

#### Solution:

* Add database indexes on `verifications(provider_id, provider_version_id, success, wip, pact_version_id)` and `pact_publications(provider_id, created_at)`
* Constrain queries to last **30** days of verification activity using new config `verified_by_other_branch_before_this_branch_look_back`
* Filter by `verifications.execution_date` instead of `versions.created_at` to avoid unnecessary joins and correctly identify recent branch activity
* Optimize `for_all_tag_heads` to pre-filter consumers before aggregating tags 

#### Configuration:

New env var: 
`PACT_BROKER_VERIFIED_BY_OTHER_BRANCH_LOOKBACK_DAYS` (default: **30**)

#### Impact: 
Reduces query scope and leverages indexes to prevent cartesian explosion on providers with many old branches/verifications.

Jira Ticket: [PACT-5705]
