### PR TITLE
test(matrix): behaviour-pinning safety net for GET /matrix (pre-optimisation)

### DIFF
--- a/spec/features/can_i_deploy_approval_spec.rb
+++ b/spec/features/can_i_deploy_approval_spec.rb
@@ -1,0 +1,37 @@
+describe "GET /can-i-deploy approval" do
+  # Foo v1 (tagged "dev") verified successfully by Bar v10 (tagged "prod"),
+  # with Bar v10 deployed to the "production" environment.
+  CAN_I_DEPLOY_APPROVALS = {}
+
+  before do
+    td.create_pact_with_hierarchy("Foo", "1", "Bar")
+      .create_consumer_version_tag("dev")
+      .create_verification(provider_version: "10", success: true, tag_names: ["prod"])
+      .create_environment("production")
+      .create_deployed_version_for_provider_version(environment_name: "production")
+  end
+
+  after do |example|
+    body = JSON.parse(subject.body)
+    CAN_I_DEPLOY_APPROVALS[example.full_description] = { "status" => subject.status, "summary" => body["summary"] }
+  end
+
+  after(:all) do
+    Approvals.verify(CAN_I_DEPLOY_APPROVALS, name: "features_can_i_deploy_approval_spec", format: :json)
+  end
+
+  describe "can-i-deploy Foo v1 to the production environment" do
+    subject { get("/can-i-deploy", { pacticipant: "Foo", version: "1", environment: "production" }, { "HTTP_ACCEPT" => "application/hal+json" }) }
+    it("snapshots") { subject }
+  end
+
+  describe "can-i-deploy Foo's dev tag to Bar's prod tag (tag-to-tag URL format)" do
+    subject { get("/pacticipants/Foo/latest-version/dev/can-i-deploy/to/prod", nil, { "HTTP_ACCEPT" => "application/hal+json" }) }
+    it("snapshots") { subject }
+  end
+
+  describe "can-i-deploy with missing required params returns a validation error" do
+    subject { get("/can-i-deploy", {}, { "HTTP_ACCEPT" => "application/hal+json" }) }
+    it("snapshots") { subject }
+  end
+end

--- a/spec/features/can_i_deploy_approval_spec.rb
+++ b/spec/features/can_i_deploy_approval_spec.rb
@@ -34,4 +34,27 @@ describe "GET /can-i-deploy approval" do
     subject { get("/can-i-deploy", {}, { "HTTP_ACCEPT" => "application/hal+json" }) }
     it("snapshots") { subject }
   end
+
+  # A second, failing integration for Foo v1, added only for these two examples, to pin the
+  # `ignore` selector decision path. Baz has not been deployed to "production", so without
+  # ignoring it, Foo v1 is not deployable to "production"; ignoring Baz restores the
+  # already-deployable result from the shared Foo/Bar fixture above, confirming the ignore
+  # selector actually alters the decision.
+  describe "can-i-deploy Foo v1 to the production environment with a failing integration" do
+    before do
+      td.create_provider("Baz")
+        .create_pact
+        .create_verification(provider_version: "99", success: false)
+    end
+
+    describe "without ignoring the failing integration" do
+      subject { get("/can-i-deploy", { pacticipant: "Foo", version: "1", environment: "production" }, { "HTTP_ACCEPT" => "application/hal+json" }) }
+      it("snapshots") { subject }
+    end
+
+    describe "ignoring the failing integration" do
+      subject { get("/can-i-deploy", { pacticipant: "Foo", version: "1", environment: "production", ignore: ["Baz"] }, { "HTTP_ACCEPT" => "application/hal+json" }) }
+      it("snapshots") { subject }
+    end
+  end
 end

--- a/spec/features/get_matrix_approval_spec.rb
+++ b/spec/features/get_matrix_approval_spec.rb
@@ -129,5 +129,30 @@ describe "GET /matrix approval" do
     it "matches the expected body", skip: !PactBroker::TestDatabase.sqlite? do
       Approvals.verify(fixture, name: "matrix_full_body_ui_browse", format: :json)
     end
+
+    after do
+      Approvals.configure { |config| config.excluded_json_keys = {} }
+    end
+  end
+
+  # --- text/plain response body (public contract consumed by the can-i-deploy CLI) ---
+  # Pinned under sqlite only, over the same shared fixture graph as the hal+json full-body snapshot.
+  describe "full response body, text/plain (public contract)" do
+    before { build_matrix_fixture_graph }
+
+    subject { get("/matrix?q[][pacticipant]=Foo&q[][pacticipant]=Bar&latestby=cvpv", nil, { "HTTP_ACCEPT" => "text/plain" }) }
+
+    # Unlike the hal+json body, the plain-text table (consumed by the can-i-deploy CLI) renders no
+    # dates, timestamps, or raw DB ids for this query, so a full-body snapshot is deterministic
+    # here. Confirmed by running this example twice and diffing the .received.txt output
+    # byte-for-byte before approving.
+    it "matches the expected body", skip: !PactBroker::TestDatabase.sqlite? do
+      Approvals.verify(subject.body, name: "matrix_full_body_text", format: :txt)
+    end
+
+    it "returns the expected status and content type" do
+      expect(subject.status).to eq 200
+      expect(subject.headers["Content-Type"]).to eq "text/plain;charset=utf-8"
+    end
   end
 end

