### PR TITLE
fix: use cvpv when checking can-i-deploy against an environment

### DIFF
--- a/lib/pact_broker/api/resources/can_i_deploy_pacticipant_version_by_branch_to_environment.rb
+++ b/lib/pact_broker/api/resources/can_i_deploy_pacticipant_version_by_branch_to_environment.rb
@@ -37,8 +37,11 @@ module PactBroker
         end
 
         def options
+          # "cvpv" (not "cvp") so that every version of an integrated application that is currently
+          # released/deployed to the environment is evaluated independently, rather than collapsing
+          # to just the latest provider version (which hides still-live incompatible versions). See issue #903.
           @options ||=  {
-                          latestby: "cvp",
+                          latestby: "cvpv",
                           environment_name: identifier_from_path[:environment_name]
                         }
         end

--- a/lib/pact_broker/api/resources/can_i_deploy_pacticipant_version_by_branch_to_environment_badge.rb
+++ b/lib/pact_broker/api/resources/can_i_deploy_pacticipant_version_by_branch_to_environment_badge.rb
@@ -1,4 +1,5 @@
 require "pact_broker/api/resources/can_i_deploy_pacticipant_version_by_branch_to_environment"
+require "pact_broker/api/resources/badge_methods"
 
 module PactBroker
   module Api

--- a/lib/pact_broker/matrix/parse_can_i_deploy_query.rb
+++ b/lib/pact_broker/matrix/parse_can_i_deploy_query.rb
@@ -26,6 +26,11 @@ module PactBroker
 
         if params[:environment].is_a?(String)
           options[:environment_name] = params[:environment]
+          # Multiple versions of an integrated application can be simultaneously released to an
+          # environment (record-release), or deployed to it on different targets (record-deployment).
+          # "cvp" collapses these down to the latest provider version, hiding incompatible versions
+          # that are still live. "cvpv" evaluates every co-resident version independently. See issue #903.
+          options[:latestby] = "cvpv"
         end
 
         if params[:ignore].is_a?(Array)

--- a/spec/features/can_i_deploy_spec.rb
+++ b/spec/features/can_i_deploy_spec.rb
@@ -69,4 +69,137 @@ RSpec.describe "can i deploy" do
       expect(response_body[:errors]).to be_instance_of(Hash)
     end
   end
