### PR TITLE
chore: delete stale branches first

### DIFF
--- a/lib/pact_broker/db/clean_incremental.rb
+++ b/lib/pact_broker/db/clean_incremental.rb
@@ -46,9 +46,9 @@ module PactBroker
       def execute_clean
         db.transaction do
           before_counts = current_counts
+          delete_stale_branches
           PactBroker::Domain::Version.where(id: versions_to_delete.from_self.select_map(:id)).delete
           delete_orphan_pact_versions
-          delete_stale_branches
           after_counts = current_counts
 
           TABLES.each_with_object({}) do | table_name, comparison_counts |

--- a/spec/lib/pact_broker/db/clean_incremental_spec.rb
+++ b/spec/lib/pact_broker/db/clean_incremental_spec.rb
@@ -272,6 +272,42 @@ module PactBroker
             end
           end
         end
+
+        context "when a version is only retained because it is the head of a stale branch" do
+          before do
+            Timecop.freeze(Date.today - 100) do
+              td.publish_pact(consumer_name: "Widget", provider_name: "Gadget", consumer_version_number: "1", branch: "feat/old")
+            end
+            Timecop.freeze(Date.today - 5) do
+              td.publish_pact(consumer_name: "Widget", provider_name: "Gadget", consumer_version_number: "2", branch: "main")
+            end
+          end
+
+          let(:options) do
+            {
+              keep: [
+                PactBroker::DB::Clean::Selector.new(branch: true, latest: true),
+                PactBroker::DB::Clean::Selector.new(latest: true),
+                PactBroker::DB::Clean::Selector.new(max_age: 30)
+              ],
+              keep_branches: [PactBroker::DB::Clean::BranchSelector.new(max_age: 90)]
+            }
+          end
+
+          it "deletes the stale branch first and the now-unprotected version in the same run" do
+            expect(PactBroker::Versions::Branch.where(name: "feat/old").count).to be 1
+            expect(PactBroker::Domain::Version.where(number: "1").count).to be 1
+
+            subject
+
+            expect(PactBroker::Versions::Branch.where(name: "feat/old").count).to be 0
+            expect(PactBroker::Domain::Version.where(number: "1").count).to be 0
+          end
+
+          it "keeps the version on the fresh branch (latest / within max_age)" do
+            expect { subject }.to_not change { PactBroker::Domain::Version.where(number: "2").count }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR updates execute_clean to run delete_stale_branches before the version deletion step.

This addresses cases where a stale branch contains only a single version. With the previous implementation, that version is still considered the branch head when the version deletion query runs, causing it to be retained by the keep selectors. The stale branch is then deleted afterwards, leaving the version behind until a subsequent cleanup run.

By deleting stale branches first, those versions are no longer treated as branch heads and can be cleaned up in the same execution, along with any downstream orphaned records.