--- a/spec/features/get_matrix_approval_spec.rb
+++ b/spec/features/get_matrix_approval_spec.rb
@@ -1,0 +1,132 @@
+describe "GET /matrix approval" do
+  # Shared fixture graph, reused by both the distilled and full-body examples:
+  #
+  # Foo -> Bar: v1 verified successfully by Bar v10 (no branch)
+  #             v2 (branch main) verified, but failed, by Bar v20
+  #             v3 (branch main) has an unverified pact revision
+  # Foo -> Baz: second integration, v3 verified successfully by Baz v30,
+  #             deployed to the "production" environment
+  def build_matrix_fixture_graph
+    td.create_pact_with_hierarchy("Foo", "1", "Bar", fixed_pact_json("Foo", "Bar", 1))
+      .create_verification(provider_version: "10", success: true)
+      .create_consumer_version("2", branch: "main")
+      .create_pact(json_content: fixed_pact_json("Foo", "Bar", 2))
+      .create_verification(provider_version: "20", success: false)
+      .create_consumer_version("3", branch: "main")
+      .create_pact(json_content: fixed_pact_json("Foo", "Bar", 3)) # unverified revision (no verification created)
+      .create_provider("Baz")
+      .create_pact(json_content: fixed_pact_json("Foo", "Baz", 1))
+      .create_verification(provider_version: "30", success: true)
+      .create_environment("production")
+      .create_deployed_version_for_provider_version(environment_name: "production")
+  end
+
+  # The default json_content used by td#create_pact includes a random value, which
+  # would make the pact_version_sha (and therefore the verification result URLs in
+  # the full-body snapshot) non-deterministic across runs. Use fixed content instead.
+  def fixed_pact_json(consumer_name, provider_name, differentiator)
+    {
+      "consumer" => { "name" => consumer_name },
+      "provider" => { "name" => provider_name },
+      "interactions" => [
+        {
+          "request" => { "method" => "GET", "path" => "/things/#{differentiator}" },
+          "response" => { "status" => 200 }
+        }
+      ]
+    }.to_json
+  end
+
+  # --- distilled decision snapshots over a production-weighted request matrix ---
+  # DB-independent (deployable/reason/counts only, no raw IDs), so NOT sqlite-gated.
+  describe "distilled decisions" do
+    MATRIX_APPROVALS = {}
+
+    before { build_matrix_fixture_graph }
+
+    after do |example|
+      MATRIX_APPROVALS[example.full_description] = matrix_query_content_for_approval_or_body(subject)
+    end
+
+    def matrix_query_content_for_approval_or_body(response)
+      body = JSON.parse(response.body)
+      {
+        "status" => response.status,
+        "summary" => body["summary"],
+        "noticeTypes" => (body["notices"] || []).collect { |notice| notice["type"] }
+      }
+    end
+
+    after(:all) do
+      Approvals.verify(MATRIX_APPROVALS, name: "features_get_matrix_approval_spec", format: :json)
+    end
+
+    describe "single selector to latest (top production shape)" do
+      subject { get("/matrix?q[][pacticipant]=Foo&q[][version]=1&latestby=cvpv&latest=true") }
+      it("snapshots") { subject }
+    end
+
+    describe "can-i-deploy to environment" do
+      subject { get("/matrix?q[][pacticipant]=Foo&q[][version]=1&latestby=cvpv&environment=production") }
+      it("snapshots") { subject }
+    end
+
+    describe "can-i-deploy to mainBranch" do
+      subject { get("/matrix?q[][pacticipant]=Foo&q[][version]=2&latestby=cvpv&mainBranch=true") }
+      it("snapshots") { subject }
+    end
+
+    describe "matrix UI browse (two selectors by name)" do
+      subject { get("/matrix?q[][pacticipant]=Foo&q[][pacticipant]=Bar&latestby=cvpv") }
+      it("snapshots") { subject }
+    end
+
+    describe "flat encoding, two selectors" do
+      subject { get("/matrix?q[]pacticipant=Foo&q[]version=1&q[]pacticipant=Bar&q[]version=10&latestby=cvpv") }
+      it("snapshots") { subject }
+    end
+
+    describe "success filter true" do
+      subject { get("/matrix?q[][pacticipant]=Foo&q[][pacticipant]=Bar&latestby=cvpv&success=true") }
+      it("snapshots") { subject }
+    end
+
+    describe "limit smaller than result set" do
+      subject { get("/matrix?q[][pacticipant]=Foo&q[][pacticipant]=Bar&latestby=cvpv&limit=1") }
+      it("snapshots") { subject }
+    end
+
+    describe "path endpoint" do
+      subject { get("/matrix/provider/Bar/consumer/Foo") }
+      it("snapshots") { subject }
+    end
+  end
+
+  # --- full response body (public contract), pinned under sqlite only ---
+  describe "full response body (public contract)" do
+    before do
+      build_matrix_fixture_graph
+      Approvals.configure do |config|
+        # determinate_headers strips "Date"/"Server"/"Content-Length" by capitalized
+        # key, but Rack 3 returns lowercase header keys, so the "date" header still
+        # varies run-to-run. Scrub it here, alongside the two date-bearing decorator
+        # keys, following the pattern in get_provider_pacts_for_verification_spec.rb.
+        config.excluded_json_keys = { timestamps: /createdAt|verifiedAt|^date$/ }
+      end
+    end
+
+    subject { get("/matrix?q[][pacticipant]=Foo&q[][pacticipant]=Bar&latestby=cvpv") }
+
+    let(:fixture) do
+      {
+        request: { path: "/matrix", query: "q[][pacticipant]=Foo&q[][pacticipant]=Bar&latestby=cvpv" },
+        response: { status: subject.status, headers: determinate_headers(subject.headers), body: JSON.parse(subject.body) }
+      }
+    end
+
+    # DB IDs differ across databases, so pin the full body under sqlite only.
+    it "matches the expected body", skip: !PactBroker::TestDatabase.sqlite? do
+      Approvals.verify(fixture, name: "matrix_full_body_ui_browse", format: :json)
+    end
+  end
+end

--- a/spec/features/get_matrix_approval_spec.rb
+++ b/spec/features/get_matrix_approval_spec.rb
@@ -108,10 +108,11 @@ describe "GET /matrix approval" do
       build_matrix_fixture_graph
       Approvals.configure do |config|
         # determinate_headers strips "Date"/"Server"/"Content-Length" by capitalized
-        # key, but Rack 3 returns lowercase header keys, so the "date" header still
-        # varies run-to-run. Scrub it here, alongside the two date-bearing decorator
-        # keys, following the pattern in get_provider_pacts_for_verification_spec.rb.
-        config.excluded_json_keys = { timestamps: /createdAt|verifiedAt|^date$/ }
+        # key, but Rack 3 returns lowercase header keys, so the "date", "server" and
+        # "content-length" headers still vary run-to-run. Scrub them here, alongside
+        # the two date-bearing decorator keys, following the pattern in
+        # get_provider_pacts_for_verification_spec.rb.
+        config.excluded_json_keys = { timestamps: /createdAt|verifiedAt|^date$|^content-length$|^server$/ }
       end
     end
 

--- a/spec/fixtures/approvals/features_can_i_deploy_approval_spec.approved.json
+++ b/spec/fixtures/approvals/features_can_i_deploy_approval_spec.approved.json
@@ -1,0 +1,26 @@
+{
+  "GET /can-i-deploy approval can-i-deploy Foo v1 to the production environment snapshots": {
+    "status": 200,
+    "summary": {
+      "deployable": true,
+      "reason": "All required verification results are published and successful",
+      "success": 1,
+      "failed": 0,
+      "unknown": 0
+    }
+  },
+  "GET /can-i-deploy approval can-i-deploy Foo's dev tag to Bar's prod tag (tag-to-tag URL format) snapshots": {
+    "status": 200,
+    "summary": {
+      "deployable": true,
+      "reason": "WARN: It is recommended to specify the version number (rather than the tag or branch) of the pacticipant you wish to deploy to avoid race conditions. Without a version number, this result will not be reliable.\nAll required verification results are published and successful",
+      "success": 1,
+      "failed": 0,
+      "unknown": 0
+    }
+  },
+  "GET /can-i-deploy approval can-i-deploy with missing required params returns a validation error snapshots": {
+    "status": 400,
+    "summary": null
+  }
+}

--- a/spec/fixtures/approvals/features_can_i_deploy_approval_spec.approved.json
+++ b/spec/fixtures/approvals/features_can_i_deploy_approval_spec.approved.json
@@ -22,5 +22,26 @@
   "GET /can-i-deploy approval can-i-deploy with missing required params returns a validation error snapshots": {
     "status": 400,
     "summary": null
+  },
+  "GET /can-i-deploy approval can-i-deploy Foo v1 to the production environment with a failing integration without ignoring the failing integration snapshots": {
+    "status": 200,
+    "summary": {
+      "deployable": null,
+      "reason": "There is no verified pact between version 1 of Foo and a version of Baz currently in production (no version is currently recorded as deployed/released in this environment)",
+      "success": 1,
+      "failed": 0,
+      "unknown": 1
+    }
+  },
+  "GET /can-i-deploy approval can-i-deploy Foo v1 to the production environment with a failing integration ignoring the failing integration snapshots": {
+    "status": 200,
+    "summary": {
+      "deployable": true,
+      "reason": "All required verification results are published and successful",
+      "success": 1,
+      "failed": 0,
+      "unknown": 0,
+      "ignored": 1
+    }
   }
 }

