### PR TITLE
feat: semantic logger upgrade + otel integration

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -34,6 +34,25 @@ The application log format. Can be any value supported by Semantic Logger.
 **Allowed values:** `default`, `json`, `color`<br/>
 **More information:** https://github.com/rocketjob/semantic_logger/tree/master/lib/semantic_logger/formatters<br/>
 
+### log_otel_enabled
+
+Controls whether logs are also emitted to the OpenTelemetry logs pipeline.
+
+`auto` (the default) adds the OpenTelemetry appender only when the
+`opentelemetry-logs-sdk` gem is installed and an OpenTelemetry logger provider
+is configured. `true` forces the appender on and raises an error if the gem is
+not available. `false` disables it entirely.
+
+The `opentelemetry-logs-sdk` gem is an optional, runtime-detected dependency and
+is not bundled with the Pact Broker. When `log_format` is set to `json`, active
+trace and span IDs are also embedded in the JSON log output.
+
+**Supported versions:** From v2.120.0<br/>
+**Environment variable name:** `PACT_BROKER_LOG_OTEL_ENABLED`<br/>
+**YAML configuration key name:** `log_otel_enabled`<br/>
+**Default:** `auto`<br/>
+**Allowed values:** `auto`, `true`, `false`<br/>
+
 ### log_dir
 
 The log file directory
@@ -248,8 +267,8 @@ The number of seconds after which an SQL query will be aborted. Only supported f
 
 **Environment variable name:** `PACT_BROKER_DATABASE_STATEMENT_TIMEOUT`<br/>
 **YAML configuration key name:** `database_statement_timeout`<br/>
-**Default:** `15000`<br/>
-**Allowed values:** A positive integer in milliseconds<br/>
+**Default:** `15`<br/>
+**Allowed values:** A positive integer or float.<br/>
 **More information:** https://www.postgresql.org/docs/9.3/runtime-config-client.html<br/>
 
 ### metrics_sql_statement_timeout
@@ -532,6 +551,14 @@ The URL of the shields.io server used to generate the README badges.
 **YAML configuration key name:** `shields_io_base_url`<br/>
 **Default:** `https://img.shields.io`<br/>
 **More information:** https://shields.io<br/>
+
+### badge_default_cache_setting
+
+Cache Control header value for the badge, this  sets the cache-control header for the badge image, for more information on header formats see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/cache-control
+
+**Environment variable name:** `PACT_BROKER_BADGE_DEFAULT_CACHE_SETTING`<br/>
+**YAML configuration key name:** `badge_default_cache_setting`<br/>
+**Default:** `max-age=30`<br/>
 
 ### badge_provider_mode
 

--- a/docs/configuration.yml
+++ b/docs/configuration.yml
@@ -18,6 +18,24 @@ groups:
           - json
           - color
         more_info: https://github.com/rocketjob/semantic_logger/tree/master/lib/semantic_logger/formatters
+      log_otel_enabled:
+        description: |-
+          Controls whether logs are also emitted to the OpenTelemetry logs pipeline.
+
+          `auto` (the default) adds the OpenTelemetry appender only when the
+          `opentelemetry-logs-sdk` gem is installed and an OpenTelemetry logger provider
+          is configured. `true` forces the appender on and raises an error if the gem is
+          not available. `false` disables it entirely.
+
+          The `opentelemetry-logs-sdk` gem is an optional, runtime-detected dependency and
+          is not bundled with the Pact Broker. When `log_format` is set to `json`, active
+          trace and span IDs are also embedded in the JSON log output.
+        default_value: auto
+        allowed_values:
+          - auto
+          - true
+          - false
+        supported_versions: From v2.120.0
       log_dir:
         description: "The log file directory"
         default_value: "./logs"

--- a/lib/pact_broker/config/runtime_configuration.rb
+++ b/lib/pact_broker/config/runtime_configuration.rb
@@ -40,6 +40,7 @@ module PactBroker
         log_stream: :file,
         log_level: :info,
         log_format: nil,