+
+  # End-to-end guard for issue #903: when multiple versions of a provider are released to an
+  # environment, can-i-deploy must evaluate every co-resident version, not just the latest.
+  context "when multiple versions of the provider are released to an environment and an older one is incompatible" do
+    before do
+      td.create_environment("production")
+        .create_pact_with_hierarchy("Waffle", "1", "Pancake")
+        .create_verification(provider_version: "10", number: 1, success: false)
+        .create_released_version_for_provider_version(environment_name: "production")
+        .create_verification(provider_version: "11", number: 2, success: true)
+        .create_released_version_for_provider_version(environment_name: "production")
+    end
+
+    let(:query) { { pacticipant: "Waffle", version: "1", environment: "production" } }
+
+    it "returns a row for every released provider version and is not deployable" do
+      expect(subject).to be_a_hal_json_success_response
+      expect(response_body[:matrix].size).to eq 2
+      expect(response_body[:summary][:deployable]).to be false
+    end
+  end
+
+  context "when multiple versions of the provider are released to an environment and all are compatible" do
+    before do
+      td.create_environment("production")
+        .create_pact_with_hierarchy("Waffle", "1", "Pancake")
+        .create_verification(provider_version: "10", number: 1, success: true)
+        .create_released_version_for_provider_version(environment_name: "production")
+        .create_verification(provider_version: "11", number: 2, success: true)
+        .create_released_version_for_provider_version(environment_name: "production")
+    end
+
+    let(:query) { { pacticipant: "Waffle", version: "1", environment: "production" } }
+
+    it "returns a row for every released provider version and is deployable" do
+      expect(subject).to be_a_hal_json_success_response
+      expect(response_body[:matrix].size).to eq 2
+      expect(response_body[:summary][:deployable]).to be true
+    end
+  end
+
+  context "when multiple versions of the provider are deployed to an environment on different application instances and all are compatible" do
+    before do
+      td.create_environment("production")
+        .create_pact_with_hierarchy("Waffle", "1", "Pancake")
+        .create_verification(provider_version: "10", number: 1, success: true)
+        .create_deployed_version_for_provider_version(environment_name: "production", target: "instance-1")
+        .create_verification(provider_version: "11", number: 2, success: true)
+        .create_deployed_version_for_provider_version(environment_name: "production", target: "instance-2")
+    end
+
+    let(:query) { { pacticipant: "Waffle", version: "1", environment: "production" } }
+
+    it "returns a row for every deployed provider version and is deployable" do
+      expect(subject).to be_a_hal_json_success_response
+      expect(response_body[:matrix].size).to eq 2
+      expect(response_body[:summary][:deployable]).to be true
+    end
+  end
+
+  context "when multiple versions of the provider are deployed to an environment on different application instances and one is incompatible" do
+    before do
+      td.create_environment("production")
+        .create_pact_with_hierarchy("Waffle", "1", "Pancake")
+        .create_verification(provider_version: "10", number: 1, success: false)
+        .create_deployed_version_for_provider_version(environment_name: "production", target: "instance-1")
+        .create_verification(provider_version: "11", number: 2, success: true)
+        .create_deployed_version_for_provider_version(environment_name: "production", target: "instance-2")
+    end
+
+    let(:query) { { pacticipant: "Waffle", version: "1", environment: "production" } }
+
+    it "returns a row for every deployed provider version and is not deployable" do
+      expect(subject).to be_a_hal_json_success_response
+      expect(response_body[:matrix].size).to eq 2
+      expect(response_body[:summary][:deployable]).to be false
+    end
+  end
+
+  context "when a single version of the provider is deployed to an environment without an application instance and is incompatible" do
+    before do
+      td.create_environment("production")
+        .create_pact_with_hierarchy("Waffle", "1", "Pancake")
+        .create_verification(provider_version: "10", number: 1, success: false)
+        .create_deployed_version_for_provider_version(environment_name: "production")
+    end
+
+    let(:query) { { pacticipant: "Waffle", version: "1", environment: "production" } }
+
+    it "is not deployable" do
+      expect(subject).to be_a_hal_json_success_response
+      expect(response_body[:matrix].size).to eq 1
+      expect(response_body[:summary][:deployable]).to be false
+    end
+  end
+
+  context "when multiple versions of the provider are deployed to an environment and last is incompatible" do
+    before do
+      td.create_environment("production")
+        .create_pact_with_hierarchy("Waffle", "1", "Pancake")
+        .create_verification(provider_version: "10", number: 1, success: true)
+        .create_deployed_version_for_provider_version(environment_name: "production")
+        .create_verification(provider_version: "11", number: 2, success: false)
+        .create_deployed_version_for_provider_version(environment_name: "production")
+    end
+
+    let(:query) { { pacticipant: "Waffle", version: "1", environment: "production" } }
+
+    it "only considers the currently deployed version (the redeployment replaced the previous one) and is not deployable" do
+      expect(subject).to be_a_hal_json_success_response
+      expect(response_body[:matrix].size).to eq 1
+      expect(response_body[:summary][:deployable]).to be false
+    end
+  end
+
+  context "when multiple versions of the provider are deployed to an environment and last is compatible" do
+    before do
+      td.create_environment("production")
+        .create_pact_with_hierarchy("Waffle", "1", "Pancake")
+        .create_verification(provider_version: "10", number: 1, success: false)
+        .create_deployed_version_for_provider_version(environment_name: "production")
+        .create_verification(provider_version: "11", number: 2, success: true)
+        .create_deployed_version_for_provider_version(environment_name: "production")
+    end
+
+    let(:query) { { pacticipant: "Waffle", version: "1", environment: "production" } }
+
+    it "only considers the currently deployed version (the redeployment replaced the previous one) and is deployable" do
+      expect(subject).to be_a_hal_json_success_response
+      expect(response_body[:matrix].size).to eq 1
+      expect(response_body[:summary][:deployable]).to be true
+    end
+  end
 end

--- a/spec/fixtures/approvals/matrix_integration_environment_spec.approved.json
+++ b/spec/fixtures/approvals/matrix_integration_environment_spec.approved.json
@@ -58,5 +58,35 @@
     "reasons": [
       "PactBroker::Matrix::Successful"
     ]