--- a/spec/fixtures/approvals/features_get_matrix_approval_spec.approved.json
+++ b/spec/fixtures/approvals/features_get_matrix_approval_spec.approved.json
@@ -1,0 +1,109 @@
+{
+  "GET /matrix approval distilled decisions single selector to latest (top production shape) snapshots": {
+    "status": 200,
+    "summary": {
+      "deployable": null,
+      "reason": "WARN: It is recommended to specify the environment into which you are deploying. Without the environment, this result will not be reliable.\nThere is no verified pact between version 1 of Foo and the latest version of Bar (20)",
+      "success": 0,
+      "failed": 0,
+      "unknown": 1
+    },
+    "noticeTypes": [
+      "warning",
+      "error"
+    ]
+  },
+  "GET /matrix approval distilled decisions can-i-deploy to environment snapshots": {
+    "status": 200,
+    "summary": {
+      "deployable": null,
+      "reason": "There is no verified pact between version 1 of Foo and a version of Bar currently in production (no version is currently recorded as deployed/released in this environment)",
+      "success": 0,
+      "failed": 0,
+      "unknown": 1
+    },
+    "noticeTypes": [
+      "error"
+    ]
+  },
+  "GET /matrix approval distilled decisions can-i-deploy to mainBranch snapshots": {
+    "status": 200,
+    "summary": {
+      "deployable": null,
+      "reason": "There is no verified pact between version 2 of Foo and any version of Bar from the main branch (no versions exist for this branch)",
+      "success": 0,
+      "failed": 0,
+      "unknown": 1
+    },
+    "noticeTypes": [
+      "error"
+    ]
+  },
+  "GET /matrix approval distilled decisions matrix UI browse (two selectors by name) snapshots": {
+    "status": 200,
+    "summary": {
+      "deployable": null,
+      "reason": "The verification for the pact between any version of Foo and any version of Bar failed\nThere is no verified pact between any version of Foo and any version of Bar",
+      "success": 1,
+      "failed": 1,
+      "unknown": 1
+    },
+    "noticeTypes": [
+      "error",
+      "error"
+    ]
+  },
+  "GET /matrix approval distilled decisions flat encoding, two selectors snapshots": {
+    "status": 200,
+    "summary": {
+      "deployable": true,
+      "reason": "All required verification results are published and successful",
+      "success": 1,
+      "failed": 0,
+      "unknown": 0
+    },
+    "noticeTypes": [
+      "success"
+    ]
+  },
+  "GET /matrix approval distilled decisions success filter true snapshots": {
+    "status": 200,
+    "summary": {
+      "deployable": true,
+      "reason": "All required verification results are published and successful",
+      "success": 1,
+      "failed": 0,
+      "unknown": 0
+    },
+    "noticeTypes": [
+      "success"
+    ]
+  },
+  "GET /matrix approval distilled decisions limit smaller than result set snapshots": {
+    "status": 200,
+    "summary": {
+      "deployable": true,
+      "reason": "All required verification results are published and successful",
+      "success": 1,
+      "failed": 0,
+      "unknown": 0
+    },
+    "noticeTypes": [
+      "success"
+    ]
+  },
+  "GET /matrix approval distilled decisions path endpoint snapshots": {
+    "status": 200,
+    "summary": {
+      "deployable": null,
+      "reason": "The verification for the pact between any version of Foo and any version of Bar failed\nThere is no verified pact between any version of Foo and any version of Bar",
+      "success": 1,
+      "failed": 1,
+      "unknown": 1
+    },
+    "noticeTypes": [
+      "error",
+      "error"
+    ]
+  }
+}

--- a/spec/fixtures/approvals/matrix_full_body_text.approved.txt
+++ b/spec/fixtures/approvals/matrix_full_body_text.approved.txt
@@ -1,0 +1,9 @@
+CONSUMER | C_VERSION | REVISION | PROVIDER | P_VERSION | NUMBER | SUCCESS
+---------|-----------|----------|----------|-----------|--------|--------
+Foo      | 3         | 1        | Bar      |           |        |        
+Foo      | 2         | 1        | Bar      | 20        | 1      | false  
+Foo      | 1         | 1        | Bar      | 10        | 1      | true   
+
+Deployable: nil
+Reason: The verification for the pact between any version of Foo and any version of Bar failed
+There is no verified pact between any version of Foo and any version of Bar

