### PR TITLE
chore(deps): require json >= 2.19.9

### DIFF
--- a/pact_broker.gemspec
+++ b/pact_broker.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = "MIT"
 
-  gem.add_runtime_dependency "json", "~> 2.3"
+  gem.add_runtime_dependency "json", ">= 2.19.9"
   gem.add_runtime_dependency "psych", "~> 5.0"
   gem.add_runtime_dependency "roar", "~> 1.1"
   gem.add_runtime_dependency "dry-validation", "~> 1.8"


### PR DESCRIPTION
## Summary
* `pact_broker.gemspec` constrained `json` to `~> 2.3`, which allowed the resolver to pick `json` 2.12.x and was causing CI build failures.
* Widened the constraint to `>= 2.19.9`. `bundle update json` now resolves to `json` 2.20.0.

## Test plan
- [x] `bundle update json` resolves to `json 2.20.0` (was 2.12.2)
- [x] Full test suite: 4433 examples — same 11 pre-existing failures as on unmodified `master` (confirmed by re-running with this change stashed), unrelated to this bump
- [x] `bundle exec rubocop pact_broker.gemspec` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)