### PR TITLE
chore(matrix): remove dead code found via coverage review (#966)

### DIFF
--- a/lib/pact_broker/api/decorators/reason_decorator.rb
+++ b/lib/pact_broker/api/decorators/reason_decorator.rb
@@ -5,13 +5,8 @@ module PactBroker
     module Decorators
       class ReasonDecorator
         def initialize(reason)
-          if reason.is_a?(PactBroker::Matrix::IgnoredReason)
-            @reason = reason.root_reason
-            @ignored = true
-          else
-            @reason = reason
-            @ignored = false
-          end
+          @reason = reason
+          @ignored = false
         end
 
         def to_s

--- a/lib/pact_broker/matrix/deployment_status_summary.rb
+++ b/lib/pact_broker/matrix/deployment_status_summary.rb
@@ -174,10 +174,6 @@ module PactBroker
         end.flatten
       end
 
-      def missing_specified_version_reasons(selectors)
-        selectors.collect(&:version_does_not_exist_description)
-      end
-
       def pact_not_verified_by_required_provider_version(integration)
         PactNotVerifiedByRequiredProviderVersion.new(*selectors_for(integration))
       end
@@ -238,24 +234,6 @@ module PactBroker
             ResolvedSelector.for_pacticipant(row.provider, {}, :inferred, false)
           [dummy_consumer_selector, dummy_provider_selector]
         end.flatten
-      end
-
-      # experimental
-      def warnings_for_missing_interactions
-        considered_rows.select(&:success).collect do | row |
-          begin
-            if row.verification.interactions_missing_test_results.any? && !row.verification.all_interactions_missing_test_results?
-              InteractionsMissingVerifications.new(selector_for(row.consumer_name, row.consumer_version_number), selector_for(row.provider_name, row.provider_version_number), row.verification.interactions_missing_test_results)
-            end
-          rescue StandardError => e
-            logger.warn("Error determining if there were missing interaction verifications", e)
-            nil
-          end
-        end.compact.tap { |it| report_missing_interaction_verifications(it) if it.any? }
-      end
-
-      def report_missing_interaction_verifications(messages)
-        logger.warn("Interactions missing verifications", messages)
       end
     end
   end

--- a/lib/pact_broker/matrix/integration.rb
+++ b/lib/pact_broker/matrix/integration.rb
@@ -45,47 +45,8 @@ module PactBroker
         other.is_a?(Integration) && consumer_id == other.consumer_id && provider_id == other.provider_id && other.required? == required?
       end
 
-      def <=> other
-        comparison = consumer_name <=> other.consumer_name
-        return comparison if comparison != 0
-        provider_name <=> other.provider_name
-      end
-
-      def to_hash
-        {
-          consumer_name: consumer_name,
-          consumer_id: consumer_id,
-          provider_name: provider_name,
-          provider_id: provider_id,
-        }
-      end
-
       def pacticipant_names
         [consumer_name, provider_name]
-      end
-
-      def to_s
-        "Integration between #{consumer_name} (id=#{consumer_id}) and #{provider_name} (id=#{provider_id}) required=#{required?}"
-      end
-
-      def involves_consumer_with_id?(consumer_id)
-        self.consumer_id == consumer_id
-      end
-
-      def involves_consumer_with_names?(consumer_names)
-        consumer_names.include?(self.consumer_name)
-      end
-
-      def involves_provider_with_name?(provider_name)
-        self.provider_name == provider_name
-      end
-
-      def involves_consumer_with_name?(consumer_name)
-        self.consumer_name == consumer_name
-      end
-
-      def involves_pacticipant_with_name?(pacticipant_name)
-        pacticipant_names.include?(pacticipant_name)
       end
 
       def matches_pacticipant_ids?(other)

--- a/lib/pact_broker/matrix/matrix_row_instance_methods.rb
+++ b/lib/pact_broker/matrix/matrix_row_instance_methods.rb
@@ -44,10 +44,6 @@ module PactBroker
         name1 <=> name2
       end
 
-      def to_s
-        "#{consumer_name} v#{consumer_version_number} #{provider_name} #{provider_version_number} #{success}"
-      end
-
       def compare_number_desc number1, number2
         if number1 && number2
           number2 <=> number1
@@ -60,14 +56,6 @@ module PactBroker
 
       def eql?(obj)
         (obj.class == model) && (obj.values == values)
-      end
-
-      def pacticipant_names
-        [consumer_name, provider_name]
-      end
-
-      def involves_pacticipant_with_name?(pacticipant_name)
-        pacticipant_name.include?(pacticipant_name)
       end
 
       def provider_version_id

--- a/lib/pact_broker/matrix/parse_query.rb
+++ b/lib/pact_broker/matrix/parse_query.rb
@@ -26,11 +26,6 @@ module PactBroker
           options[:latestby] = params["latestby"]
         end
 
-        # Don't think this is used anywhere...
-        if params.key?("days") && params["days"] != ""
-          options[:days] = params["days"].to_i
-        end
-
         if params.key?("limit") && params["limit"] != ""
           options[:limit] = params["limit"]
         else

--- a/lib/pact_broker/matrix/reason.rb
+++ b/lib/pact_broker/matrix/reason.rb
@@ -21,24 +21,6 @@ module PactBroker
       end
     end
 
-    class IgnoredReason
-      attr_reader :root_reason
-
-      # todo equals
-
-      def initialize(root_reason)
-        @root_reason = root_reason
-      end
-
-      def == other
-        other.is_a?(IgnoredReason) && other.root_reason == self.root_reason
-      end
-
-      def type
-        :info
-      end
-    end
-
     class ErrorReasonWithTwoSelectors < ErrorReason
       attr_reader :consumer_selector, :provider_selector
 
@@ -51,14 +33,6 @@ module PactBroker
         super(other) &&
           consumer_selector == other.consumer_selector &&
           provider_selector == other.provider_selector
-      end
-
-      def selectors
-        [consumer_selector, provider_selector]
-      end
-
-      def to_s
-        "#{self.class} consumer_selector=#{consumer_selector}, provider_selector=#{provider_selector}"
       end
     end
 
@@ -93,14 +67,6 @@ module PactBroker
       def == other
         super(other) && selector == other.selector
       end
-
-      def selectors
-        [selector]
-      end
-
-      def to_s
-        "#{self.class} selector=#{selector}"
-      end
     end
 
     class Warning < Reason
@@ -123,27 +89,11 @@ module PactBroker
       def == other
         super(other) && selector == other.selector
       end
-
-      def selectors
-        [selector]
-      end
-
-      def to_s
-        "#{self.class} selector=#{selector}"
-      end
     end
 
-    class NoEnvironmentSpecified < Warning
-      def selectors
-        []
-      end
-    end
+    class NoEnvironmentSpecified < Warning; end
 
-    class SelectorWithoutPacticipantVersionNumberSpecified < Warning
-      def selectors
-        []
-      end
-    end
+    class SelectorWithoutPacticipantVersionNumberSpecified < Warning; end
 
     # The pact for the required consumer version has been
     # successfully verified by the required provider version

--- a/lib/pact_broker/matrix/resolved_selector.rb
+++ b/lib/pact_broker/matrix/resolved_selector.rb
@@ -124,14 +124,6 @@ module PactBroker
         self[:environment_name]
       end
 
-      def most_specific_criterion
-        if pacticipant_version_id
-          { pacticipant_version_id: pacticipant_version_id }
-        else
-          { pacticipant_id: pacticipant_id }
-        end
-      end
-
       def only_pacticipant_name_specified?
         !!pacticipant_name && self[:original_selector].without(:pacticipant_name).none?{ |_key, value| value }
       end

--- a/lib/pact_broker/matrix/unresolved_selector.rb
+++ b/lib/pact_broker/matrix/unresolved_selector.rb
@@ -22,14 +22,6 @@ module PactBroker
         self[:pacticipant_version_number]
       end
 
-      def latest?
-        !!latest
-      end
-
-      def overall_latest?
-        latest? && !tag && !branch
-      end
-
       def latest
         self[:latest]
       end
@@ -78,11 +70,6 @@ module PactBroker
 
       def pacticipant_version_number= pacticipant_version_number
         self[:pacticipant_version_number] = pacticipant_version_number
-      end
-
-      # TODO delete this once docker image uses new selector class for clean
-      def max_age= max_age
-        self[:max_age] = max_age
       end
 
       def max_age

--- a/spec/lib/pact_broker/matrix/integration_spec.rb
+++ b/spec/lib/pact_broker/matrix/integration_spec.rb
@@ -453,49 +453,6 @@ module PactBroker
           end
         end
 
-        describe "when verification results are published missing tests for some interactions" do
-          let(:pact_content) do
-            {
-              "interactions" => [
-                {
-                  "description" => "desc1"
-                },{
-                  "description" => "desc2"
-                }
-              ]
-            }
-          end
-
-          let(:verification_tests) do
-            [
-              {
-                "interactionDescription" => "desc1"
-              }
-            ]
-          end
-
-          before do
-            td.create_consumer("Foo")
-              .create_provider("Bar")
-              .create_consumer_version
-              .create_pact(json_content: pact_content.to_json)
-              .create_verification(provider_version: "1", test_results: { tests: verification_tests })
-          end
-
-          let(:selectors) do
-            [
-              UnresolvedSelector.new(pacticipant_name: "Foo", latest: true),
-              UnresolvedSelector.new(pacticipant_name: "Bar", latest: true)
-            ]
-          end
-
-          let(:options) { { latestby: "cvpv"} }
-
-          xit "should include a warning" do
-            expect(subject.deployment_status_summary.reasons.last).to be_a(PactBroker::Matrix::InteractionsMissingVerifications)
-          end
-        end
-
         describe "when adding a new provider" do
           before do
             td.publish_pact(consumer_name: "c1", provider_name: "p1", consumer_version_number: "1")


### PR DESCRIPTION
## What

Removes **28 methods across 6 files** in the matrix / can-i-deploy code that have **zero callers** anywhere in `lib/` or `spec/` (verified by exhaustive grep, including dynamic dispatch and decorator duck-typing).

Each change is a self-contained `chore(matrix): remove …` commit so they can be reviewed and cherry-picked individually:

| Commit | Removes |
|---|---|
| `remove dead Integration predicate/comparison methods` | `Integration#<=>`, `#to_hash`, `#to_s`, and all 5 `involves_*` methods |
| `remove dead MatrixRow instance methods` | `MatrixRowInstanceMethods#to_s`, `#pacticipant_names`, `#involves_pacticipant_with_name?` |
| `remove dead ResolvedSelector#most_specific_criterion` | `ResolvedSelector#most_specific_criterion` |
| `remove dead UnresolvedSelector setter and predicates` | `UnresolvedSelector#max_age=`, `#latest?`, `#overall_latest?` |
| `remove unused days query param` | the `options[:days]` block in `ParseQuery` (comment: "Don't think this is used anywhere") |
| `remove orphaned and experimental deployment-status methods` | `missing_specified_version_reasons` + the `# experimental` `warnings_for_missing_interactions` / `report_missing_interaction_verifications` (and the one `xit`-skipped spec that covered them) |
| `remove dead IgnoredReason class and unused reason interface methods` | the never-constructed `IgnoredReason` class (+ its now-unreachable `is_a?` branch in `ReasonDecorator`) and the unused `#selectors`/`#to_s` methods across the reason subclasses |

## Why / provenance

This came out of a **code-coverage review of the matrix/can-i-deploy test safety net in #966**. A full-suite SimpleCov run showed the HTTP/decorator layer at 100% but pockets of uncovered code in the query/reasoning engine. Investigating each gap, these methods turned out to have no callers at all — dead code rather than a behavioural coverage gap. (The live-but-untested paths found in the same review got characterisation tests added in #966 instead.)

One of the removed methods, `MatrixRowInstanceMethods#involves_pacticipant_with_name?`, also contained a latent bug (a shadowed parameter making it always return `true`) — it is dead, so it is removed rather than fixed.

## Effect on coverage

With the dead code gone, the affected files rise toward full coverage: `integration.rb` 76→100%, `unresolved_selector.rb` 94→100%, `parse_query.rb` 98→100%, `reason.rb` 79→92%.

## Kept deliberately

All reason `#==` and `#type` methods are kept (the `#==` methods are exercised by existing `eq [...]` array assertions in `deployment_status_summary_spec.rb`), along with `Integration#from_hash`/`#pacticipant_names`, `MatrixRow#<=>`/`#last_action_date`/`#return_or_raise_if_not_set`, the `max_age` reader, and `ResolvedSelector#latest?` (a different, live method).

## Verification

Branches from `master`; the matrix (271 examples), reason-decorator, can-i-deploy, and deployment-status specs all pass with zero failures. No live code removed; no assertion weakened.

🤖 Assisted-by: Claude Code
