### PR TITLE
fix: defer debug log string interpolation in pact publish

### DIFF
--- a/lib/pact_broker/pacts/service.rb
+++ b/lib/pact_broker/pacts/service.rb
@@ -182,7 +182,7 @@ module PactBroker
       # Modifing pacts is strongly discouraged now, and support for it will be dropped in the next major version of the Pact Broker
       def create_pact_revision params, existing_pact
         logger.info("Updating existing pact publication", params.without(:json_content))
-        logger.debug("Content #{params[:json_content]}")
+        logger.debug { "Content #{params[:json_content]}" }
         pact_version_sha = params.fetch(:pact_version_sha)
         json_content = add_interaction_ids(params[:json_content])
         update_params = { pact_version_sha: pact_version_sha, json_content: json_content }
@@ -211,7 +211,7 @@ module PactBroker
       # When no publication for the given consumer/provider/consumer version number exists
       def create_pact(params, version, provider)
         logger.debug("Creating new pact publication", params.without(:json_content))
-        logger.debug("Content #{params[:json_content]}")
+        logger.debug { "Content #{params[:json_content]}" }
         json_content = add_interaction_ids(params[:json_content])
         pact = pact_repository.create(
           version_id: version.id,

--- a/spec/lib/pact_broker/pacts/service_spec.rb
+++ b/spec/lib/pact_broker/pacts/service_spec.rb
@@ -38,17 +38,28 @@ module PactBroker
         let(:content) { double("content") }
         let(:content_with_interaction_ids) { double("content_with_interaction_ids", to_json: json_content_with_ids) }
         let(:expected_event_context) { { consumer_version_tags: ["dev"] } }
+        let(:logger) { double("logger").as_null_object }
 
         before do
           allow(Content).to receive(:from_json).and_return(content)
           allow(content).to receive(:with_ids).and_return(content_with_interaction_ids)
           allow(PactBroker::Pacts::GenerateSha).to receive(:call).and_call_original
           allow(Service).to receive(:broadcast)
+          allow(Service).to receive(:logger).and_return(logger)
         end
 
         subject { Service.create_or_update_pact(params) }
 
         context "when no pact exists with the same params" do
+          it "passes json content to the debug logger via a block to defer string interpolation" do
+            block_messages = []
+            allow(logger).to receive(:debug) do |*args, &block|
+              block_messages << block.call if args.empty? && block
+            end
+            subject
+            expect(block_messages.first).to include(json_content)
+          end
+
           it "saves the pact interactions/messages with ids added to them" do
             expect(pact_repository).to receive(:create).with hash_including(json_content: json_content_with_ids)
             subject
@@ -118,6 +129,15 @@ module PactBroker
         end
 
         context "when a pact exists with the same params" do
+          it "passes json content to the debug logger via a block to defer string interpolation" do
+            block_messages = []
+            allow(logger).to receive(:debug) do |*args, &block|
+              block_messages << block.call if args.empty? && block
+            end
+            subject
+            expect(block_messages.first).to include(json_content)
+          end
+
           let(:existing_pact) do
             double("existing_pact",
               id: 4,


### PR DESCRIPTION
## Problem
`pact_broker_fork/lib/pact_broker/pacts/service.rb` had two logger.debug calls in `create_pact` and `create_pact_revision` that interpolated the full pact JSON content as a plain string argument:

`logger.debug("Content #{params[:json_content]}")`

Ruby evaluates the interpolation eagerly — the full string (potentially several MB of JSON) is allocated before the logger ever checks whether debug is enabled. 

This could contributor to the CPU burst / GC pressure pattern seen on contract upload under load.

### Fix
Converted both calls to Semantic Logger's block form:

`logger.debug { "Content #{params[:json_content]}" }`

The block is only evaluated if debug level is active, so at `:info` in production the allocation never happens.