+        log_otel_enabled: :auto,
         warning_error_class_names: ["Sequel::ForeignKeyConstraintViolation"],
         hide_pactflow_messages: false,
         log_configuration_on_startup: true,
@@ -129,6 +130,10 @@ module PactBroker
         super(log_format&.to_sym)
       end
 
+      def log_otel_enabled= value
+        super(coerce_log_otel_enabled(value))
+      end
+
       def custom_log_formatters= custom_log_formatters
         super(custom_log_formatters&.symbolize_keys)
       end
@@ -215,11 +220,25 @@ module PactBroker
         if log_stream == :file && log_dir.blank?
           raise_validation_error("Must specify log_dir if log_stream is set to file")
         end
+
+        unless [:auto, true, false].include?(log_otel_enabled)
+          raise_validation_error("log_otel_enabled must be one of: auto, true, false")
+        end
       end
 
       def raise_validation_error(msg)
         raise PactBroker::ConfigurationError, msg
       end
+
+      def coerce_log_otel_enabled(value)
+        case value
+        when nil, "", "auto", :auto then :auto
+        when true, "true", "1", 1 then true
+        when false, "false", "0", 0 then false
+        else value
+        end
+      end
+      private :coerce_log_otel_enabled
 
       def set_webhook_attribute_defaults
         # can't set a default on this, or anyway config blows up when trying to merge the

--- a/lib/pact_broker/configuration.rb
+++ b/lib/pact_broker/configuration.rb
@@ -3,6 +3,8 @@ require "pact_broker/error"
 require "semantic_logger"
 require "forwardable"
 require "pact_broker/config/runtime_configuration"
+require "pact_broker/logging/open_telemetry_appender_setup"
+require "pact_broker/logging/trace_aware_json_formatter"
 require "anyway/auto_cast"
 require "request_store"
 
@@ -98,16 +100,27 @@ module PactBroker
     def logger_from_runtime_configuration
       @logger_from_runtime_configuration ||= begin
         SemanticLogger.default_level = runtime_configuration.log_level
+        formatter = resolve_log_formatter(runtime_configuration.log_format)
         if runtime_configuration.log_stream == :file
           path = runtime_configuration.log_dir + "/pact_broker.log"
           FileUtils.mkdir_p(runtime_configuration.log_dir)
-          @default_appender = SemanticLogger.add_appender(file_name: path, formatter: runtime_configuration.log_format)
+          @default_appender = SemanticLogger.add_appender(file_name: path, formatter: formatter)
         else
-          @default_appender = SemanticLogger.add_appender(io: $stdout, formatter: runtime_configuration.log_format)
+          @default_appender = SemanticLogger.add_appender(io: $stdout, formatter: formatter)
         end
+        PactBroker::Logging::OpenTelemetryAppenderSetup.call(runtime_configuration)
         @logger_from_runtime_configuration = SemanticLogger["pact-broker"]
       end
     end
+
+    def resolve_log_formatter(log_format)
+      if log_format == :json
+        PactBroker::Logging::TraceAwareJsonFormatter.new
+      else
+        log_format
+      end
+    end
+    private :resolve_log_formatter
 
     def logger
       custom_logger || logger_from_runtime_configuration

