### PR TITLE
fix: join with pacticipant when query main branch

### DIFF
--- a/lib/pact_broker/db/clean.rb
+++ b/lib/pact_broker/db/clean.rb
@@ -208,11 +208,11 @@ module PactBroker
       def stale_branch_ids_to_keep
         queries = []
 
-        main_branch_names = db[:pacticipants]
-          .exclude(main_branch: nil)
-          .select_map(:main_branch)
-          .uniq
-        queries << db[:branches].where(name: main_branch_names).select(:id) unless main_branch_names.empty?
+        queries << db[:branches]
+                     .join(:pacticipants, id: Sequel[:branches][:pacticipant_id])
+                     .exclude(Sequel[:pacticipants][:main_branch] => nil)
+                     .where(Sequel[:branches][:name] => Sequel[:pacticipants][:main_branch])
+                     .select(Sequel[:branches][:id])
 
         keep_branches.each do | selector |
           if selector.max_age

--- a/lib/pact_broker/db/clean_incremental.rb
+++ b/lib/pact_broker/db/clean_incremental.rb
@@ -131,11 +131,11 @@ module PactBroker
         queries = []
 
         # Always keep main branches for each pacticipant
-        main_branch_names = PactBroker::Domain::Pacticipant
-          .exclude(main_branch: nil)
-          .select_map(:main_branch)
-          .uniq
-        queries << PactBroker::Versions::Branch.where(name: main_branch_names).select(Sequel[:branches][:id]) unless main_branch_names.empty?
+        queries << PactBroker::Versions::Branch
+                     .join(:pacticipants, id: Sequel[:branches][:pacticipant_id])
+                     .exclude(Sequel[:pacticipants][:main_branch] => nil)
+                     .where(Sequel[:branches][:name] => Sequel[:pacticipants][:main_branch])
+                     .select(Sequel[:branches][:id])
 
         keep_branches.each do | selector |
           if selector.max_age

--- a/spec/lib/pact_broker/db/clean_incremental_spec.rb
+++ b/spec/lib/pact_broker/db/clean_incremental_spec.rb
@@ -201,6 +201,32 @@ module PactBroker
             end
           end
 
