### PR TITLE
feat(clean): expose branch_deletion_limit on CleanTask

### DIFF
--- a/lib/pact_broker/tasks/clean_task.rb
+++ b/lib/pact_broker/tasks/clean_task.rb
@@ -12,6 +12,7 @@ module PactBroker
       attr_reader :keep_version_selectors
       attr_reader :keep_branch_selectors
       attr_accessor :version_deletion_limit
+      attr_accessor :branch_deletion_limit
       attr_accessor :logger
       attr_accessor :dry_run
       attr_accessor :use_lock # allow disabling of postgres lock if it is causing problems
@@ -77,6 +78,7 @@ module PactBroker
           keep: keep_version_selectors,
           keep_branches: keep_branch_selectors,
           limit: version_deletion_limit,
+          branch_limit: branch_deletion_limit,
           logger: logger,
           dry_run: dry_run
         )


### PR DESCRIPTION
## Summary

Follow-on to #933, which added `branch_limit` support to `CleanIncremental` but didn't expose it via `CleanTask`.

- Adds `attr_accessor :branch_deletion_limit` to `CleanTask`
- Passes `branch_limit: branch_deletion_limit` to `CleanIncremental.call` in `perform_clean`

When `branch_deletion_limit` is not set it passes `nil`, which causes `CleanIncremental` to fall back to `limit` (i.e. `version_deletion_limit`) — no behaviour change for existing users.

This is needed so the [pact-broker Docker image](https://github.com/pact-foundation/pact-broker-docker) can expose a `PACT_BROKER_DATABASE_CLEAN_BRANCH_DELETION_LIMIT` environment variable, giving operators independent control over the per-run branch deletion batch size.

## Test plan

- [ ] Existing `CleanIncremental` specs continue to pass (no change to core logic)
- [ ] Manually verify `CleanTask` with `branch_deletion_limit` set forwards the value correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)