--- a/lib/pact_broker/logging/open_telemetry_appender_setup.rb
+++ b/lib/pact_broker/logging/open_telemetry_appender_setup.rb
@@ -1,0 +1,73 @@
+require "semantic_logger"
+require "pact_broker/error"
+
+module PactBroker
+  module Logging
+    # Adds semantic_logger's :open_telemetry appender when configured, without
+    # taking a hard dependency on the OpenTelemetry gems.
+    class OpenTelemetryAppenderSetup
+      def self.call(runtime_configuration)
+        new(runtime_configuration).call
+      end
+
+      def initialize(runtime_configuration)
+        @runtime_configuration = runtime_configuration
+      end
+
+      # Returns the added (or already-present) appender, or nil if none was added.
+      def call
+        case @runtime_configuration.log_otel_enabled
+        when false
+          nil
+        when true
+          unless otel_available?
+            raise PactBroker::ConfigurationError,
+              "log_otel_enabled is set to true but the opentelemetry-logs-sdk gem could not be loaded. " \
+              "Add it to your Gemfile, or set log_otel_enabled to auto/false."
+          end
+          add_appender(warn_if_no_provider: true)
+        else # :auto
+          add_appender(warn_if_no_provider: false) if otel_available? && otel_provider_configured?
+        end
+      end
+
+      private
+
+      def add_appender(warn_if_no_provider:)
+        existing = existing_otel_appender
+        return existing if existing
+
+        if warn_if_no_provider && !otel_provider_configured?
+          SemanticLogger["pact-broker"].warn(
+            "log_otel_enabled is true but no OpenTelemetry LoggerProvider is configured; " \
+            "OTel log records may be dropped."
+          )
+        end
+
+        SemanticLogger.add_appender(appender: :open_telemetry)
+      end
+
+      def existing_otel_appender
+        return nil unless defined?(SemanticLogger::Appender::OpenTelemetry)
+
+        SemanticLogger.appenders.find { |appender| appender.is_a?(SemanticLogger::Appender::OpenTelemetry) }
+      end
+
+      def otel_available?
+        require "opentelemetry-logs-sdk"
+        defined?(OpenTelemetry::Logs) ? true : false
+      rescue LoadError
+        false
+      end
+
+      def otel_provider_configured?
+        return false unless defined?(OpenTelemetry)
+
+        # A no-op / proxy provider means no real logs pipeline is configured.
+        OpenTelemetry.logger_provider.class.name.to_s.start_with?("OpenTelemetry::SDK::Logs")
+      rescue StandardError
+        false
+      end
+    end
+  end
+end

--- a/lib/pact_broker/logging/trace_aware_json_formatter.rb
+++ b/lib/pact_broker/logging/trace_aware_json_formatter.rb
@@ -1,0 +1,38 @@
+require "semantic_logger"
+require "semantic_logger/formatters/json"
+
+module PactBroker
+  module Logging
+    # A JSON log formatter that adds the standard OpenTelemetry log-correlation
+    # fields (trace_id, span_id, trace_flags) when a valid span is active.
+    # Degrades to plain JSON when OTel is not loaded or there is no active span,
+    # so it is safe for the open-source Pact Broker.
+    class TraceAwareJsonFormatter < SemanticLogger::Formatters::Json
+      def call(log, logger)
+        json = super
+        context = otel_trace_context
+        return json if context.empty?
+
+        # `hash` was populated by Raw#call during `super`; reuse it.
+        hash.merge(context).to_json
+      end
+
+      private
+
+      def otel_trace_context
+        return {} unless defined?(OpenTelemetry::Trace)
+
+        span_context = OpenTelemetry::Trace.current_span.context
+        return {} unless span_context.valid?
+
+        {
+          trace_id: span_context.hex_trace_id,
+          span_id: span_context.hex_span_id,
+          trace_flags: span_context.trace_flags.sampled? ? "01" : "00"
+        }
+      rescue StandardError
+        {}
+      end
+    end
+  end
+end

--- a/lib/pact_broker/logging/trace_aware_json_formatter.rb
+++ b/lib/pact_broker/logging/trace_aware_json_formatter.rb
@@ -14,7 +14,7 @@ module PactBroker
         return json if context.empty?
 
         # `hash` was populated by Raw#call during `super`; reuse it.
-        hash.merge(context).to_json
+        SemanticLogger::Utils.to_json(hash.merge(context))
       end
 
       private

--- a/pact_broker.gemspec
+++ b/pact_broker.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "sucker_punch", "~>3.0"
   gem.add_runtime_dependency "rack-protection", "~> 4.1"
   gem.add_runtime_dependency "table_print", "~> 1.5"