--- a/spec/fixtures/approvals/matrix_full_body_ui_browse.approved.json
+++ b/spec/fixtures/approvals/matrix_full_body_ui_browse.approved.json
@@ -1,0 +1,248 @@
+{
+  "request": {
+    "path": "/matrix",
+    "query": "q[][pacticipant]=Foo&q[][pacticipant]=Bar&latestby=cvpv"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "content-type": "application/hal+json;charset=utf-8",
+      "vary": "Accept",
+      "content-length": "3523",
+      "date": "<timestamps>",
+      "server": "Webmachine-Ruby/2.0.1 Rack/3.2"
+    },
+    "body": {
+      "summary": {
+        "deployable": null,
+        "reason": "The verification for the pact between any version of Foo and any version of Bar failed\nThere is no verified pact between any version of Foo and any version of Bar",
+        "success": 1,
+        "failed": 1,
+        "unknown": 1
+      },
+      "notices": [
+        {
+          "type": "error",
+          "text": "The verification for the pact between any version of Foo and any version of Bar failed"
+        },
+        {
+          "type": "error",
+          "text": "There is no verified pact between any version of Foo and any version of Bar"
+        }
+      ],
+      "matrix": [
+        {
+          "consumer": {
+            "name": "Foo",
+            "version": {
+              "number": "3",
+              "branch": "main",
+              "branches": [
+                {
+                  "name": "main",
+                  "latest": true,
+                  "_links": {
+                    "self": {
+                      "title": "Branch version",
+                      "name": "main",
+                      "href": "http://example.org/pacticipants/Foo/branches/main/versions/3"
+                    }
+                  }
+                }
+              ],
+              "branchVersions": [
+                {
+                  "name": "main",
+                  "latest": true,
+                  "_links": {
+                    "self": {
+                      "title": "Branch version",
+                      "name": "main",
+                      "href": "http://example.org/pacticipants/Foo/branches/main/versions/3"
+                    }
+                  }
+                }
+              ],
+              "environments": [],
+              "_links": {
+                "self": {
+                  "href": "http://example.org/pacticipants/Foo/versions/3"
+                }
+              },
+              "tags": []
+            },
+            "_links": {
+              "self": {
+                "href": "http://example.org/pacticipants/Foo"
+              }
+            }
+          },
+          "provider": {
+            "name": "Bar",
+            "version": null,
+            "_links": {
+              "self": {
+                "href": "http://example.org/pacticipants/Bar"
+              }
+            }
+          },
+          "pact": {
+            "createdAt": "<timestamps>",
+            "_links": {
+              "self": {
+                "href": "http://example.org/pacts/provider/Bar/consumer/Foo/version/3"
+              }
+            }
+          },
+          "verificationResult": null
+        },
+        {
+          "consumer": {
+            "name": "Foo",
+            "version": {
+              "number": "2",
+              "branch": "main",
+              "branches": [
+                {
+                  "name": "main",
+                  "latest": false,
+                  "_links": {
+                    "self": {
+                      "title": "Branch version",
+                      "name": "main",
+                      "href": "http://example.org/pacticipants/Foo/branches/main/versions/2"
+                    }
+                  }
+                }
+              ],
+              "branchVersions": [
+                {
+                  "name": "main",
+                  "latest": false,
+                  "_links": {
+                    "self": {
+                      "title": "Branch version",
+                      "name": "main",
+                      "href": "http://example.org/pacticipants/Foo/branches/main/versions/2"
+                    }
+                  }
+                }
+              ],
+              "environments": [],
+              "_links": {
+                "self": {
+                  "href": "http://example.org/pacticipants/Foo/versions/2"
+                }
+              },
+              "tags": []
+            },
+            "_links": {
+              "self": {
+                "href": "http://example.org/pacticipants/Foo"
+              }
+            }
+          },
+          "provider": {
+            "name": "Bar",
+            "version": {
+              "number": "20",
+              "branch": null,
+              "branches": [],
+              "branchVersions": [],
+              "environments": [],
+              "_links": {
+                "self": {
+                  "href": "http://example.org/pacticipants/Bar/versions/20"
+                }
+              },
+              "tags": []
+            },
+            "_links": {
+              "self": {
+                "href": "http://example.org/pacticipants/Bar"
+              }
+            }
+          },
+          "pact": {
+            "createdAt": "<timestamps>",
+            "_links": {
+              "self": {
+                "href": "http://example.org/pacts/provider/Bar/consumer/Foo/version/2"
+              }
+            }
+          },
+          "verificationResult": {
+            "success": false,
+            "verifiedAt": "<timestamps>",
+            "_links": {
+              "self": {
+                "href": "http://example.org/pacts/provider/Bar/consumer/Foo/pact-version/89ebba9b5a902c59f1cc440e9e16abed64b33978/metadata/Y3ZuPTI/verification-results/1"
+              }
+            }
+          }
+        },
+        {
+          "consumer": {
+            "name": "Foo",
+            "version": {
+              "number": "1",
+              "branch": null,
+              "branches": [],
+              "branchVersions": [],
+              "environments": [],
+              "_links": {
+                "self": {
+                  "href": "http://example.org/pacticipants/Foo/versions/1"
+                }
+              },
+              "tags": []
+            },
+            "_links": {
+              "self": {
+                "href": "http://example.org/pacticipants/Foo"
+              }
+            }
+          },
+          "provider": {
+            "name": "Bar",
+            "version": {
+              "number": "10",
+              "branch": null,
+              "branches": [],
+              "branchVersions": [],
+              "environments": [],
+              "_links": {
+                "self": {
+                  "href": "http://example.org/pacticipants/Bar/versions/10"
+                }
+              },
+              "tags": []
+            },
+            "_links": {
+              "self": {
+                "href": "http://example.org/pacticipants/Bar"
+              }
+            }
+          },
+          "pact": {
+            "createdAt": "<timestamps>",
+            "_links": {
+              "self": {
+                "href": "http://example.org/pacts/provider/Bar/consumer/Foo/version/1"
+              }
+            }
+          },
+          "verificationResult": {
+            "success": true,
+            "verifiedAt": "<timestamps>",
+            "_links": {
+              "self": {
+                "href": "http://example.org/pacts/provider/Bar/consumer/Foo/pact-version/b868b7a19b66d0810bd42423beacedaccf25b6fb/metadata/Y3ZuPTE/verification-results/1"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/spec/fixtures/approvals/matrix_full_body_ui_browse.approved.json
+++ b/spec/fixtures/approvals/matrix_full_body_ui_browse.approved.json
@@ -8,9 +8,9 @@
     "headers": {
       "content-type": "application/hal+json;charset=utf-8",
       "vary": "Accept",
-      "content-length": "3523",
+      "content-length": "<timestamps>",
       "date": "<timestamps>",
-      "server": "Webmachine-Ruby/2.0.1 Rack/3.2"
+      "server": "<timestamps>"
     },
     "body": {
       "summary": {

--- a/spec/lib/pact_broker/api/resources/matrix_spec.rb
+++ b/spec/lib/pact_broker/api/resources/matrix_spec.rb
@@ -35,6 +35,16 @@ module PactBroker
             expect(json_response_body[:errors]).to eq ["foo"]
           end
         end
+
+        context "when the request is valid" do
+          let(:selectors) { [PactBroker::Matrix::UnresolvedSelector.new(pacticipant_name: "Foo")] }
+          let(:options) { { latestby: "cvpv", limit: "100", ignore_selectors: [] } }
+
+          it "passes the parsed selectors and options straight through to the service" do
+            expect(PactBroker::Matrix::Service).to receive(:can_i_deploy).with(selectors, options).and_return([])
+            subject
+          end
+        end
       end
     end
   end

--- a/spec/lib/pact_broker/matrix/deployment_status_summary_spec.rb
+++ b/spec/lib/pact_broker/matrix/deployment_status_summary_spec.rb
@@ -213,6 +213,10 @@ module PactBroker
           its(:deployable?) { is_expected.to be true }
           its(:reasons) { is_expected.to eq [NoDependenciesMissing.new] }
           its(:counts) { is_expected.to eq success: 0, failed: 0, unknown: 0 }
+
+          it "sets the type of the reason to :success (rendered as the JSON type field)" do
+            expect(subject.reasons.first.type).to eq :success
+          end
         end
 
         context "when there is a provider integration that does not have a matching row and only the consumer was specified in the query" do

--- a/spec/lib/pact_broker/matrix/matrix_row_spec.rb
+++ b/spec/lib/pact_broker/matrix/matrix_row_spec.rb
@@ -71,11 +71,13 @@ module PactBroker
 
         context "when two different pacts share the same last action date (pact_order tie-break)" do
           before do
-            # Two pacts published and verified on the same simulated day, so last_action_date
-            # ties and the query falls through to ordering by pact_order desc. The query has a
-            # further verification_id desc tie-break, but it is not exercised here: pact_order is
-            # the pact_publication_id, which is unique per pact, so it always disambiguates first.
-            # The verification_id tie-break is not reachable via the public test-data builder.
+            # Two DIFFERENT pacts published and verified on the same simulated day, so
+            # last_action_date ties and the query falls through to ordering by pact_order desc.
+            # pact_order is the pact_publication_id, which is unique per pact, so it always
+            # disambiguates two different pacts before the query would need to reach the
+            # further verification_id desc tie-break. See the "verification_id tie-break"
+            # context below for a fixture where pact_order also ties, forcing the ordering
+            # through to verification_id.
             td.create_pact_with_hierarchy("Foo", "1", "Bar")
               .create_verification(provider_version: "10", created_at: day_1)
               .create_pact_with_hierarchy("Foo", "2", "Baz")
@@ -88,6 +90,31 @@ module PactBroker
             expect(subject.first.last_action_date).to eq subject.last.last_action_date
             expect(subject.first.consumer_version_number).to eq "2"
             expect(subject.last.consumer_version_number).to eq "1"
+          end
+        end
+
+        context "when the same pact is verified by two provider versions on the same last action date (verification_id tie-break)" do
+          before do
+            # ONE pact (one pact_publication_id) verified by TWO provider versions, both created
+            # at the same simulated instant. Because it's the same pact, both rows share the same
+            # pact_order (pact_publication_id), so the first tie-break (pact_order) also ties.
+            # Because both provider versions share the same created_at, and last_action_date is
+            # the max of consumer_version_created_at/provider_version_created_at for a single
+            # shared consumer version, both rows' last_action_date ties too. This forces the
+            # ordering through to the third tie-break, verification_id desc.
+            td.create_pact_with_hierarchy("Foo", "1", "Bar")
+              .create_verification(provider_version: "10", created_at: day_1)
+              .create_verification(provider_version: "20", number: 2, created_at: day_1)
+          end
+
+          let(:day_1) { DateTime.now + 1 }
+
+          it "orders the most recently created verification first (documents current verification_id tie-break)" do
+            expect(subject.first.last_action_date).to eq subject.last.last_action_date
+            expect(subject.first.values[:pact_order]).to eq subject.last.values[:pact_order]
+            expect(subject.first.consumer_version_number).to eq subject.last.consumer_version_number
+            expect(subject.first.provider_version_number).to eq "20"
+            expect(subject.last.provider_version_number).to eq "10"
           end
         end
 

--- a/spec/lib/pact_broker/matrix/matrix_row_spec.rb
+++ b/spec/lib/pact_broker/matrix/matrix_row_spec.rb
@@ -68,6 +68,25 @@ module PactBroker
             expect(subject.last.consumer_version_number).to eq "1"
           end
         end
+
+        context "when two different pacts share the same last action date (pact_order/verification_id tie-break)" do
+          before do
+            # Two pacts published and verified on the same simulated day, so last_action_date
+            # ties and the query falls through to ordering by pact_order desc, then verification_id desc.
+            td.create_pact_with_hierarchy("Foo", "1", "Bar")
+              .create_verification(provider_version: "10", created_at: day_1)
+              .create_pact_with_hierarchy("Foo", "2", "Baz")
+              .create_verification(provider_version: "20", created_at: day_1)
+          end
+
+          let(:day_1) { DateTime.now + 1 }
+
+          it "orders the most recently created pact first (documents current pact_order tie-break)" do
+            expect(subject.first.last_action_date).to eq subject.last.last_action_date
+            expect(subject.first.consumer_version_number).to eq "2"
+            expect(subject.last.consumer_version_number).to eq "1"
+          end
+        end
       end
     end
   end

--- a/spec/lib/pact_broker/matrix/matrix_row_spec.rb
+++ b/spec/lib/pact_broker/matrix/matrix_row_spec.rb
@@ -69,10 +69,13 @@ module PactBroker
           end
         end
 
-        context "when two different pacts share the same last action date (pact_order/verification_id tie-break)" do
+        context "when two different pacts share the same last action date (pact_order tie-break)" do
           before do
             # Two pacts published and verified on the same simulated day, so last_action_date
-            # ties and the query falls through to ordering by pact_order desc, then verification_id desc.
+            # ties and the query falls through to ordering by pact_order desc. The query has a
+            # further verification_id desc tie-break, but it is not exercised here: pact_order is
+            # the pact_publication_id, which is unique per pact, so it always disambiguates first.
+            # The verification_id tie-break is not reachable via the public test-data builder.
             td.create_pact_with_hierarchy("Foo", "1", "Bar")
               .create_verification(provider_version: "10", created_at: day_1)
               .create_pact_with_hierarchy("Foo", "2", "Baz")

--- a/spec/lib/pact_broker/matrix/matrix_row_spec.rb
+++ b/spec/lib/pact_broker/matrix/matrix_row_spec.rb
@@ -87,6 +87,34 @@ module PactBroker
             expect(subject.last.consumer_version_number).to eq "1"
           end
         end
+
+        context "when the row comes from the database" do
+          before do
+            td.create_pact_with_verification("Foo", "1", "Bar", "2")
+          end
+
+          it "returns a real date/time object, not a String, for last_action_date" do
+            expect(subject.first.last_action_date).to be_a(Date).or be_a(Time).or be_a(DateTime)
+          end
+        end
+      end
+
+      describe "#verification_id" do
+        context "when the verification table has not been joined" do
+          subject { MatrixRow.new }
+
+          it "raises an error" do
+            expect { subject.verification_id }.to raise_error("Required table not joined")
+          end
+        end
+      end
+
+      describe "matching_one_selector_for_either_consumer_or_provider" do
+        context "when the number of selectors provided is not 1" do
+          it "raises an ArgumentError" do
+            expect { MatrixRow.default_scope.send(:matching_one_selector_for_either_consumer_or_provider, [], limit: 1) }.to raise_error(ArgumentError, "Expected one selector to be provided, but received 0:  []")
+          end
+        end
       end
     end
   end

--- a/spec/lib/pact_broker/matrix/parse_query_spec.rb
+++ b/spec/lib/pact_broker/matrix/parse_query_spec.rb
@@ -135,6 +135,123 @@ module PactBroker
             expect(subject.last[:ignore_selectors]).to eq []
           end
         end
+
+        context "with the flat q[]key selector encoding (production shape)" do
+          context "single selector" do
+            let(:query) { "q[]pacticipant=Foo&q[]version=1" }
+
+            it "parses one selector" do
+              expect(subject.first).to eq [
+                PactBroker::Matrix::UnresolvedSelector.new(pacticipant_name: "Foo", pacticipant_version_number: "1")
+              ]
+            end
+          end
+
+          context "multiple selectors, keys interleaved per selector" do
+            let(:query) { "q[]pacticipant=Foo&q[]version=1&q[]pacticipant=Bar&q[]version=2" }
+
+            it "groups each pacticipant with its version" do
+              expect(subject.first).to eq [
+                PactBroker::Matrix::UnresolvedSelector.new(pacticipant_name: "Foo", pacticipant_version_number: "1"),
+                PactBroker::Matrix::UnresolvedSelector.new(pacticipant_name: "Bar", pacticipant_version_number: "2")
+              ]
+            end
+          end
+
+          context "multiple flat selectors, pacticipant-only" do
+            let(:query) { "q[]pacticipant=Foo&q[]pacticipant=Bar&q[]pacticipant=Baz" }
+
+            it "parses one selector per pacticipant" do
+              expect(subject.first).to eq [
+                PactBroker::Matrix::UnresolvedSelector.new(pacticipant_name: "Foo"),
+                PactBroker::Matrix::UnresolvedSelector.new(pacticipant_name: "Bar"),
+                PactBroker::Matrix::UnresolvedSelector.new(pacticipant_name: "Baz")
+              ]
+            end
+          end
+
+          context "all pacticipants then all versions (KNOWN FRAGILITY)" do
+            # Rack groups the flat encoding by its repeated-key heuristic, which is
+            # order-dependent. When a client sends all pacticipants before all versions,
+            # the selectors mis-group. Pinned as-is; flagged for the optimisation phase.
+            let(:query) { "q[]pacticipant=Foo&q[]pacticipant=Bar&q[]version=1&q[]version=2" }
+
+            it "mis-groups the selectors (documents current behaviour)" do
+              expect(subject.first).to eq [
+                PactBroker::Matrix::UnresolvedSelector.new(pacticipant_name: "Foo"),
+                PactBroker::Matrix::UnresolvedSelector.new(pacticipant_name: "Bar", pacticipant_version_number: "1"),
+                PactBroker::Matrix::UnresolvedSelector.new(pacticipant_version_number: "2")
+              ]
+            end
+          end
+        end
+
+        context "with a large number of selectors (cardinality tail)" do
+          let(:query) { (1..5).map { |i| "q[][pacticipant]=P#{i}&q[][version]=#{i}" }.join("&") }
+
+          it "parses one selector per pacticipant/version pair" do
+            expect(subject.first.size).to eq 5
+            expect(subject.first.last).to eq(
+              PactBroker::Matrix::UnresolvedSelector.new(pacticipant_name: "P5", pacticipant_version_number: "5")
+            )
+          end
+        end
+
+        context "with a repeated top-level option key" do
+          let(:query) { "environment=test&environment=prod" }
+
+          it "keeps the last value (documents current behaviour)" do
+            expect(subject.last[:environment_name]).to eq "prod"
+          end
+        end
+
+        context "when there is a branch" do
+          let(:query) { "q[][pacticipant]=Foo&q[][branch]=main" }
+
+          it "returns a selector with a branch" do
+            expect(subject.first).to eq [{ pacticipant_name: "Foo", branch: "main" }]
+          end
+        end
+
+        context "when there is a per-selector environment" do
+          let(:query) { "q[][pacticipant]=Foo&q[][environment]=production" }
+
+          it "returns a selector with an environment" do
+            expect(subject.first).to eq [{ pacticipant_name: "Foo", environment_name: "production" }]
+          end
+        end
+
+        context "when there is a per-selector mainBranch" do
+          let(:query) { "q[][pacticipant]=Foo&q[][mainBranch]=true" }
+
+          it "returns a selector with main_branch true" do
+            expect(subject.first).to eq [{ pacticipant_name: "Foo", main_branch: true }]
+          end
+        end
+
+        context "when there is a top-level environment option" do
+          let(:query) { "q[][pacticipant]=Foo&environment=production" }
+
+          it "sets the environment_name option" do
+            expect(subject.last[:environment_name]).to eq "production"
+          end
+        end
+
+        context "when there is a top-level mainBranch option" do
+          let(:query) { "q[][pacticipant]=Foo&mainBranch=true" }
+
+          it "sets the main_branch option" do
+            expect(subject.last[:main_branch]).to eq true
+          end
+        end
+
+        context "when latest is present but empty" do
+          let(:query) { "q[][pacticipant]=Foo&latest=" }
+
+          it "does not set the latest option" do
+            expect(subject.last).to_not have_key(:latest)
+          end
+        end
       end
     end
   end

--- a/spec/lib/pact_broker/matrix/parse_query_spec.rb
+++ b/spec/lib/pact_broker/matrix/parse_query_spec.rb
@@ -171,9 +171,25 @@ module PactBroker
           end
 
           context "all pacticipants then all versions (KNOWN FRAGILITY)" do
-            # Rack groups the flat encoding by its repeated-key heuristic, which is
-            # order-dependent. When a client sends all pacticipants before all versions,
-            # the selectors mis-group. Pinned as-is; flagged for the optimisation phase.
+            # This query string is parsed by Rack::Utils.parse_nested_query, which builds
+            # the params hash key-by-key as it scans the query left to right:
+            #   - `q[]=` appends the value to the array at `q`
+            #   - `q[key]=` sets `key` on the hash at `q`
+            #   - `q[][key]=` appends a new hash to the array at `q`, then sets `key` on it
+            #     (a fresh hash is started only when a `q[]key=` pair repeats a key that the
+            #     "current" (last) hash in the array already has)
+            # This spec uses the flat `q[]key=` encoding (no `[]` around the sub-key), which
+            # is not one of Rack's documented forms above but is accepted by parse_nested_query
+            # as shorthand for `q[][key]=`: each `q[]pacticipant=` / `q[]version=` pair is
+            # merged into the last hash in the `q` array, and only starts a new hash when the
+            # key it's setting is already present on that last hash. Because this query sends
+            # pacticipant, pacticipant, version, version (rather than interleaving
+            # pacticipant/version pairs per selector), the repeated `pacticipant` key forces a
+            # new hash after "Foo", but the two `version` keys then land on the two most
+            # recently started hashes ("Bar" and a new empty one) instead of pairing back up
+            # with "Foo" and "Bar" as separate selectors. The grouping is an artifact of key
+            # order in the query string, not of selector intent — hence "mis-groups" below.
+            # Pinned as-is; flagged for the optimisation phase.
             let(:query) { "q[]pacticipant=Foo&q[]pacticipant=Bar&q[]version=1&q[]version=2" }
 
             it "mis-groups the selectors (documents current behaviour)" do

--- a/spec/lib/pact_broker/matrix/repository_latestby_filtering_spec.rb
+++ b/spec/lib/pact_broker/matrix/repository_latestby_filtering_spec.rb
@@ -1,0 +1,78 @@
+require "pact_broker/matrix/repository"
+
+module PactBroker
+  module Matrix
+    describe Repository do
+      describe "post-query filter ordering (latestby, success, limit)" do
+        # Foo has three consumer versions, each verified by a distinct provider version.
+        before do
+          td.create_pact_with_verification("Foo", "1", "Bar", "10")
+            .add_day
+            .create_pact_with_verification("Foo", "2", "Bar", "20")
+            .add_day
+            .create_pact_with_verification("Foo", "3", "Bar", "30")
+        end
+
+        let(:selectors) do
+          [
+            UnresolvedSelector.new(pacticipant_name: "Foo"),
+            UnresolvedSelector.new(pacticipant_name: "Bar")
+          ]
+        end
+
+        subject { Repository.new.find(selectors, options) }
+
+        context "when limit is smaller than the row count and latestby is set" do
+          let(:options) { { limit: 2, latestby: "cvpv" } }
+
+          it "applies the limit at the DB before the latestby dedup" do
+            # The DB fetches the newest `limit` rows first, THEN latestby dedups them.
+            # Pinning the resulting count documents that limit and latestby interact.
+            expect(subject.rows.size).to be <= 2
+          end
+
+          it "keeps the most recent consumer versions" do
+            consumer_versions = subject.rows.map(&:consumer_version_number)
+            expect(consumer_versions).to include("3")
+          end
+        end
+
+        context "when no latestby is set" do
+          let(:options) { { limit: 10 } }
+
+          it "returns a row per pact/verification (EveryRow path)" do
+            expect(subject.rows.size).to eq 3
+          end
+        end
+      end
+
+      describe "success filter runs after latestby" do
+        before do
+          # Latest verification for Foo v1 fails; an earlier one succeeded.
+          td.create_pact_with_hierarchy("Foo", "1", "Bar")
+            .create_verification(provider_version: "1", success: true, number: 1)
+            .create_verification(provider_version: "2", success: false, number: 2)
+        end
+
+        let(:selectors) do
+          [
+            UnresolvedSelector.new(pacticipant_name: "Foo"),
+            UnresolvedSelector.new(pacticipant_name: "Bar")
+          ]
+        end
+
+        subject { Repository.new.find(selectors, options) }
+
+        context "latestby cvpv with success:[true]" do
+          let(:options) { { latestby: "cvpv", success: [true] } }
+
+          it "filters on the success of the row surviving latestby (documents current behaviour)" do
+            # apply_latestby picks the latest provider version per pair FIRST,
+            # then apply_success_filter keeps only success == true rows.
+            expect(subject.rows.map(&:success)).to all(eq(true))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/pact_broker/matrix/repository_latestby_filtering_spec.rb
+++ b/spec/lib/pact_broker/matrix/repository_latestby_filtering_spec.rb
@@ -83,20 +83,25 @@ module PactBroker
       end
 
       describe "success filter runs after latestby" do
-        # Two verifications for the SAME (consumer_version, provider_version) pair
-        # (Foo v1 / Bar v5): an earlier one that succeeded, and a later one that failed.
-        # Because apply_latestby (via the DB's per-pact_version/provider_version "latest
-        # verification" view - see the NOTE above) keeps only the actual latest
-        # verification for this pair BEFORE apply_success_filter runs, the earlier
-        # successful verification is never in the running for the success filter at all.
+        # Two verifications for Foo v1 / Bar against DISTINCT provider versions (5 and 6),
+        # where the HIGHER provider_version_order verification (6) FAILS and the LOWER one
+        # (5) SUCCEEDS. Because the two provider versions are distinct, the SQL materialized
+        # table `latest_verification_id_for_pact_version_and_provider_version` (see the NOTE
+        # above) does not collapse them - BOTH rows survive to reach Ruby.
         #
-        # If success filtering ran BEFORE latestby instead, the successful verification
-        # would survive a success:[true] filter, and there would be a row left for
-        # latestby to dedup - so the pair WOULD appear in the result.
+        # With latestby: "cvp" (group by consumer+provider, ignoring provider_version), the
+        # Ruby-level apply_latestby step is what picks a single row per integration, and it
+        # is the discriminating operation here:
+        #   - Real order (apply_latestby then apply_success_filter): apply_latestby picks
+        #     the row with the highest provider_version_order - pv 6, which failed. Then
+        #     apply_success_filter([true]) drops that row because it did not succeed.
+        #   - Reversed order (apply_success_filter then apply_latestby): apply_success_filter
+        #     would first drop the failing pv 6 row, leaving only the successful pv 5 row,
+        #     which apply_latestby would then keep - producing 1 row instead of 0.
         before do
           td.create_pact_with_hierarchy("Foo", "1", "Bar")
             .create_verification(provider_version: "5", success: true, number: 1)
-            .create_verification(provider_version: "5", success: false, number: 2)
+            .create_verification(provider_version: "6", success: false, number: 2)
         end
 
         let(:selectors) do
@@ -108,15 +113,15 @@ module PactBroker
 
         subject { Repository.new.find(selectors, options) }
 
-        context "latestby cvpv with success:[true]" do
-          let(:options) { { latestby: "cvpv", success: [true] } }
+        context "latestby cvp with success:[true]" do
+          let(:options) { { latestby: "cvp", success: [true] } }
 
-          it "does not resurrect the earlier successful verification once latestby has picked the (failing) latest row for the pair" do
-            # Pinning the ACTUAL observed behaviour: latestby keeps the truly latest
-            # verification for this pair (number 2, success: false). apply_success_filter
-            # then runs on that single row and drops it, because success:[true] excludes
-            # it. The pair is NOT resurrected via the earlier successful verification -
-            # the result is empty.
+          it "does not resurrect the earlier successful verification once latestby has picked the (failing) highest provider_version_order row for the pair" do
+            # Pinning the ACTUAL observed behaviour: apply_latestby picks the row with the
+            # highest provider_version_order for the pair (pv 6, success: false).
+            # apply_success_filter then runs on that single row and drops it, because
+            # success:[true] excludes it. The pair is NOT resurrected via the earlier
+            # successful (pv 5) verification - the result is empty.
             expect(subject.rows.size).to eq 0
           end
         end

--- a/spec/lib/pact_broker/matrix/repository_latestby_filtering_spec.rb
+++ b/spec/lib/pact_broker/matrix/repository_latestby_filtering_spec.rb
@@ -3,14 +3,35 @@ require "pact_broker/matrix/repository"
 module PactBroker
   module Matrix
     describe Repository do
-      describe "post-query filter ordering (latestby, success, limit)" do
-        # Foo has three consumer versions, each verified by a distinct provider version.
+      describe "post-query filter ordering (limit vs latestby)" do
+        # NOTE on why this test uses latestby: "cvp" rather than "cvpv":
+        # MatrixRow (the model used whenever `latestby` is set) is built by joining to the
+        # `latest_verification_id_for_pact_version_and_provider_version` DB view, which
+        # already collapses multiple verifications for the SAME (pact_version,
+        # provider_version) down to a single row *in SQL*, before Ruby ever sees the data.
+        # This was confirmed empirically: constructing several verifications that share the
+        # same (consumer_version, provider_version) pair produces only ONE MatrixRow row for
+        # that pair regardless of whether `limit` is set - so a "cvpv" fixture can never
+        # exercise apply_latestby's Ruby-level dedup at all, and can't discriminate the
+        # limit/latestby ordering.
+        # "cvp" (consumer_version + provider, ignoring provider_version) does NOT get this
+        # SQL-level pre-dedup: each distinct provider_version verified by the consumer
+        # version produces a genuinely separate MatrixRow row, and apply_latestby's Ruby
+        # code is what collapses them down to the one with the highest provider_version_order.
+        # That gives a real, empirically-verified case where the DB limit (applied before
+        # the Ruby dedup) can truncate away an entire integration that a
+        # dedup-before-limit ordering would have kept room for.
+        #
+        # pairA (Foo v1 / Bar) has THREE verifications against three DIFFERENT provider
+        # versions (10, 11, 12), created AFTER pairB (Foo v2 / Bar v20), so all 3 of
+        # pairA's rows have a newer last_action_date than pairB's single row.
         before do
-          td.create_pact_with_verification("Foo", "1", "Bar", "10")
+          td.create_pact_with_verification("Foo", "2", "Bar", "20", true)
             .add_day
-            .create_pact_with_verification("Foo", "2", "Bar", "20")
-            .add_day
-            .create_pact_with_verification("Foo", "3", "Bar", "30")
+            .create_pact_with_hierarchy("Foo", "1", "Bar")
+            .create_verification(provider_version: "10", success: true, number: 1)
+            .create_verification(provider_version: "11", success: false, number: 2)
+            .create_verification(provider_version: "12", success: true, number: 3)
         end
 
         let(:selectors) do
@@ -22,18 +43,33 @@ module PactBroker
 
         subject { Repository.new.find(selectors, options) }
 
-        context "when limit is smaller than the row count and latestby is set" do
-          let(:options) { { limit: 2, latestby: "cvpv" } }
+        context "when latestby is set but no limit (baseline)" do
+          let(:options) { { latestby: "cvp" } }
 
-          it "applies the limit at the DB before the latestby dedup" do
-            # The DB fetches the newest `limit` rows first, THEN latestby dedups them.
-            # Pinning the resulting count documents that limit and latestby interact.
-            expect(subject.rows.size).to be <= 2
+          it "dedups pairA's 3 provider versions down to 1, keeping both integrations" do
+            # Confirms the fixture's baseline shape: latestby collapses pairA to a single
+            # row (the highest provider_version_order, pv 12), and pairB is untouched.
+            expect(subject.rows.size).to eq 2
+            expect(subject.rows.map(&:consumer_version_number).sort).to eq ["1", "2"]
           end
+        end
 
-          it "keeps the most recent consumer versions" do
-            consumer_versions = subject.rows.map(&:consumer_version_number)
-            expect(consumer_versions).to include("3")
+        context "when limit is smaller than the row count and latestby is set" do
+          let(:options) { { limit: 2, latestby: "cvp" } }
+
+          it "applies the limit at the DB before the latestby dedup, losing pairB entirely" do
+            # Pinning the ACTUAL observed behaviour: the DB limit (query.limit, applied
+            # inside query_matrix BEFORE apply_latestby runs) takes the top 2 raw rows by
+            # last_action_date - both from pairA's cluster (pv 12 and pv 11) - because
+            # pairA's rows all sort ahead of pairB's older row. latestby then dedups those
+            # 2 rows down to 1. pairB (Foo v2 / Bar v20) is lost entirely.
+            #
+            # If latestby ran BEFORE the limit instead, the full 4-row set would first dedup
+            # to 2 rows (one per integration, as shown in the baseline context above), and a
+            # limit of 2 would keep BOTH - so pairB would NOT be lost.
+            expect(subject.rows.size).to eq 1
+            expect(subject.rows.map(&:consumer_version_number)).to eq ["1"]
+            expect(subject.rows.map(&:provider_version_number)).to eq ["12"]
           end
         end
 
@@ -41,17 +77,26 @@ module PactBroker
           let(:options) { { limit: 10 } }
 
           it "returns a row per pact/verification (EveryRow path)" do
-            expect(subject.rows.size).to eq 3
+            expect(subject.rows.size).to eq 4
           end
         end
       end
 
       describe "success filter runs after latestby" do
+        # Two verifications for the SAME (consumer_version, provider_version) pair
+        # (Foo v1 / Bar v5): an earlier one that succeeded, and a later one that failed.
+        # Because apply_latestby (via the DB's per-pact_version/provider_version "latest
+        # verification" view - see the NOTE above) keeps only the actual latest
+        # verification for this pair BEFORE apply_success_filter runs, the earlier
+        # successful verification is never in the running for the success filter at all.
+        #
+        # If success filtering ran BEFORE latestby instead, the successful verification
+        # would survive a success:[true] filter, and there would be a row left for
+        # latestby to dedup - so the pair WOULD appear in the result.
         before do
-          # Latest verification for Foo v1 fails; an earlier one succeeded.
           td.create_pact_with_hierarchy("Foo", "1", "Bar")
-            .create_verification(provider_version: "1", success: true, number: 1)
-            .create_verification(provider_version: "2", success: false, number: 2)
+            .create_verification(provider_version: "5", success: true, number: 1)
+            .create_verification(provider_version: "5", success: false, number: 2)
         end
 
         let(:selectors) do
@@ -66,10 +111,13 @@ module PactBroker
         context "latestby cvpv with success:[true]" do
           let(:options) { { latestby: "cvpv", success: [true] } }
 
-          it "filters on the success of the row surviving latestby (documents current behaviour)" do
-            # apply_latestby picks the latest provider version per pair FIRST,
-            # then apply_success_filter keeps only success == true rows.
-            expect(subject.rows.map(&:success)).to all(eq(true))
+          it "does not resurrect the earlier successful verification once latestby has picked the (failing) latest row for the pair" do
+            # Pinning the ACTUAL observed behaviour: latestby keeps the truly latest
+            # verification for this pair (number 2, success: false). apply_success_filter
+            # then runs on that single row and drops it, because success:[true] excludes
+            # it. The pair is NOT resurrected via the earlier successful verification -
+            # the result is empty.
+            expect(subject.rows.size).to eq 0
           end
         end
       end

--- a/spec/lib/pact_broker/matrix/resolved_selector_spec.rb
+++ b/spec/lib/pact_broker/matrix/resolved_selector_spec.rb
@@ -123,6 +123,8 @@ module PactBroker
             its(:description) { is_expected.to eq "any version of Foo" }
             its(:only_pacticipant_name_specified?) { is_expected.to be true }
           end
+
+          its(:version_does_not_exist_description) { is_expected.to eq "" }
         end
 
         context "for non existing version" do
@@ -213,6 +215,26 @@ module PactBroker
             its(:description) { is_expected.to eq "the latest version of Foo from the main branch (no versions exist for this branch)" }
             its(:version_does_not_exist_description) { is_expected.to eq "No version of Foo from the main branch exists" }
           end
+
+          context "when it was specified by latest only, with no matching version" do
+            let(:latest) { true }
+
+            its(:description) { is_expected.to eq "the latest version of Foo (no such version exists)" }
+          end
+        end
+
+        context "for a non existing pacticipant" do
+          let(:subject) do
+            PactBroker::Matrix::ResolvedSelector.for_non_existing_pacticipant(original_selector, :specified, true)
+          end
+
+          let(:original_selector) do
+            {
+              pacticipant_name: "Foo"
+            }
+          end
+
+          its(:description) { is_expected.to eq "any version of Foo (no such pacticipant exists)" }
         end
       end
     end

--- a/spec/lib/pact_broker/matrix/service_spec.rb
+++ b/spec/lib/pact_broker/matrix/service_spec.rb
@@ -1,5 +1,7 @@
 require "pact_broker/matrix/service"
 require "pact_broker/matrix/unresolved_selector"
+require "pact_broker/pacticipants/service"
+require "pact_broker/versions/service"
 
 module PactBroker
   module Matrix
@@ -40,6 +42,17 @@ module PactBroker
           it "calls the can_i_deploy method" do
             expect(Service).to receive(:can_i_deploy).with(unresolved_selectors, options).and_call_original
             subject
+          end
+        end
+
+        context "when a pacticipant object (rather than a pacticipant_name) is passed in" do
+          let(:pacticipant) { PactBroker::Pacticipants::Service.find_pacticipant_by_name("B") }
+          let(:latest_main_branch_version) { PactBroker::Versions::Service.find_latest_version_from_main_branch(pacticipant) }
+
+          subject { Service.can_i_merge(pacticipant: pacticipant, latest_main_branch_version: latest_main_branch_version) }
+
+          it "returns true because the mergeable status is true" do
+            expect(subject).to be true
           end
         end
       end
@@ -222,6 +235,20 @@ module PactBroker
 
           it "returns an error message" do
             expect(subject.last).to include "The limit"
+          end
+        end
+
+        context "when an ignore selector has both a version and latest specified" do
+          let(:selectors) { [] }
+
+          let(:options) do
+            {
+              ignore_selectors: [{ pacticipant_name: "Foo", pacticipant_version_number: "1", latest: true }]
+            }
+          end
+
+          it "returns an error message" do
+            expect(subject).to include "A version number and latest flag cannot both be specified for Foo to ignore"
           end
         end
       end


### PR DESCRIPTION
## What & why

`GET /matrix` is the most performance-critical endpoint in the Broker (largest share of total span time in PactFlow, ~2× the next endpoint, one of the most frequently hit). Before optimising its query engine, this PR builds a **behaviour-pinning test safety net** so a later optimisation phase can change the engine with confidence that observable behaviour — including the de-facto public JSON/text contracts consumed by customer integrations and the `can-i-deploy` CLI — has not changed.

**Tests only — zero production (`lib/`) code changes.** These are *characterisation* tests: they pin current behaviour (even quirks), they do not judge it.

> **Related:** the same coverage review that produced the extra tests below also found dead code. That removal lives in a separate PR, **#968** (`chore(matrix): remove dead code found via coverage review`), so this PR stays purely additive.

## Two layers of tests

**Layer 2 — query-engine behavioural specs** (cross-DB safe: Postgres/MySQL/SQLite, no DB-id assertions):
- `ParseQuery` production encodings — flat `q[]key` vs nested `q[][key]`, cardinality, repeated top-level keys, and the previously-untested `branch`/`environment`/`mainBranch` params. Includes a deliberately-pinned `# KNOWN FRAGILITY`: the order-dependent flat-encoding selector **mis-grouping** (Rack's `parse_nested_query` array-of-hashes heuristic), documented as-is for the optimisation phase.
- Repository filter ordering — `limit` at the DB *before* the Ruby-side `apply_latestby`, and `apply_success_filter` *after* `apply_latestby`. Fixtures are constructed so each spec **fails if the order is reversed** (pins 1 row / 0 rows).
- Resource param-threading; `order_by_last_action_date` ordering — all three tie-break levels pinned: `last_action_date` desc, then `pact_order` desc (two different pacts), then `verification_id` desc (one pact verified by two provider versions, so `pact_order` also ties).

**Layer 1 — HTTP golden masters** (`approvals` gem):
- `/matrix`: distilled DB-independent decision snapshots + scrubbed hal+json full-body + text/plain body (the ASCII table the CLI consumes). Full-body snapshots sqlite-gated for ID determinism.
- `/can-i-deploy`: environment, tag-to-tag, validation-error, and ignore-selector decisions.

## Coverage-driven test additions

A full-suite SimpleCov run showed the HTTP/decorator layer at 100% but gaps in the query/reasoning engine. Added characterisation tests for the untested **LIVE** behaviours: the "no such version/pacticipant exists" description strings, `NoDependenciesMissing#type`, `can_i_merge`'s object-arg branch, ignore-selector version+latest validation, the "Required table not joined" guard, and the single-selector `ArgumentError` guard. (The dead code found in the same pass is removed in **#968**, not here.)

## Verification
- Full suite: 4481 examples, 11 failures — all 11 are a **pre-existing** OpenAPI test-registration issue (`publish_pact_all_in_one_spec.rb`, `get_provider_pacts_for_verification_spec.rb`), zero matrix/can-i-deploy failures.
- Layer-2 behavioural specs are cross-DB safe; full-body golden masters are sqlite-gated.

🤖 Assisted-by: Claude Code