+          context "when two pacticipants have a branch with the same name but only one declares it as main_branch" do
+            before do
+              Timecop.freeze(Date.today - 100) do
+                td.publish_pact(consumer_name: "ConsumerA", provider_name: "ProviderX", consumer_version_number: "1", branch: "shared-main")
+                td.publish_pact(consumer_name: "ConsumerB", provider_name: "ProviderX", consumer_version_number: "1", branch: "shared-main")
+              end
+              PactBroker::Domain::Pacticipant.where(name: "ConsumerA").update(main_branch: "shared-main")
+              # ConsumerB intentionally has no main_branch set
+            end
+
+            let(:options) { { keep: keep_all_versions, keep_branches: [PactBroker::DB::Clean::BranchSelector.new(max_age: 90)] } }
+
+            def branch_count_for(pacticipant_name, branch_name)
+              pacticipant_id = PactBroker::Domain::Pacticipant.where(name: pacticipant_name).get(:id)
+              PactBroker::Versions::Branch.where(pacticipant_id: pacticipant_id, name: branch_name).count
+            end
+
+            it "keeps the stale 'shared-main' branch belonging to the pacticipant that declares it as main_branch" do
+              expect { subject }.to_not change { branch_count_for("ConsumerA", "shared-main") }.from(1)
+            end
+
+            it "deletes the stale 'shared-main' branch belonging to the pacticipant that does not declare it as main_branch" do
+              expect { subject }.to change { branch_count_for("ConsumerB", "shared-main") }.from(1).to(0)
+            end
+          end
+
           context "when a branch name is listed in keep_branches selectors" do
             let(:options) do
               {

--- a/spec/lib/pact_broker/db/clean_spec.rb
+++ b/spec/lib/pact_broker/db/clean_spec.rb
@@ -1,5 +1,6 @@
 require "pact_broker/db/clean"
 require "pact_broker/matrix/unresolved_selector"
+require "timecop"
 
 module PactBroker
   module DB
@@ -145,6 +146,100 @@ module PactBroker
 
           it "deletes the ones associated with the deleted pacts" do
             expect { subject }.to change { PactBroker::Webhooks::TriggeredWebhook.count }.by(-1)
+          end
+        end
+
+        context "stale branch cleanup" do
+          before do
+            Timecop.freeze(Date.today - 100) do
+              td.publish_pact(consumer_name: "Foo", provider_name: "Bar", consumer_version_number: "1", branch: "feat/old")
+            end
+            Timecop.freeze(Date.today - 50) do
+              td.publish_pact(consumer_name: "Foo", provider_name: "Bar", consumer_version_number: "2", branch: "feat/fresh")
+              td.publish_pact(consumer_name: "Foo", provider_name: "Bar", consumer_version_number: "3", branch: "main")
+            end
+          end
+
+          # Keep all versions so branch deletion is what's observable
+          let(:keep_all_versions) { [{ max_age: 999 }] }
+
+          context "when keep_branches is configured with a max_age" do
+            let(:options) { { keep: keep_all_versions, keep_branches: [PactBroker::DB::Clean::BranchSelector.new(max_age: 90)] } }
+
+            it "deletes branches whose updated_at is older than max_age" do
+              expect { subject }.to change { PactBroker::Versions::Branch.where(name: "feat/old").count }.from(1).to(0)
+            end
+
+            it "keeps branches updated within max_age" do
+              expect { subject }.to_not change { PactBroker::Versions::Branch.where(name: "feat/fresh").count }
+            end
+
+            it "returns the number of deleted branches in the deleted counts" do
+              expect(subject[:deleted][:stale_branches]).to eq 1
+            end
+          end
+
+          context "when the pacticipant has a main_branch set" do
+            before do
+              Timecop.freeze(Date.today - 100) do
+                td.publish_pact(consumer_name: "Foo", provider_name: "Bar", consumer_version_number: "4", branch: "main-protected")
+              end
+              PactBroker::Domain::Pacticipant.where(name: "Foo").update(main_branch: "main-protected")
+            end
+
+            let(:options) { { keep: keep_all_versions, keep_branches: [PactBroker::DB::Clean::BranchSelector.new(max_age: 90)] } }
+
+            it "never deletes the main branch even when stale" do
+              expect { subject }.to_not change { PactBroker::Versions::Branch.where(name: "main-protected").count }
+            end
+          end
+
+          context "when a branch name is listed in keep_branches selectors" do
+            let(:options) do
+              {
+                keep: keep_all_versions,
+                keep_branches: [
+                  PactBroker::DB::Clean::BranchSelector.new(max_age: 90),
+                  PactBroker::DB::Clean::BranchSelector.new(branch: ["feat/old"])
+                ]
+              }
+            end
+
+            it "keeps explicitly named branches even when stale" do
+              expect { subject }.to_not change { PactBroker::Versions::Branch.where(name: "feat/old").count }
+            end
+          end
+
+          context "when keep_branches is nil" do
+            let(:options) { { keep: keep_all_versions, keep_branches: nil } }
+
+            it "does not delete any branches" do
+              expect { subject }.to_not change { PactBroker::Versions::Branch.count }
+            end
+
+            it "reports zero stale branches deleted" do
+              expect(subject[:deleted][:stale_branches]).to eq 0
+            end
+          end
+
+          context "when keep_branches is an empty array" do
+            let(:options) { { keep: keep_all_versions, keep_branches: [] } }
+
+            it "does not delete any branches" do
+              expect { subject }.to_not change { PactBroker::Versions::Branch.count }
+            end
+
+            it "reports zero stale branches deleted" do
+              expect(subject[:deleted][:stale_branches]).to eq 0
+            end
+          end
+
+          context "when keep_branches is not specified in the options" do
+            let(:options) { { keep: keep_all_versions } }
+
+            it "does not delete any branches" do
+              expect { subject }.to_not change { PactBroker::Versions::Branch.count }
+            end
           end
         end
       end

--- a/spec/lib/pact_broker/db/clean_spec.rb
+++ b/spec/lib/pact_broker/db/clean_spec.rb
@@ -194,6 +194,32 @@ module PactBroker
             end
           end
 
+          context "when two pacticipants have a branch with the same name but only one declares it as main_branch" do
+            before do
+              Timecop.freeze(Date.today - 100) do
+                td.publish_pact(consumer_name: "ConsumerA", provider_name: "ProviderX", consumer_version_number: "1", branch: "shared-main")
+                td.publish_pact(consumer_name: "ConsumerB", provider_name: "ProviderX", consumer_version_number: "1", branch: "shared-main")
+              end
+              PactBroker::Domain::Pacticipant.where(name: "ConsumerA").update(main_branch: "shared-main")
+              # ConsumerB intentionally has no main_branch set
+            end
+
+            let(:options) { { keep: keep_all_versions, keep_branches: [PactBroker::DB::Clean::BranchSelector.new(max_age: 90)] } }
+
+            def branch_count_for(pacticipant_name, branch_name)
+              pacticipant_id = PactBroker::Domain::Pacticipant.where(name: pacticipant_name).get(:id)
+              PactBroker::Versions::Branch.where(pacticipant_id: pacticipant_id, name: branch_name).count
+            end
+
+            it "keeps the stale 'shared-main' branch belonging to the pacticipant that declares it as main_branch" do
+              expect { subject }.to_not change { branch_count_for("ConsumerA", "shared-main") }.from(1)
+            end
+
+            it "deletes the stale 'shared-main' branch belonging to the pacticipant that does not declare it as main_branch" do
+              expect { subject }.to change { branch_count_for("ConsumerB", "shared-main") }.from(1).to(0)
+            end
+          end
+
           context "when a branch name is listed in keep_branches selectors" do
             let(:options) do
               {

--- a/spec/lib/pact_broker/versions/branch_version_repository_spec.rb
+++ b/spec/lib/pact_broker/versions/branch_version_repository_spec.rb
@@ -1,4 +1,5 @@
 require "pact_broker/versions/branch_version_repository"
+require "timecop"
 
 module PactBroker
   module Versions
@@ -44,6 +45,13 @@ module PactBroker
             expect(branch_head.version.id).to eq subject.refresh.id
           end
 
+          it "sets the branch updated_at" do
+            now = Time.new(2025, 1, 1, 12, 0, 0)
+            Timecop.freeze(now) { subject }
+            branch = PactBroker::Versions::Branch.where(name: "new-branch").single_record
+            expect(branch.updated_at.to_time.to_i).to eq(now.to_i)
+          end
+
           context "when auto_created is true" do
             subject { repository.add_branch(version, new_branch_name, auto_created: true) }
 
@@ -73,6 +81,15 @@ module PactBroker
           it "does not change the branch head" do
             branch_head = subject.pacticipant.branch_head_for("original-branch")
             expect(branch_head.version).to eq subject
+          end
+
+          it "updates the branch updated_at" do
+            branch = PactBroker::Versions::Branch.where(name: "original-branch").single_record
+            original_updated_at = branch.updated_at
+            now = Time.now + 3600
+            Timecop.freeze(now) { subject }
+            expect(branch.refresh.updated_at.to_time.to_i).to eq(now.to_i)
+            expect(branch.updated_at).to be > original_updated_at
           end
         end
       end


### PR DESCRIPTION
### Problem
Main-branch protection is matching only on branch name, not the owning pacticipant. If any pacticipant has main_branch = "develop", every stale branch named develop for every other pacticipant will be kept, even when it is not that pacticipant's main branch. Join or filter on both branches.pacticipant_id and pacticipants.main_branch so the exception applies only to the correct pacticipant.

### Fix
```
queries << PactBroker::Versions::Branch
	.join(:pacticipants, id: Sequel[:branches][:pacticipant_id])
	.exclude(Sequel[:pacticipants][:main_branch] => nil)
	.where(Sequel[:branches][:name] => Sequel[:pacticipants][:main_branch])
	.select(Sequel[:branches][:id])
```