-  gem.add_runtime_dependency "semantic_logger", "~> 4.11"
+  gem.add_runtime_dependency "semantic_logger", "~> 5.0"
   gem.add_runtime_dependency "sanitize", "~> 6.0"
   gem.add_runtime_dependency "wisper", "~> 2.0"
   gem.add_runtime_dependency "anyway_config", "~> 2.1"

--- a/pact_broker.gemspec
+++ b/pact_broker.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{See description}
   gem.homepage      = "https://github.com/pact-foundation/pact_broker"
 
-  gem.required_ruby_version = ">= 2.7.0"
+  gem.required_ruby_version = ">= 3.2.0"
 
   gem.files         = begin
                         if Dir.exist?(".git")

--- a/script/docs/generate-configuration-docs.rb
+++ b/script/docs/generate-configuration-docs.rb
@@ -11,6 +11,7 @@ variable `PACT_BROKER_CONF` to the full path to the configuration file.
 EOM
 
 require "yaml"
+require "stringio"
 $stream = StringIO.new
 
 def write string

--- a/spec/lib/pact_broker/config/runtime_configuration_spec.rb
+++ b/spec/lib/pact_broker/config/runtime_configuration_spec.rb
@@ -161,6 +161,46 @@ module PactBroker
           end
         end
       end
+
+      describe "log_otel_enabled" do
+        subject { RuntimeConfiguration.new }
+
+        it "defaults to :auto" do
+          expect(subject.log_otel_enabled).to eq :auto
+        end
+
+        it "coerces nil and blank to :auto" do
+          subject.log_otel_enabled = nil
+          expect(subject.log_otel_enabled).to eq :auto
+          subject.log_otel_enabled = ""
+          expect(subject.log_otel_enabled).to eq :auto
+        end
+
+        it "coerces the string 'auto' to :auto" do
+          subject.log_otel_enabled = "auto"
+          expect(subject.log_otel_enabled).to eq :auto
+        end
+
+        it "coerces truthy strings to true" do
+          subject.log_otel_enabled = "true"
+          expect(subject.log_otel_enabled).to eq true
+          subject.log_otel_enabled = "1"
+          expect(subject.log_otel_enabled).to eq true
+        end
+
+        it "coerces falsey strings to false" do
+          subject.log_otel_enabled = "false"
+          expect(subject.log_otel_enabled).to eq false
+          subject.log_otel_enabled = "0"
+          expect(subject.log_otel_enabled).to eq false
+        end
+
+        it "raises a ConfigurationError for invalid values on load" do
+          config = RuntimeConfiguration.new
+          config.log_otel_enabled = "sometimes"
+          expect { config.send(:validate_logging_attributes!) }.to raise_error(PactBroker::ConfigurationError, /log_otel_enabled/)
+        end
+      end
     end
   end
 end

--- a/spec/lib/pact_broker/configuration_spec.rb
+++ b/spec/lib/pact_broker/configuration_spec.rb
@@ -160,5 +160,47 @@ module PactBroker
         end
       end
     end
+
+    describe "#logger_from_runtime_configuration" do
+      let(:config) { PactBroker::Configuration.default_configuration }
+
+      before do
+        allow(SemanticLogger).to receive(:add_appender)
+        allow(PactBroker::Logging::OpenTelemetryAppenderSetup).to receive(:call)
+      end
+
+      it "invokes the OpenTelemetry appender setup" do
+        expect(PactBroker::Logging::OpenTelemetryAppenderSetup).to receive(:call).with(config.runtime_configuration)
+        config.logger_from_runtime_configuration
+      end
+
+      context "when log_format is :json" do
+        before do
+          config.runtime_configuration.log_stream = :stdout
+          config.runtime_configuration.log_format = :json
+        end
+
+        it "uses the trace-aware JSON formatter" do
+          expect(SemanticLogger).to receive(:add_appender) do |args|
+            expect(args[:formatter]).to be_a(PactBroker::Logging::TraceAwareJsonFormatter)
+          end
+          config.logger_from_runtime_configuration
+        end
+      end
+
+      context "when log_format is not :json" do
+        before do
+          config.runtime_configuration.log_stream = :stdout
+          config.runtime_configuration.log_format = :default
+        end
+
+        it "passes the format symbol through unchanged" do
+          expect(SemanticLogger).to receive(:add_appender) do |args|
+            expect(args[:formatter]).to eq :default
+          end
+          config.logger_from_runtime_configuration
+        end
+      end
+    end
   end
 end

