### PR TITLE
fix: remove deadcode, improve testing with UTC

### DIFF
--- a/lib/pact_broker/db/clean.rb
+++ b/lib/pact_broker/db/clean.rb
@@ -187,32 +187,18 @@ module PactBroker
       def delete_stale_branches
         return 0 unless keep_branches && !keep_branches.empty?
 
-        ids_to_delete = stale_branch_ids_to_delete
-        count = ids_to_delete.count
-        db[:branches].where(id: ids_to_delete.from_self.select(:id)).delete
-        count
+        db[:branches].where(id: stale_branch_ids_to_delete.from_self.select(:id)).delete
       end
 
       def stale_branch_ids_to_delete
-        ids_to_keep = stale_branch_ids_to_keep
-        if ids_to_keep.nil?
-          db[:branches].where(false).select(:id)
-        else
-          db[:branches]
-            .select(Sequel[:branches][:id])
-            .left_outer_join(ids_to_keep, { Sequel[:branches][:id] => Sequel[:keep_branches][:id] }, table_alias: :keep_branches)
-            .where(Sequel[:keep_branches][:id] => nil)
-        end
+        db[:branches]
+          .select(Sequel[:branches][:id])
+          .left_outer_join(stale_branch_ids_to_keep, { Sequel[:branches][:id] => Sequel[:keep_branches][:id] }, table_alias: :keep_branches)
+          .where(Sequel[:keep_branches][:id] => nil)
       end
 
       def stale_branch_ids_to_keep
-        queries = []
-
-        queries << db[:branches]
-                     .join(:pacticipants, id: Sequel[:branches][:pacticipant_id])
-                     .exclude(Sequel[:pacticipants][:main_branch] => nil)
-                     .where(Sequel[:branches][:name] => Sequel[:pacticipants][:main_branch])
-                     .select(Sequel[:branches][:id])
+        queries = [main_branch_ids_to_keep]
 
         keep_branches.each do | selector |
           if selector.max_age
@@ -224,7 +210,15 @@ module PactBroker
           end
         end
 
-        queries.empty? ? nil : queries.reduce(:union)
+        queries.reduce(:union)
+      end
+
+      def main_branch_ids_to_keep
+        db[:branches]
+          .join(:pacticipants, id: Sequel[:branches][:pacticipant_id])
+          .exclude(Sequel[:pacticipants][:main_branch] => nil)
+          .where(Sequel[:branches][:name] => Sequel[:pacticipants][:main_branch])
+          .select(Sequel[:branches][:id])
       end
 
       def keep_branches

--- a/lib/pact_broker/db/clean_incremental.rb
+++ b/lib/pact_broker/db/clean_incremental.rb
@@ -118,26 +118,15 @@ module PactBroker
       end
 
       def stale_branch_ids_to_delete
-        ids_to_keep = stale_branch_ids_to_keep
-        if ids_to_keep.nil?
-          PactBroker::Versions::Branch.where(false).select(:id)
-        else
-          PactBroker::Versions::Branch
-            .select(Sequel[:branches][:id])
-            .left_outer_join(ids_to_keep, { Sequel[:branches][:id] => Sequel[:keep_branches][:id] }, table_alias: :keep_branches)
-            .where(Sequel[:keep_branches][:id] => nil)
-        end
+        PactBroker::Versions::Branch
+          .select(Sequel[:branches][:id])
+          .left_outer_join(stale_branch_ids_to_keep, { Sequel[:branches][:id] => Sequel[:keep_branches][:id] }, table_alias: :keep_branches)
+          .where(Sequel[:keep_branches][:id] => nil)
       end
 
       def stale_branch_ids_to_keep
-        queries = []
-
         # Always keep main branches for each pacticipant
