### PR TITLE
feat: return more webhooks attributes in logs decorator

### DIFF
--- a/lib/pact_broker/api/decorators/triggered_webhook_logs_decorator.rb
+++ b/lib/pact_broker/api/decorators/triggered_webhook_logs_decorator.rb
@@ -11,6 +11,10 @@ module PactBroker
         end
 
 
+        property :event_name, as: :eventName
+        property :consumer_name, as: :consumerName
+        property :provider_name, as: :providerName
+
         nested :triggeredWebhook, embedded: true do
           property :uuid
         end

--- a/spec/fixtures/approvals/triggered_webhook_logs_decorator.approved.json
+++ b/spec/fixtures/approvals/triggered_webhook_logs_decorator.approved.json
@@ -1,4 +1,7 @@
 {
+  "eventName": "contract_requiring_verification_published",
+  "consumerName": "Example Consumer",
+  "providerName": "Example Provider",
   "executions": [
     {
       "success": true,

--- a/spec/lib/pact_broker/api/decorators/triggered_webhook_logs_decorator_spec.rb
+++ b/spec/lib/pact_broker/api/decorators/triggered_webhook_logs_decorator_spec.rb
@@ -7,6 +7,9 @@ module PactBroker
         let(:triggered_webhook) do
           double("PactBroker::Webhooks::TriggeredWebhook",
             uuid: "1234",
+            event_name: "contract_requiring_verification_published",
+            consumer_name: "Example Consumer",
+            provider_name: "Example Provider",
             webhook_executions: [webhook_execution],
             webhook: webhook
           )


### PR DESCRIPTION
Currently in triggered webhook logs, the response does not return provider, consumer, and event name. That would be useful so that we can have them.