### PR TITLE
feat: expose released environments on version API

### DIFF
--- a/lib/pact_broker/api/decorators/version_decorator.rb
+++ b/lib/pact_broker/api/decorators/version_decorator.rb
@@ -74,9 +74,12 @@ module PactBroker
         end
 
         links :'pb:deployed-environments' do | context |
-          # I couldn't another way to check if call is from a collection or a single item 🤷‍♂️
-          # Also not sure why the heck .to_a?(Hash) doesn't work, I mean what...
-          deployed_versions = context[:deployed_versions].class.to_s == "Hash" ? context[:deployed_versions][represented.id] : context[:deployed_versions]
+          # NB: use fully-qualified ::Hash. The tins gem shadows the bare `Hash`
+          # constant in this scope, so `is_a?(Hash)` returns false even for a real
+          # Hash (this is the collection-vs-single-item branch: the collection
+          # resource passes a version_id-keyed Hash, the single resource an Array).
+          deployed_versions = context.dig(:deployed_versions)
+          deployed_versions = deployed_versions[represented.id] if deployed_versions.is_a?(::Hash)
           deployed_versions&.collect do | deployed_version |
             {
               title: "Version deployed to #{deployed_version.environment.display_name}",
@@ -86,6 +89,23 @@ module PactBroker
             }.tap do |hash|
               hash[:application_instance] = deployed_version.application_instance unless deployed_version.application_instance.nil?
             end
+          end
+        end
+
+        links :'pb:released-environments' do | context |
+          # NB: use fully-qualified ::Hash. The tins gem shadows the bare `Hash`
+          # constant in this scope, so `is_a?(Hash)` returns false even for a real
+          # Hash (this is the collection-vs-single-item branch: the collection
+          # resource passes a version_id-keyed Hash, the single resource an Array).
+          released_versions = context.dig(:released_versions)
+          released_versions = released_versions[represented.id] if released_versions.is_a?(::Hash)
+          released_versions&.collect do | released_version |
+            {
+              title: "Version released to #{released_version.environment.display_name}",
+              name: released_version.environment.display_name,
+              href: released_version_url(released_version, context.fetch(:base_url)),
+              currently_supported: released_version.currently_supported
+            }
           end
         end
 

--- a/lib/pact_broker/api/resources/version.rb
+++ b/lib/pact_broker/api/resources/version.rb
@@ -54,7 +54,7 @@ module PactBroker
         end
 
         def to_json
-          decorator_class(:version_decorator).new(version).to_json(**decorator_options(environments: environments, deployed_versions: deployed_versions))
+          decorator_class(:version_decorator).new(version).to_json(**decorator_options(environments: environments, deployed_versions: deployed_versions, released_versions: released_versions))
         end
 
         def delete_resource
@@ -85,6 +85,10 @@ module PactBroker
 
         def deployed_versions
           @deployed_versions ||= deployed_version_service.find_deployed_versions_for_version(version)
+        end
+
+        def released_versions
+          @released_versions ||= released_version_service.find_released_versions_for_version(version)
         end
 
         def version

--- a/lib/pact_broker/api/resources/versions.rb
+++ b/lib/pact_broker/api/resources/versions.rb
@@ -27,7 +27,7 @@ module PactBroker
         end
 
         def to_json
-          decorator_class(:versions_decorator).new(versions).to_json(**decorator_options(identifier_from_path.merge(deployed_versions: deployed_versions)))
+          decorator_class(:versions_decorator).new(versions).to_json(**decorator_options(identifier_from_path.merge(deployed_versions: deployed_versions, released_versions: released_versions)))
         end
 
         def versions
@@ -36,6 +36,10 @@ module PactBroker
 
         def deployed_versions
           @deployed_versions ||= deployed_version_service.find_deployed_versions_for_versions(versions)
+        end
+
+        def released_versions
+          @released_versions ||= released_version_service.find_released_versions_for_versions(versions)
         end
 
         def policy_name

--- a/lib/pact_broker/deployments/released_version_service.rb
+++ b/lib/pact_broker/deployments/released_version_service.rb
@@ -46,6 +46,20 @@ module PactBroker
           .single_record
       end
 
+      def self.find_released_versions_for_version(version)
+        scope_for(ReleasedVersion)
+          .where(version_id: version.id)
+          .eager(:environment)
+          .all
+      end
+
+      def self.find_released_versions_for_versions(versions_array)
+        scope_for(ReleasedVersion)
+          .where(version_id: versions_array.map(&:id))
+          .eager(:environment)
+          .to_hash_groups(:version_id)
+      end
+
       def self.record_version_support_ended(released_version)
         released_version.record_support_ended
       end

