### PR TITLE
chore: log level lowering to reduce noise

### DIFF
--- a/lib/pact_broker/api/resources/provider_pacts_for_verification.rb
+++ b/lib/pact_broker/api/resources/provider_pacts_for_verification.rb
@@ -94,7 +94,7 @@ module PactBroker
         end
 
         def log_request
-          logger.info "Fetching pacts for verification by #{provider_name}", provider_name: provider_name, params: query
+          logger.debug "Fetching pacts for verification by #{provider_name}", provider_name: provider_name, params: query
         end
 
         def nested_query

--- a/lib/pact_broker/logging.rb
+++ b/lib/pact_broker/logging.rb
@@ -52,6 +52,16 @@ module PactBroker
       end
     end
 
+    def measure_debug(message, payload: {})
+      if logger.respond_to?(:measure_debug)
+        logger.measure_debug(message, payload: payload) do
+          yield
+        end
+      else
+        yield
+      end
+    end
+
     def log_error e, description = nil
       if logger.instance_of?(SemanticLogger::Logger)
         if description

--- a/lib/pact_broker/pacts/service.rb
+++ b/lib/pact_broker/pacts/service.rb
@@ -210,7 +210,7 @@ module PactBroker
 
       # When no publication for the given consumer/provider/consumer version number exists
       def create_pact(params, version, provider)
-        logger.info("Creating new pact publication", params.without(:json_content))
+        logger.debug("Creating new pact publication", params.without(:json_content))
         logger.debug("Content #{params[:json_content]}")
         json_content = add_interaction_ids(params[:json_content])
         pact = pact_repository.create(

--- a/lib/pact_broker/versions/branch_version_repository.rb
+++ b/lib/pact_broker/versions/branch_version_repository.rb
@@ -22,7 +22,7 @@ module PactBroker
       end
 
       def add_branch(version, branch_name, auto_created: false)
-        PactBroker.logger.info("BranchVersionRepository#add_branch method called with version #{version.inspect} and branch_name '#{branch_name}'")
+        PactBroker.logger.debug("BranchVersionRepository#add_branch method called with version #{version.inspect} and branch_name '#{branch_name}'")
         Sequel::Model.db.transaction do
           branch = find_or_create_branch(version.pacticipant, branch_name)
           branch_version = version.branch_version_for_branch(branch)

--- a/lib/pact_broker/webhooks/event_listener.rb
+++ b/lib/pact_broker/webhooks/event_listener.rb
@@ -56,7 +56,7 @@ module PactBroker
         logger.debug("Event detected", event_name: event.name, event_comment: event.comment)
         if event.triggered_webhooks&.any?
           triggered_webhook_descriptions = event.triggered_webhooks.collect{ |tw| { event_name: event.name, webhook_uuid: tw.webhook_uuid, triggered_webhook_uuid: tw.uuid, webhook_description: tw.webhook.description } }
-          logger.info("Triggered webhooks for #{event.name}", triggered_webhooks: triggered_webhook_descriptions)
+          logger.debug("Triggered webhooks for #{event.name}", triggered_webhooks: triggered_webhook_descriptions)
         else
           logger.debug "No enabled webhooks found for event #{event.name}"
         end


### PR DESCRIPTION
## Summary

  This PR reduces log verbosity by changing frequently called operational logs from info to debug level. These logs are useful for debugging but create excessive
  noise during normal operation.

## Changes

- Changed log level from info to debug for:
- Pact fetching requests (provider_pacts_for_verification.rb)
- Pact publication creation (pacts/service.rb)
- Branch version additions (branch_version_repository.rb)
- Added measure_debug helper method to Logging module for consistency with existing measure_info pattern

## Motivation

These logs fire on every pact verification request, publication, and branch association. In active environments with frequent CI runs, this generates significant log volume without providing actionable information for normal operations. Moving to debug level maintains observability when needed while keeping production logs cleaner.

## Testing

No new tests required - this is a configuration-only change to existing logging statements. The measure_debug method follows the same defensive pattern as measure_info.