+  },
+  "PactBroker::Matrix::Service find with environments when deploying a consumer with multiple versions of a provider released to production (latestby cvpv) when an older released provider version has a failing verification does not allow the consumer to be deployed": {
+    "deployable": false,
+    "reasons": [
+      "PactBroker::Matrix::VerificationFailed"
+    ]
+  },
+  "PactBroker::Matrix::Service find with environments when deploying a consumer with multiple versions of a provider released to production (latestby cvpv) when every released provider version has a successful verification allows the consumer to be deployed": {
+    "deployable": true,
+    "reasons": [
+      "PactBroker::Matrix::Successful"
+    ]
+  },
+  "PactBroker::Matrix::Service find with environments when deploying a consumer with multiple versions of a provider deployed to production on different targets (latestby cvpv) when an older targeted deployment has a failing verification does not allow the consumer to be deployed": {
+    "deployable": false,
+    "reasons": [
+      "PactBroker::Matrix::VerificationFailed"
+    ]
+  },
+  "PactBroker::Matrix::Service find with environments when deploying a consumer with multiple versions of a provider deployed to production on different targets (latestby cvpv) when every targeted deployment has a successful verification allows the consumer to be deployed": {
+    "deployable": true,
+    "reasons": [
+      "PactBroker::Matrix::Successful"
+    ]
+  },
+  "PactBroker::Matrix::Service find with environments when a version is deployed without a target and then replaced by a redeployment (latestby cvpv) only considers the currently deployed version and allows the consumer to be deployed": {
+    "deployable": true,
+    "reasons": [
+      "PactBroker::Matrix::Successful"
+    ]
   }
 }

--- a/spec/lib/pact_broker/api/resources/can_i_deploy_pacticipant_version_by_branch_to_environment_badge_spec.rb
+++ b/spec/lib/pact_broker/api/resources/can_i_deploy_pacticipant_version_by_branch_to_environment_badge_spec.rb
@@ -1,4 +1,5 @@
 require "pact_broker/api/resources/can_i_deploy_pacticipant_version_by_branch_to_environment_badge"
+require "pact_broker/matrix/service"
 
 module PactBroker
   module Api
@@ -35,6 +36,20 @@ module PactBroker
           it "return the badge URL" do
             expect(badge_service). to receive(:can_i_deploy_badge_url).with("main", "dev", "custom-label", true)
             expect(subject.headers["Location"]).to eq "http://badge_url"
+          end
+        end
+
+        context "the matrix query (inherited from the non-badge resource)" do
+          before do
+            # Use the real #results/#options instead of the stub so we can observe the latestby that
+            # is passed through to the matrix service. Guards that the badge path is also fixed (#903).
+            allow_any_instance_of(described_class).to receive(:results).and_call_original
+            allow(PactBroker::Matrix::Service).to receive(:can_i_deploy).and_return(results)
+          end
+
+          it "uses the cvpv latestby so all versions released/deployed to the environment are evaluated" do
+            expect(PactBroker::Matrix::Service).to receive(:can_i_deploy).with(anything, hash_including(latestby: "cvpv"))
+            subject
           end
         end
 

--- a/spec/lib/pact_broker/api/resources/can_i_deploy_pacticipant_version_by_branch_to_environment_spec.rb
+++ b/spec/lib/pact_broker/api/resources/can_i_deploy_pacticipant_version_by_branch_to_environment_spec.rb
@@ -1,4 +1,4 @@
-require "pact_broker/api/resources/can_i_deploy_pacticipant_version_by_tag_to_tag"
+require "pact_broker/api/resources/can_i_deploy_pacticipant_version_by_branch_to_environment"
 require "pact_broker/matrix/service"
 
 module PactBroker
@@ -33,6 +33,11 @@ module PactBroker
 
         it "checks if the version can be deployed to the environment" do
           expect(PactBroker::Matrix::Service).to receive(:can_i_deploy).with(anything, hash_including(environment_name: "dev"))
+          subject
+        end
+
+        it "uses the cvpv latestby so all versions released/deployed to the environment are evaluated" do
+          expect(PactBroker::Matrix::Service).to receive(:can_i_deploy).with(anything, hash_including(latestby: "cvpv"))
           subject
         end
 

--- a/spec/lib/pact_broker/matrix/integration_environment_spec.rb
+++ b/spec/lib/pact_broker/matrix/integration_environment_spec.rb
@@ -38,7 +38,7 @@ module PactBroker
             ]
           end
 
-          let(:options) { { latestby: "cvp", environment_name: "test" } }
+          let(:options) { { latestby: "cvpv", environment_name: "test" } }
 
           it "allows the consumer to be deployed" do
             expect(subject.deployment_status_summary).to be_deployable
@@ -59,7 +59,7 @@ module PactBroker
             ]
           end
 
-          let(:options) { { latestby: "cvp", environment_name: "test" } }
+          let(:options) { { latestby: "cvpv", environment_name: "test" } }
 
           it "does not allow the consumer to be deployed" do
             expect(subject.deployment_status_summary).to_not be_deployable
@@ -78,7 +78,7 @@ module PactBroker
             ]
           end
 
