### PR TITLE
test: add coverage for Contracts::Service#url_for_triggered_webhook

### DIFF
--- a/spec/lib/pact_broker/contracts/service_spec.rb
+++ b/spec/lib/pact_broker/contracts/service_spec.rb
@@ -213,6 +213,16 @@ module PactBroker
           end
         end
       end
+
+      describe "#url_for_triggered_webhook" do
+        let(:triggered_webhook) { instance_double("PactBroker::Webhooks::TriggeredWebhook", uuid: "the-triggered-webhook-uuid") }
+
+        subject { Service.send(:url_for_triggered_webhook, triggered_webhook, "http://example.org") }
+
+        it "returns the URL for the triggered webhook logs" do
+          expect(subject).to eq "http://example.org/triggered-webhooks/the-triggered-webhook-uuid/logs"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
* `PactBroker::Contracts::Service#url_for_triggered_webhook` (the link printed by `pact broker publish` when a webhook is triggered) had no direct test coverage.
* Added a spec locking in its current behaviour — building a link to the triggered-webhooks logs API resource (`/triggered-webhooks/:uuid/logs`).
* This is a regression guard: a downstream consumer (Pactflow) overrides this method for its own UI routing while relying on the OSS behaviour staying stable here.

## Test plan
- [x] `bundle exec rspec spec/lib/pact_broker/contracts/service_spec.rb` — 18 examples, 0 failures
- [x] `bundle exec rubocop spec/lib/pact_broker/contracts/service_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)