### PR TITLE
perf(matrix): flatten selector union to prevent quadratic query nesting

### DIFF
--- a/lib/pact_broker/domain/version.rb
+++ b/lib/pact_broker/domain/version.rb
@@ -241,9 +241,11 @@ module PactBroker
         # @return Sequel::Dataset<PactBroker::Domain::Version>
         def ids_for_selectors(unresolved_selectors)
           # Need the select at the start and at the end to stop extra columns being returned (eg. branch name, environment name)
+          # from_self: false keeps this a single flat UNION. Sequel's default would wrap the
+          # accumulated dataset in a new subquery for every selector, nesting it N-1 deep.
           unresolved_selectors
             .collect{ |selector| self.select(Sequel[:versions][:id]).for_selector(selector).select(:id) }
-            .reduce(&:union)
+            .reduce { |all_ids, ids| all_ids.union(ids, from_self: false) }
         end
 
         def pacticipants_set

--- a/spec/lib/pact_broker/domain/version_spec.rb
+++ b/spec/lib/pact_broker/domain/version_spec.rb
@@ -495,6 +495,24 @@ module PactBroker
           expect(all.first.associations[:current_deployed_versions].first.environment.name).to eq "prod"
         end
       end
+
+      describe "ids_for_selectors" do
+        def selectors_for(pacticipant_names)
+          pacticipant_names.collect { |name| PactBroker::Matrix::UnresolvedSelector.new(pacticipant_name: name, latest: true) }
+        end
+
+        # Each redundant layer is another subquery the database has to plan.
+        def subquery_nesting_depth(dataset)
+          dataset.sql.scan("SELECT * FROM (").count
+        end
+
+        it "does not nest the query more deeply as the number of selectors grows" do
+          two = Version.ids_for_selectors(selectors_for(%w{App1 App2}))
+          ten = Version.ids_for_selectors(selectors_for((1..10).collect { |i| "App#{i}" }))
+
+          expect(subquery_nesting_depth(ten)).to eq subquery_nesting_depth(two)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

`PactBroker::Domain::Version.ids_for_selectors` builds a dataset per unresolved selector and combines them with `reduce(&:union)`. Sequel's `union` defaults to `from_self: true`, which rewraps the *entire accumulated dataset* in a new subquery on every step. With N selectors the resulting SQL nests **N-1** layers of `SELECT * FROM (...)`.

The matrix / can-i-deploy query infers one selector per integrated pacticipant, so a hub application (e.g. a shared library that hundreds of consumers depend on) running `can-i-deploy --to-environment prod` produces hundreds of stacked subqueries. The database has to plan every layer, which brings query planning to a halt — the string length is unremarkable, but the nesting is pathological.

Measured nesting depth (`SELECT * FROM (` count) for `latest: true` selectors:

| selectors | before | after |
|-----------|--------|-------|
| 2         | 1      | 0     |
| 10        | 9      | 0     |
| 100       | 99     | 0     |

## Fix

Pass `from_self: false` so the per-selector arms compose into a single flat N-way `UNION` instead of a tower of subqueries. The individual arms carry no `ORDER BY` or `LIMIT`, so no wrapping subquery is needed to preserve their semantics (the `environment` selector's own internal union wrapping, applied by `for_selector`, is unaffected).

This also covers the other call sites of `ids_for_selectors` (`matrix_row_dataset_module`, `matrix_row_verification_dataset_module`, `integration_row`).

## Tests

Added a spec asserting the invariant that nesting depth does not grow with selector count (verified failing before the change — 2 selectors → 1 layer, 10 → 9 — and passing after). Full suite shows no new failures versus `origin/master`.

## References

PACT-7179