### PR TITLE
docs: fix Pact Matrix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Please read the [UPGRADING.md](UPGRADING.md) documentation before upgrading your
 
 The Pact Broker follows the [semantic versioning](https://semver.org/) scheme.
 
-[decouple]: https://www.rea-group.com/blog/enter-the-pact-matrix-or-how-to-decouple-the-release-cycles-of-your-microservices/
+[decouple]: https://docs.pact.io/pact_broker/can_i_deploy
 [pact]: https://github.com/pact-foundation/pact-ruby
 [nerf]: https://github.com/pact-foundation/pact_broker/wiki/pact-broker-ci-nerf-gun
 [different-teams]: https://github.com/pact-foundation/pact-ruby/wiki/Using-pact-where-the-consumer-team-is-different-from-the-provider-team


### PR DESCRIPTION
## Summary

- replace the broken REA article reference in the README
- link to the maintained Pact documentation for the Pact Matrix and `can-i-deploy`

Closes #970

## Verification

- confirmed the old URL returns HTTP 404
- confirmed the replacement returns HTTP 200 and documents the Pact Matrix
- verified the README reference pair and ran `git diff --check`