-        queries << PactBroker::Versions::Branch
-                     .join(:pacticipants, id: Sequel[:branches][:pacticipant_id])
-                     .exclude(Sequel[:pacticipants][:main_branch] => nil)
-                     .where(Sequel[:branches][:name] => Sequel[:pacticipants][:main_branch])
-                     .select(Sequel[:branches][:id])
+        queries = [main_branch_ids_to_keep]
 
         keep_branches.each do | selector |
           if selector.max_age
@@ -149,7 +138,15 @@ module PactBroker
           end
         end
 
-        queries.empty? ? nil : queries.reduce(&:union)
+        queries.reduce(&:union)
+      end
+
+      def main_branch_ids_to_keep
+        PactBroker::Versions::Branch
+          .join(:pacticipants, id: Sequel[:branches][:pacticipant_id])
+          .exclude(Sequel[:pacticipants][:main_branch] => nil)
+          .where(Sequel[:branches][:name] => Sequel[:pacticipants][:main_branch])
+          .select(Sequel[:branches][:id])
       end
 
       def delete_orphan_pact_versions

--- a/lib/pact_broker/tasks/clean_task.rb
+++ b/lib/pact_broker/tasks/clean_task.rb
@@ -43,7 +43,7 @@ module PactBroker
       def rake_task &block
         namespace :pact_broker do
           namespace :db do
-            desc "Clean unnecessary pacts and verifications from database"
+            desc "Clean unnecessary pacts, verifications and stale branches from database"
             task :clean do | _t, _args |
               instance_eval(&block)
 
@@ -69,6 +69,8 @@ module PactBroker
           add_defaults_to_keep_selectors
           output "Deleting oldest #{version_deletion_limit} versions, keeping versions that match the configured selectors", keep_version_selectors.collect(&:to_hash)
         end
+
+        output_keep_branch_selectors
 
         start_time = Time.now
         results = PactBroker::DB::CleanIncremental.call(database_connection,
@@ -117,6 +119,14 @@ module PactBroker
       def output(string, payload = {})
         prefix = dry_run ? "[DRY RUN] " : ""
         logger ? logger.info("#{prefix}#{string}", payload) : puts("#{prefix}#{string} #{payload.to_json}")
+      end
+
+      def output_keep_branch_selectors
+        if keep_branch_selectors.nil? || keep_branch_selectors.empty?
+          output "Stale branch cleanup is disabled (no keep_branch_selectors configured)"
+        else
+          output "Deleting stale branches that do not match the configured selectors (main branches are always kept)", keep_branch_selectors.collect(&:to_hash)
+        end
       end
 
       def add_defaults_to_keep_selectors

--- a/spec/lib/pact_broker/versions/branch_version_repository_spec.rb
+++ b/spec/lib/pact_broker/versions/branch_version_repository_spec.rb
@@ -46,7 +46,7 @@ module PactBroker
           end
 
           it "sets the branch updated_at" do
-            now = Time.new(2025, 1, 1, 12, 0, 0)
+            now = Time.utc(2025, 1, 1, 12, 0, 0)
             Timecop.freeze(now) { subject }
             branch = PactBroker::Versions::Branch.where(name: "new-branch").single_record
             expect(branch.updated_at.to_time.to_i).to eq(now.to_i)
@@ -86,7 +86,7 @@ module PactBroker
           it "updates the branch updated_at" do
             branch = PactBroker::Versions::Branch.where(name: "original-branch").single_record
             original_updated_at = branch.updated_at
-            now = Time.now + 3600
+            now = (original_updated_at.to_time.utc + 3600)
             Timecop.freeze(now) { subject }
             expect(branch.refresh.updated_at.to_time.to_i).to eq(now.to_i)
             expect(branch.updated_at).to be > original_updated_at


### PR DESCRIPTION
### Remove the dead code to simplify the logic

`stale_branch_ids_to_keep` always includes the “keep main branches” query, and `stale_branch_ids_to_delete` is only called when `keep_branches` is non-empty. In that case `ids_to_keep` cannot be nil, so this if ids_to_keep.nil? branch is effectively dead code. 