### PR TITLE
feat(PACT-6253): add json_schemer as explicit gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem "bump", "~> 0.5"
 gem "padrino-core", ">= 0.16.0.pre3", require: false
 gem "rackup", "~> 2.2"
 gem "thor", "~> 1.4" # thor is secondary dependency but bumping here to avoid CVEs
-gem "json_schemer", "~> 2.5"
 
 group :development do
   gem "pry-byebug"

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "bump", "~> 0.5"
 gem "padrino-core", ">= 0.16.0.pre3", require: false
 gem "rackup", "~> 2.2"
 gem "thor", "~> 1.4" # thor is secondary dependency but bumping here to avoid CVEs
+gem "json_schemer", "~> 2.5"
 
 group :development do
   gem "pry-byebug"

--- a/pact_broker.gemspec
+++ b/pact_broker.gemspec
@@ -76,4 +76,5 @@ Gem::Specification.new do |gem|
   # dropped in ruby 3.5 stdlib
   gem.add_runtime_dependency "ostruct", "~> 0.5" 
   gem.add_development_dependency "pstore", "~> 0.1" # until webmachine requires it
+  gem.add_runtime_dependency "json_schemer", "~> 2.5"
 end

--- a/pact_broker.gemspec
+++ b/pact_broker.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mutex_m", "~> 0.3" # until as-notifications -> webmachine requires it
   gem.add_runtime_dependency "csv", "~> 3.0" # lib/pact_broker/api/decorators/relationships_csv_decorator.rb
   # dropped in ruby 3.5 stdlib
-  gem.add_runtime_dependency "ostruct", "~> 0.5" 
-  gem.add_development_dependency "pstore", "~> 0.1" # until webmachine requires it
+  gem.add_runtime_dependency "ostruct", "~> 0.5"
   gem.add_runtime_dependency "json_schemer", "~> 2.5"
+  gem.add_development_dependency "pstore", "~> 0.1" # until webmachine requires it
 end


### PR DESCRIPTION
## Summary

- Adds `json_schemer (~> 2.5)` as an explicit dependency in `Gemfile`
- Previously only available as a transitive dependency via `openapi_first`; making it explicit prevents silent version changes when `openapi_first` is updated

## Test plan

- [ ] `bundle install` completes successfully
- [ ] CI passes

Closes PACT-6253

🤖 Generated with [Claude Code](https://claude.com/claude-code)