### PR TITLE
chore(deps): bump json gem and update bundler-audit ignore list

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,5 +1,4 @@
 ---
 ignore:
-  # Ignore Sinatra CVE
-  # See comment in https://github.com/pact-foundation/pact_broker/pull/746
-  - CVE-2024-21510
+  # Ignore WEBrick CVE
+  - CVE-2026-38969

--- a/pact_broker.gemspec
+++ b/pact_broker.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = "MIT"
 
-  gem.add_runtime_dependency "json", "~> 2.3"
+  gem.add_runtime_dependency "json", ">= 2.19.9"
   gem.add_runtime_dependency "psych", "~> 5.0"
   gem.add_runtime_dependency "roar", "~> 1.1"
   gem.add_runtime_dependency "dry-validation", "~> 1.8"


### PR DESCRIPTION
## Summary
* Bumped `json` gem requirement in `pact_broker.gemspec` from `~> 2.3` to `>= 2.19.9` — the old constraint let the resolver pick `json` 2.12.x, which was causing CI build failures. `bundle update json` now resolves to `json` 2.20.0.
* Updated `.bundler-audit.yml`:
  * Removed `CVE-2024-21510` (Sinatra) — already fixed, `sinatra` is now on `4.2.1`, well past the vulnerable range.
  * Added `CVE-2026-38969` (WEBrick, currently at `1.9.2`) — no fixed version is available yet.

Supersedes #946 and #947 (this branch was rebased to combine both changes; those PRs' branches no longer exist).

## Test plan
- [x] `bundle update json` resolves to `json 2.20.0` (was 2.12.2)
- [x] Full test suite: 4433 examples — same 11 pre-existing failures as on unmodified `master`, unrelated to this change
- [x] `bundle exec rubocop pact_broker.gemspec` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)