-          let(:options) { { latestby: "cvp", environment_name: "test" } }
+          let(:options) { { latestby: "cvpv", environment_name: "test" } }
 
           it "does not allow the consumer to be deployed" do
             expect(subject.deployment_status_summary).to_not be_deployable
@@ -97,7 +97,7 @@ module PactBroker
             ]
           end
 
-          let(:options) { { latestby: "cvp", environment_name: "test" } }
+          let(:options) { { latestby: "cvpv", environment_name: "test" } }
 
           it "allows the provider to be deployed" do
             expect(subject.deployment_status_summary).to be_deployable
@@ -176,6 +176,104 @@ module PactBroker
             it "does allow the consumer to be deployed" do
               expect(subject.deployment_status_summary).to be_deployable
             end
+          end
+        end
+
+        # --- RELEASES: multiple released provider versions co-resident in an environment (issue #903) ---
+        # Exercises the production "cvpv" path, which the pre-existing multi-version blocks above do not
+        # (they omit latestby, so apply_latestby never collapses and the bug was never reproduced).
+        describe "when deploying a consumer with multiple versions of a provider released to production (latestby cvpv)" do
+          let(:selectors) { [ UnresolvedSelector.new(pacticipant_name: "Foo", pacticipant_version_number: "1") ] }
+          let(:options) { { latestby: "cvpv", environment_name: "prod" } }
+
+          context "when an older released provider version has a failing verification" do
+            before do
+              td.create_environment("prod")
+                .create_pact_with_hierarchy("Foo", "1", "Bar")
+                .create_verification(provider_version: "10", number: 1, success: false)
+                .create_released_version_for_provider_version(environment_name: "prod")
+                .create_verification(provider_version: "11", number: 2, success: true)
+                .create_released_version_for_provider_version(environment_name: "prod")
+            end
+
+            it "does not allow the consumer to be deployed" do
+              expect(subject.deployment_status_summary).to_not be_deployable
+            end
+          end
+
+          context "when every released provider version has a successful verification" do
+            before do
+              td.create_environment("prod")
+                .create_pact_with_hierarchy("Foo", "1", "Bar")
+                .create_verification(provider_version: "10", number: 1, success: true)
+                .create_released_version_for_provider_version(environment_name: "prod")
+                .create_verification(provider_version: "11", number: 2, success: true)
+                .create_released_version_for_provider_version(environment_name: "prod")
+            end
+
+            it "allows the consumer to be deployed" do
+              expect(subject.deployment_status_summary).to be_deployable
+            end
+          end
+        end
+
+        # --- DEPLOYMENTS WITH TARGETS: multiple deployed provider versions on different targets (issue #903) ---
+        describe "when deploying a consumer with multiple versions of a provider deployed to production on different targets (latestby cvpv)" do
+          let(:selectors) { [ UnresolvedSelector.new(pacticipant_name: "Foo", pacticipant_version_number: "1") ] }
+          let(:options) { { latestby: "cvpv", environment_name: "prod" } }
+
+          context "when an older targeted deployment has a failing verification" do
+            before do
+              td.create_environment("prod")
+                .create_pact_with_hierarchy("Foo", "1", "Bar")
+                .create_verification(provider_version: "10", number: 1, success: false)
+                .create_deployed_version_for_provider_version(environment_name: "prod", target: "instance-1")
+                .create_verification(provider_version: "11", number: 2, success: true)
+                .create_deployed_version_for_provider_version(environment_name: "prod", target: "instance-2")
+            end
+
+            it "does not allow the consumer to be deployed" do
+              expect(subject.deployment_status_summary).to_not be_deployable
+            end
+          end
+
+          context "when every targeted deployment has a successful verification" do
+            before do
+              td.create_environment("prod")
+                .create_pact_with_hierarchy("Foo", "1", "Bar")
+                .create_verification(provider_version: "10", number: 1, success: true)
+                .create_deployed_version_for_provider_version(environment_name: "prod", target: "instance-1")
+                .create_verification(provider_version: "11", number: 2, success: true)
+                .create_deployed_version_for_provider_version(environment_name: "prod", target: "instance-2")
+            end
+
+            it "allows the consumer to be deployed" do
+              expect(subject.deployment_status_summary).to be_deployable
+            end
+          end
+        end
+
+        # --- DEPLOYMENT WITHOUT TARGET: a redeployment replaces the previous version, so only one is ever live ---
+        # Guards that the cvpv change does not alter the standard single-instance record-deployment workflow:
+        # deploying Bar 11 (no target) replaces the earlier Bar 10 (no target), so only Bar 11 is currently
+        # deployed and considered. Bar 10's failing verification is irrelevant because it is no longer live.
+        # If redeployment ever stopped replacing the previous version, cvpv would surface Bar 10's failure and
+        # this test would fail.
+        describe "when a version is deployed without a target and then replaced by a redeployment (latestby cvpv)" do
+          before do
+            td.create_environment("prod")
+              .create_pact_with_hierarchy("Foo", "1", "Bar")
+              .create_verification(provider_version: "10", number: 1, success: false)
+              .create_deployed_version_for_provider_version(environment_name: "prod")
+              .create_verification(provider_version: "11", number: 2, success: true)
+              .create_deployed_version_for_provider_version(environment_name: "prod")
+          end
+
+          let(:selectors) { [ UnresolvedSelector.new(pacticipant_name: "Foo", pacticipant_version_number: "1") ] }
+          let(:options) { { latestby: "cvpv", environment_name: "prod" } }
+
+          it "only considers the currently deployed version and allows the consumer to be deployed" do
+            expect(subject.deployment_status_summary).to be_deployable
           end
         end
       end

