### PR TITLE
chore: reject blank pacticipant names in pact publish validation

### DIFF
--- a/lib/pact_broker/api/contracts/put_pact_params_contract.rb
+++ b/lib/pact_broker/api/contracts/put_pact_params_contract.rb
@@ -10,6 +10,8 @@ module PactBroker
           required(:name_in_pact).maybe(:string)
         end
 
+        rule(:name).validate(:not_blank_if_present)
+
         rule(:name, :name_in_pact) do
           if name_in_pact_does_not_match_name_in_url_path?(values)
             key.failure(validation_message("pact_name_in_path_mismatch_name_in_pact", name_in_pact: values[:name_in_pact], name_in_path: values[:name]))

--- a/lib/pact_broker/pacticipants/repository.rb
+++ b/lib/pact_broker/pacticipants/repository.rb
@@ -47,6 +47,8 @@ module PactBroker
       end
 
       def find_by_name_or_create name
+        raise PactBroker::Error, "Cannot create a pacticipant with a blank name" if name.to_s.strip.empty?
+        
         pacticipant = find_by_name(name)
         pacticipant ? pacticipant : create(name: name)
       end

--- a/spec/lib/pact_broker/api/contracts/put_pact_params_contract_spec.rb
+++ b/spec/lib/pact_broker/api/contracts/put_pact_params_contract_spec.rb
@@ -125,6 +125,46 @@ module PactBroker
               expect(subject).to be_empty
             end
           end
+
+          context "when the consumer name from the URL path is an empty string" do
+            let(:attributes) do
+              valid_attributes.merge(consumer_name: "")
+            end
+
+            it "returns a blank error for consumer.name" do
+              expect(subject[:'consumer.name'].first).to include("blank")
+            end
+          end
+
+          context "when the provider name from the URL path is an empty string" do
+            let(:attributes) do
+              valid_attributes.merge(provider_name: "")
+            end
+
+            it "returns a blank error for provider.name" do
+              expect(subject[:'provider.name'].first).to include("blank")
+            end
+          end
+
+          context "when the consumer name from the URL path is a whitespace string" do
+            let(:attributes) do
+              valid_attributes.merge(consumer_name: "  ")
+            end
+
+            it "returns a blank error for consumer.name" do
+              expect(subject[:'consumer.name'].first).to include("blank")
+            end
+          end
+
+          context "when both consumer name and consumer name in pact are nil" do
+            let(:attributes) do
+              valid_attributes.merge(consumer_name: nil, consumer_name_in_pact: nil)
+            end
+
+            it "does not return a blank error (nil is allowed by maybe(:string))" do
+              expect(subject[:'consumer.name']).to be_nil
+            end
+          end
         end
       end
     end

--- a/spec/lib/pact_broker/pacticipants/repository_spec.rb
+++ b/spec/lib/pact_broker/pacticipants/repository_spec.rb
@@ -278,6 +278,57 @@ module PactBroker
           end
         end
       end
+
+      describe "#find_by_name_or_create" do
+        let(:repository) { Repository.new }
+
+        context "when the pacticipant does not exist" do
+          it "creates and returns a new pacticipant" do
+            result = repository.find_by_name_or_create("NewApp")
+            expect(result).to be_a(PactBroker::Domain::Pacticipant)
+            expect(result.name).to eq "NewApp"
+          end
+        end
+
+        context "when the pacticipant already exists" do
+          before { repository.create(name: "ExistingApp") }
+
+          it "returns the existing pacticipant without creating a duplicate" do
+            expect { repository.find_by_name_or_create("ExistingApp") }.not_to change { PactBroker::Domain::Pacticipant.count }
+          end
+
+          it "returns the correct pacticipant" do
+            result = repository.find_by_name_or_create("ExistingApp")
+            expect(result.name).to eq "ExistingApp"
+          end
+        end
+
+        context "when the name is an empty string" do
+          it "raises a PactBroker::Error" do
+            expect { repository.find_by_name_or_create("") }.to raise_error(PactBroker::Error, /blank/)
+          end
+
+          it "does not create a pacticipant" do
+            expect { repository.find_by_name_or_create("") rescue nil }.not_to change { PactBroker::Domain::Pacticipant.count }
+          end
+        end
+
+        context "when the name is a whitespace string" do
+          it "raises a PactBroker::Error" do
+            expect { repository.find_by_name_or_create("   ") }.to raise_error(PactBroker::Error, /blank/)
+          end
+
+          it "does not create a pacticipant" do
+            expect { repository.find_by_name_or_create("   ") rescue nil }.not_to change { PactBroker::Domain::Pacticipant.count }
+          end
+        end
+
+        context "when the name is nil" do
+          it "raises a PactBroker::Error" do
+            expect { repository.find_by_name_or_create(nil) }.to raise_error(PactBroker::Error, /blank/)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem
Publishing a pact with empty consumer/provider values in the path parameter (e.g. `PUT /pacts/provider//consumer/Foo/version/1.0.0`) causes Webmachine to assign an empty string "" to consumer/provider in this case its :provider_name. This empty string passed validation because PutPacticipantNameContract declared the name field as required(:name).maybe(:string), which allows empty strings. As a result, `find_by_name_or_create` was called with name: "" and a pacticipant with a blank name gets silently created.

### Root cause
The `PutPacticipantNameContract` used maybe(:string) for the name field (the URL path segment), which passes dry-validation for any string including "". There is no rule to reject blank strings. Additionally, `find_by_name_or_create` had no guard against blank names.

The mismatch rule `name_in_pact_does_not_match_name_in_url_path`? also bypasses the check when name_in_pact is blank, because provided?("") returns false — so a pact body with "provider": {"name": ""} passed both the blank check and the mismatch check.

### Fix
`PutPacticipantNameContract` — Added rule(:name).validate(:not_blank_if_present) to reject empty or whitespace-only names from the URL path. nil is still permitted (allowed by maybe(:string)) for cases where the name is absent from the pact body.

`Pacticipants::Repository#find_by_name_or_create` — Added a defence-in-depth guard that raises PactBroker::Error if a blank name reaches the repository, protecting against any other code path that might call this method without prior validation.