--- a/spec/lib/pact_broker/api/decorators/version_decorator_spec.rb
+++ b/spec/lib/pact_broker/api/decorators/version_decorator_spec.rb
@@ -51,8 +51,14 @@ module PactBroker
 
           let(:target) { nil }
 
+          let(:released_versions) do
+            [
+              td.create_released_version_for_consumer_version(uuid: "5678", environment_name: "test").and_return(:released_version)
+            ]
+          end
+
           let(:base_url) { "http://example.org" }
-          let(:options) { { user_options: { base_url: base_url, resource_url: "resource_url", environments: environments, deployed_versions: deployed_versions } } }
+          let(:options) { { user_options: { base_url: base_url, resource_url: "resource_url", environments: environments, deployed_versions: deployed_versions, released_versions: released_versions } } }
           let(:decorator) { VersionDecorator.new(version) }
 
           subject { JSON.parse(decorator.to_json(options), symbolize_names: true) }
@@ -133,6 +139,19 @@ module PactBroker
                                                                                  application_instance: "instance-1",
                                                                                  )
               end
+            end
+          end
+
+          context "when application is released to an env" do
+            it "includes a link to the released environments for this version" do
+              expect(subject[:_links][:'pb:released-environments']).to be_instance_of(Array)
+              expect(subject[:_links][:'pb:released-environments'].first).to eq(
+                                                                               title: "Version released to Test",
+                                                                               name: "Test",
+                                                                               href: "http://example.org/released-versions/5678",
+                                                                               currently_supported: true,
+                                                                               )
+              expect(subject[:_links][:'pb:released-environments'].first).to_not include(:application_instance)
             end
           end
 

--- a/spec/lib/pact_broker/api/resources/version_spec.rb
+++ b/spec/lib/pact_broker/api/resources/version_spec.rb
@@ -32,6 +32,11 @@ module PactBroker
                 uuid: "5678", currently_deployed: true, version: version, environment_name: prod_environment.name,
                 created_at: DateTime.now - 1)
           end
+          let(:released_version) do
+            td.use_consumer_version(version.number)
+              .create_released_version_for_consumer_version(uuid: "9012", environment_name: test_environment.name)
+              .create_released_version_for_consumer_version(uuid: "3456", environment_name: prod_environment.name)
+          end
 
           context "when the pacticipant and version do not exist" do
             subject { get(path, nil, { "HTTP_ACCEPT" => "application/hal+json" }) }
@@ -44,6 +49,7 @@ module PactBroker
             before do
               # Create a version on a pacticipant
               deployed_version
+              released_version
             end
             subject { get(path, nil, { "HTTP_ACCEPT" => "application/hal+json" }) }
 
@@ -61,6 +67,9 @@ module PactBroker
                 expect(response_body_hash[:_links][:"pb:deployed-environments"]).to be_a(Array)
                 expect(response_body_hash[:_links][:"pb:deployed-environments"].size).to eq 2
                 expect(response_body_hash[:_links][:"pb:deployed-environments"].first).to include(:title, :name, :href)
+                expect(response_body_hash.dig(:_links, :"pb:released-environments")).to be_a(Array)
+                expect(response_body_hash.dig(:_links, :"pb:released-environments").size).to eq 2
+                expect(response_body_hash.dig(:_links, :"pb:released-environments").first).to include(:title, :name, :href)
               end
             end
           end

--- a/spec/lib/pact_broker/api/resources/versions_spec.rb
+++ b/spec/lib/pact_broker/api/resources/versions_spec.rb
@@ -20,6 +20,11 @@ module PactBroker
                 uuid: "5678", currently_deployed: true, version: version, environment_name: prod_environment.name,
                 created_at: DateTime.now - 1)
           end
+          let(:released_version) do
+            td.use_consumer_version(version.number)
+              .create_released_version_for_consumer_version(uuid: "9012", environment_name: test_environment.name)
+              .create_released_version_for_consumer_version(uuid: "3456", environment_name: prod_environment.name)
+          end
 
           context "when the pacticipant and version do not exist" do
             subject { get(path, nil, { "HTTP_ACCEPT" => "application/hal+json" }) }
@@ -32,6 +37,7 @@ module PactBroker
             before do
               # Create a version on a pacticipant and other data
               deployed_version