--- a/spec/lib/pact_broker/logging/open_telemetry_appender_setup_spec.rb
+++ b/spec/lib/pact_broker/logging/open_telemetry_appender_setup_spec.rb
@@ -70,9 +70,8 @@ module PactBroker
 
       context "idempotency" do
         it "does not add a second appender when one already exists" do
-          stub_const("SemanticLogger::Appender::OpenTelemetry", Class.new)
-          existing = SemanticLogger::Appender::OpenTelemetry.new
-          allow(SemanticLogger).to receive(:appenders).and_return([existing])
+          existing = double("existing otel appender")
+          allow(setup).to receive(:existing_otel_appender).and_return(existing)
           expect(SemanticLogger).to_not receive(:add_appender)
           expect(setup.call).to eq existing
         end

--- a/spec/lib/pact_broker/logging/open_telemetry_appender_setup_spec.rb
+++ b/spec/lib/pact_broker/logging/open_telemetry_appender_setup_spec.rb
@@ -1,0 +1,82 @@
+require "pact_broker/logging/open_telemetry_appender_setup"
+require "pact_broker/config/runtime_configuration"
+
+module PactBroker
+  module Logging
+    describe OpenTelemetryAppenderSetup do
+      let(:runtime_configuration) do
+        config = PactBroker::Config::RuntimeConfiguration.new
+        config.log_otel_enabled = otel_enabled
+        config
+      end
+      let(:otel_enabled) { :auto }
+      let(:setup) { OpenTelemetryAppenderSetup.new(runtime_configuration) }
+      let(:fake_appender) { double("otel appender") }
+
+      before do
+        allow(SemanticLogger).to receive(:add_appender).and_return(fake_appender)
+        allow(SemanticLogger).to receive(:appenders).and_return([])
+        allow(setup).to receive(:otel_available?).and_return(true)
+        allow(setup).to receive(:otel_provider_configured?).and_return(true)
+      end
+
+      context "when :auto, available, provider configured" do
+        it "adds the open_telemetry appender" do
+          expect(SemanticLogger).to receive(:add_appender).with(appender: :open_telemetry)
+          expect(setup.call).to eq fake_appender
+        end
+      end
+
+      context "when :auto but not available" do
+        before { allow(setup).to receive(:otel_available?).and_return(false) }
+        it "adds nothing" do
+          expect(SemanticLogger).to_not receive(:add_appender)
+          expect(setup.call).to be_nil
+        end
+      end
+
+      context "when :auto, available, but no provider" do
+        before { allow(setup).to receive(:otel_provider_configured?).and_return(false) }
+        it "adds nothing" do
+          expect(SemanticLogger).to_not receive(:add_appender)
+          expect(setup.call).to be_nil
+        end
+      end
+
+      context "when true but not available" do
+        let(:otel_enabled) { true }
+        before { allow(setup).to receive(:otel_available?).and_return(false) }
+        it "raises a ConfigurationError" do
+          expect { setup.call }.to raise_error(PactBroker::ConfigurationError, /opentelemetry-logs-sdk/)
+        end
+      end
+
+      context "when true, available, but no provider" do
+        let(:otel_enabled) { true }
+        before { allow(setup).to receive(:otel_provider_configured?).and_return(false) }
+        it "adds the appender anyway" do
+          expect(SemanticLogger).to receive(:add_appender).with(appender: :open_telemetry)
+          expect(setup.call).to eq fake_appender
+        end
+      end
+
+      context "when false, even if available" do
+        let(:otel_enabled) { false }
+        it "adds nothing" do
+          expect(SemanticLogger).to_not receive(:add_appender)
+          expect(setup.call).to be_nil
+        end
+      end
+
+      context "idempotency" do
+        it "does not add a second appender when one already exists" do
+          stub_const("SemanticLogger::Appender::OpenTelemetry", Class.new)
+          existing = SemanticLogger::Appender::OpenTelemetry.new
+          allow(SemanticLogger).to receive(:appenders).and_return([existing])
+          expect(SemanticLogger).to_not receive(:add_appender)
+          expect(setup.call).to eq existing
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/pact_broker/logging/trace_aware_json_formatter_spec.rb
+++ b/spec/lib/pact_broker/logging/trace_aware_json_formatter_spec.rb
@@ -1,0 +1,46 @@
+require "pact_broker/logging/trace_aware_json_formatter"
+require "json"
+
+module PactBroker
+  module Logging
+    describe TraceAwareJsonFormatter do
+      let(:formatter) { TraceAwareJsonFormatter.new }
+      let(:appender) do
+        double("appender", host: "localhost", application: "test_app", environment: "test")
+      end
+      let(:log) do
+        log = SemanticLogger::Log.new("test", :info)
+        log.message = "hello"
+        log
+      end
+      subject { JSON.parse(formatter.call(log, appender)) }
+
+      context "when OTel is not loaded" do
+        before { allow(formatter).to receive(:otel_trace_context).and_return({}) }
+
+        it "emits plain JSON with the message and no trace fields" do
+          expect(subject["message"]).to eq "hello"
+          expect(subject).to_not have_key("trace_id")
+          expect(subject).to_not have_key("span_id")
+        end
+      end
+
+      context "when a valid active span exists" do
+        before do
+          allow(formatter).to receive(:otel_trace_context).and_return(
+            trace_id: "0af7651916cd43dd8448eb211c80319c",
+            span_id: "b7ad6b7169203331",
+            trace_flags: "01"
+          )
+        end
+
+        it "includes the OTel correlation fields alongside the message" do
+          expect(subject["message"]).to eq "hello"
+          expect(subject["trace_id"]).to eq "0af7651916cd43dd8448eb211c80319c"
+          expect(subject["span_id"]).to eq "b7ad6b7169203331"
+          expect(subject["trace_flags"]).to eq "01"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Upgrades `semantic_logger` to v5 and uses the new features it brings to give Pact Broker's logs OpenTelemetry trace correlation, without adding a hard dependency on any OTel gems.