--- a/spec/lib/pact_broker/matrix/parse_can_i_deploy_query_spec.rb
+++ b/spec/lib/pact_broker/matrix/parse_can_i_deploy_query_spec.rb
@@ -20,7 +20,7 @@ module PactBroker
         describe "parsed_options" do
           subject { parsed_options }
 
-          its([:latestby]) { is_expected.to eq "cvp" }
+          its([:latestby]) { is_expected.to eq "cvpv" }
           its([:latest]) { is_expected.to eq nil }
           its([:environment_name]) { is_expected.to eq "prod" }
           its([:ignore_selectors]) { is_expected.to eq [] }
@@ -63,6 +63,21 @@ module PactBroker
             its([:latestby]) { is_expected.to eq "cvp" }
             its([:latest]) { is_expected.to eq true }
             its([:tag]) { is_expected.to eq "prod" }
+          end
+
+          context "with neither a tag nor an environment" do
+            # Pins that the cvpv override is scoped to environment queries only - the
+            # default grouping is unchanged. See issue #903.
+            let(:params) do
+              {
+                pacticipant: "foo",
+                version: "1"
+              }
+            end
+
+            its([:latestby]) { is_expected.to eq "cvp" }
+            its([:environment_name]) { is_expected.to eq nil }
+            its([:tag]) { is_expected.to eq nil }
           end
         end
 


### PR DESCRIPTION
[PACT-6874](https://smartbear.atlassian.net/browse/PACT-6874)
## Summary

- **Bug**: `can-i-deploy --to-environment` produced false `deployable: true` results when multiple versions of a provider were simultaneously live in an environment (via `record-release`, or `record-deployment` to different targets). The `cvp` latestby collapsed all co-resident versions down to the latest provider version, silently discarding failing rows.
- **Fix**: Switch to `cvpv` for all `can-i-deploy` paths that target an environment (`ParseCanIDeployQuery` and `CanIDeployPacticipantVersionByBranchToEnvironment`). `cvpv` groups by `(consumer, consumer_version, provider, provider_version)` so every live version keeps its own row and a failing verification cannot be hidden. The `cvp` default is preserved for tag-based and non-environment queries where collapsing to the latest is correct.
- **Badge path** also fixed: `CanIDeployPacticipantVersionByBranchToEnvironmentBadge` inherits `options` from the parent resource, so it picks up the fix automatically.

Fixes #903.

## Test plan

- [ ] `spec/lib/pact_broker/matrix/parse_can_i_deploy_query_spec.rb` — asserts `latestby: "cvpv"` for environment queries, `latestby: "cvp"` for tag and no-target queries
- [ ] `spec/lib/pact_broker/api/resources/can_i_deploy_pacticipant_version_by_branch_to_environment_spec.rb` — asserts `latestby: "cvpv"` is passed to the matrix service
- [ ] `spec/lib/pact_broker/api/resources/can_i_deploy_pacticipant_version_by_branch_to_environment_badge_spec.rb` — same assertion through the badge subclass
- [ ] `spec/lib/pact_broker/matrix/integration_environment_spec.rb` — new `describe` blocks exercise the exact false-positive scenario: released versions with one failing, all passing, multi-target deployments, and redeployment-replaces-previous (regression guard)
- [ ] `spec/features/can_i_deploy_spec.rb` — end-to-end feature specs covering released/deployed multi-version scenarios via the HTTP API

All 55 examples pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)