+              released_version
             end
             subject { get(path, nil, { "HTTP_ACCEPT" => "application/hal+json" }) }
 
@@ -50,10 +56,13 @@ module PactBroker
                 expect(versions).to be_a(Array)
                 expect(versions.size).to eq 1
                 expect(versions.first).to include(:number, :_links)
-                expect(versions.first[:_links]).to include(:self, :"pb:deployed-environments")
+                expect(versions.first[:_links]).to include(:self, :"pb:deployed-environments", :"pb:released-environments")
                 expect(versions.first[:_links][:"pb:deployed-environments"]).to be_a(Array)
                 expect(versions.first[:_links][:"pb:deployed-environments"].size).to eq 2
                 expect(versions.first[:_links][:"pb:deployed-environments"].first).to include(:title, :name, :href)
+                expect(versions.first[:_links][:"pb:released-environments"]).to be_a(Array)
+                expect(versions.first[:_links][:"pb:released-environments"].size).to eq 2
+                expect(versions.first[:_links][:"pb:released-environments"].first).to include(:title, :name, :href)
               end
             end
           end

--- a/spec/lib/pact_broker/deployments/released_version_service_spec.rb
+++ b/spec/lib/pact_broker/deployments/released_version_service_spec.rb
@@ -58,6 +58,48 @@ module PactBroker
           end
         end
       end
+
+      describe ".find_released_versions_for_version" do
+        before do
+          td.create_environment("test")
+            .create_environment("prod")
+            .create_consumer("foo")
+            .create_consumer_version("1")
+            .create_released_version_for_consumer_version(environment_name: "test")
+            .create_released_version_for_consumer_version(environment_name: "prod")
+            .create_consumer_version("2")
+            .create_released_version_for_consumer_version(environment_name: "test")
+        end
+
+        let(:version) { PactBroker::Domain::Version.where(number: "1").single_record }
+
+        it "returns all the released versions for the given version, with the environment eager loaded" do
+          released_versions = ReleasedVersionService.find_released_versions_for_version(version)
+          expect(released_versions.size).to eq 2
+          expect(released_versions.collect { |rv| rv.environment.name }).to contain_exactly("test", "prod")
+        end
+      end
+
+      describe ".find_released_versions_for_versions" do
+        before do
+          td.create_environment("test")
+            .create_consumer("foo")
+            .create_consumer_version("1")
+            .create_released_version_for_consumer_version(environment_name: "test")
+            .create_consumer_version("2")
+            .create_released_version_for_consumer_version(environment_name: "test")
+        end
+
+        let(:version_1) { PactBroker::Domain::Version.where(number: "1").single_record }
+        let(:version_2) { PactBroker::Domain::Version.where(number: "2").single_record }
+
+        it "returns a hash of released versions grouped by version_id" do
+          released_versions = ReleasedVersionService.find_released_versions_for_versions([version_1, version_2])
+          expect(released_versions).to be_a(Hash)
+          expect(released_versions[version_1.id].size).to eq 1
+          expect(released_versions[version_2.id].size).to eq 1
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds a new `pb:released-environments` HAL link relation to the version resource, mirroring the existing `pb:deployed-environments`. Today the version and versions resources only surface environments a version was **deployed** to (`record-deployment`); versions put into an environment via **`record-release`** carry no environment information. This closes that gap so API consumers (e.g. the UI) can display released environments too.

## Changes

- **`ReleasedVersionService`** — add `find_released_versions_for_version` and `find_released_versions_for_versions`, direct parallels of the existing deployed finders (`scope_for` for scoping, eager-load `:environment`, return all releases).
- **`VersionDecorator`** — add a `pb:released-environments` link collection carrying `currently_supported` per entry (no `application_instance` — releases have no target).
- **`Version` / `Versions` resources** — pass `released_versions` into the decorator context alongside `deployed_versions`.
- **Cleanup** — the collection-vs-single-item detection in both the deployed and released link blocks now uses `context.dig(...)` + `is_a?(::Hash)`. The `Hash` constant is shadowed by the `tins` gem in this scope, so `is_a?(Hash)` returns false for a real Hash — hence the fully-qualified `::Hash`. This replaces the prior `.class.to_s == "Hash"` workaround (and its comments noting the confusion).

## Tests

- Decorator: asserts the new `pb:released-environments` link shape.
- Version & Versions resources: assert the link is present (full request specs).
- `ReleasedVersionService`: unit specs for both new finders.

All green; `pb:deployed-environments` behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)