### PR TITLE
chore: fix the excessive mismatch type warning log noise in schema migrations.

### DIFF
--- a/db/migrations/000015_create_pact_version_content.rb
+++ b/db/migrations/000015_create_pact_version_content.rb
@@ -5,7 +5,7 @@ Sequel.migration do
   change do
     create_table(:pact_version_contents, charset: "utf8") do
       String :sha, primary_key: true, null: false, primary_key_constraint_name: "pk_pact_version_contents"
-      String :content, type: PactBroker::MigrationHelper.large_text_type
+      column :content, PactBroker::MigrationHelper.large_text_type
       DateTime :created_at, null: false
       DateTime :updated_at, null: false
     end

--- a/db/migrations/000023_create_pact_versions_table.rb
+++ b/db/migrations/000023_create_pact_versions_table.rb
@@ -7,7 +7,7 @@ Sequel.migration do
       foreign_key :consumer_id, :pacticipants
       foreign_key :provider_id, :pacticipants
       String :sha, null: false
-      String :content, type: PactBroker::MigrationHelper.large_text_type
+      column :content, PactBroker::MigrationHelper.large_text_type
       index [:consumer_id, :provider_id, :sha], unique: true, name: "unq_pvc_con_prov_sha"
       DateTime :created_at, null: false
     end

--- a/db/migrations/000033_create_config_table.rb
+++ b/db/migrations/000033_create_config_table.rb
@@ -6,7 +6,7 @@ Sequel.migration do
       primary_key :id
       String :name, null: false
       String :type, null: false
-      String :value, type: PactBroker::MigrationHelper.large_text_type
+      column :value, PactBroker::MigrationHelper.large_text_type
       DateTime :created_at, null: false
       DateTime :updated_at, null: false
       index [:name], unique: true, name: "unq_config_name"

--- a/db/migrations/000036_create_webhook_execution.rb
+++ b/db/migrations/000036_create_webhook_execution.rb
@@ -9,7 +9,7 @@ Sequel.migration do
       foreign_key :consumer_id, :pacticipants, null: false
       foreign_key :provider_id, :pacticipants, null: false
       Boolean :success, null: false
-      String :logs, type: PactBroker::MigrationHelper.large_text_type
+      column :logs, PactBroker::MigrationHelper.large_text_type
       DateTime :created_at, null: false
     end
   end

--- a/db/migrations/20180108_create_certificates_table.rb
+++ b/db/migrations/20180108_create_certificates_table.rb
@@ -6,7 +6,7 @@ Sequel.migration do
       primary_key :id
       String :uuid, null: false, unique: true, unique_constraint_name: "uq_certificate_uuid"
       String :description, null: true
-      String :content, null: false, type: PactBroker::MigrationHelper.large_text_type
+      column :content, PactBroker::MigrationHelper.large_text_type, null: false
       DateTime :created_at, null: false
       DateTime :updated_at, null: false
     end

--- a/db/migrations/migration_helper.rb
+++ b/db/migrations/migration_helper.rb
@@ -10,7 +10,7 @@ module PactBroker
     end
 
     def large_text_type
-      if postgres?
+      if postgres? || sqlite?
         :text
       else
         # Assume mysql
@@ -30,6 +30,10 @@ module PactBroker
 
     def postgres?
       adapter =~ /postgres/
+    end
+
+    def sqlite?
+      adapter =~ /sqlite/
     end
 
     def adapter

--- a/docker-compose-ci-mysql.yml
+++ b/docker-compose-ci-mysql.yml
@@ -1,9 +1,8 @@
-version: "3"
-
 services:
   mysql:
     image: mysql:5.7.44@sha256:4bc6bc963e6d8443453676cae56536f4b8156d78bae03c0145cbe47c2aad73bb
     command: --default-authentication-plugin=mysql_native_password
+    platform: linux/amd64
     environment:
       MYSQL_ROOT_PASSWORD: pact_broker
       MYSQL_DATABASE: pact_broker

--- a/docker-compose-ci-postgres.yml
+++ b/docker-compose-ci-postgres.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   postgres:
     image: postgres:${POSTGRES_DOCKER_IMAGE_TAG:-latest}


### PR DESCRIPTION
chore: Sequel migration now raise warnings when a column is  set with 2 mismatched column types. The creates a lot of log noise. 
