### PR TITLE
feat: change branch sort order, most recently updated first

### DIFF
--- a/lib/pact_broker/versions/branch_repository.rb
+++ b/lib/pact_broker/versions/branch_repository.rb
@@ -13,7 +13,7 @@ module PactBroker
         query = scope_for(Branch).where(pacticipant_id: pacticipant.id).select_all_qualified
         query = query.filter(:name, filter_options[:query_string]) if filter_options[:query_string]
         query
-          .order(Sequel.desc(:created_at), Sequel.desc(:id))
+          .order(Sequel.desc(:updated_at), Sequel.desc(:id))
           .eager(*eager_load_associations)
           .all_with_pagination_options(pagination_options)
       end

--- a/lib/pact_broker/versions/branch_service.rb
+++ b/lib/pact_broker/versions/branch_service.rb
@@ -21,7 +21,7 @@ module PactBroker
         # @return [Array<PactBroker::Contracts::Notice>]
         def branch_deletion_notices(pacticipant, exclude:)
           count = branch_repository.count_branches_to_delete(pacticipant, exclude: exclude)
-          remaining = branch_repository.remaining_branches_after_future_deletion(pacticipant, exclude: exclude).sort_by(&:created_at).collect(&:name).join(", ")
+          remaining = branch_repository.remaining_branches_after_future_deletion(pacticipant, exclude: exclude).sort_by(&:updated_at).collect(&:name).join(", ")
           [PactBroker::Contracts::Notice.success(message("messages.branch.bulk_delete", count: count, pacticipant_name: pacticipant.name, remaining: remaining))]
         end
       end

--- a/spec/lib/pact_broker/versions/branch_repository_spec.rb
+++ b/spec/lib/pact_broker/versions/branch_repository_spec.rb
@@ -30,10 +30,21 @@ module PactBroker
         end
 
         context "with no options" do
-          it "returns all the branches for the pacticipant starting with the most recent" do
+          it "returns all the branches for the pacticipant ordered by updated_at descending" do
             expect(subject.size).to eq 3
             expect(subject.first.name).to eq "feat/bar"
             expect(subject.last.name).to eq "main"
+          end
+        end
+
+        context "when a branch with an older created_at has a newer updated_at" do
+          before do
+            # Add a new version to "main" (created earliest), making its updated_at the most recent
+            td.create_consumer_version("5", branch: "main")
+          end
+
+          it "returns the branch with the most recent updated_at first" do
+            expect(subject.first.name).to eq "main"
           end
         end
 

--- a/spec/lib/pact_broker/versions/branch_service_spec.rb
+++ b/spec/lib/pact_broker/versions/branch_service_spec.rb
@@ -98,8 +98,8 @@ module PactBroker
         let(:branch_repository) { instance_double(PactBroker::Versions::BranchRepository, count_branches_to_delete: 3, remaining_branches_after_future_deletion: remaining_branches) }
         let(:remaining_branches) do
           [
-            instance_double(PactBroker::Versions::Branch, name: "foo", created_at: DateTime.now - 10),
-            instance_double(PactBroker::Versions::Branch, name: "bar", created_at: DateTime.now - 20)
+            instance_double(PactBroker::Versions::Branch, name: "foo", updated_at: DateTime.now - 10),
+            instance_double(PactBroker::Versions::Branch, name: "bar", updated_at: DateTime.now - 20)
           ]
         end
 


### PR DESCRIPTION
Now that we have branches stamped when they are updated, we should return most recently updated branches first.