- **Update `semantic_logger` to v5**, which requires bumping the gem's Ruby floor to 3.2 (matching the existing CI matrix).
- **Trace-aware JSON log formatter** — when `log_format` is `json`, active `trace_id` / `span_id` / `trace_flags` are embedded directly in each log line, so logs can be correlated with traces in any backend that ingests both. Falls back to plain JSON when OTel isn't loaded or there's no active span.
- **OpenTelemetry log appender** — a new `log_otel_enabled` setting (`auto` / `true` / `false`, default `auto`) optionally forwards logs to the OTel logs pipeline via `semantic_logger`'s `:open_telemetry` appender, layered in *alongside* the existing file/stdout appender rather than replacing it.
  - `auto` (default): only enabled when `opentelemetry-logs-sdk` is installed **and** a real OTel `LoggerProvider` is configured — safe default for installs that don't use OTel.
  - `true`: forces it on; raises `PactBroker::ConfigurationError` if the gem isn't available, warns if no provider is configured.
  - `false`: disabled entirely.
  - `opentelemetry-logs-sdk` remains an optional, runtime-detected dependency — it is **not** bundled with Pact Broker.

## Why

Pact Broker's logs and OTel traces/spans currently have no way to be correlated. This lets operators who already run OTel tracing pull Pact Broker's logs into the same pipeline and line them up with the request/span that produced them, without forcing the OTel gems on everyone else.

## Config changes

| Setting | Default | Allowed values | Env var |
|---|---|---|---|
| `log_otel_enabled` | `auto` | `auto`, `true`, `false` | `PACT_BROKER_LOG_OTEL_ENABLED` |

See `docs/CONFIGURATION.md` for full details.
