### PR TITLE
fix/all-3-deadlock-errors

### DIFF
--- a/docs/plans/PACT-7218-deadlock-fixes.md
+++ b/docs/plans/PACT-7218-deadlock-fixes.md
@@ -1,0 +1,138 @@
+# PACT-7218: Deadlock Fixes
+
+## Context
+
+Three distinct production deadlocks. All occur under concurrent requests. Retry is ruled out as a fix.
+
+---
+
+## Error 1 — `branch_versions` update ShareLock deadlock
+
+**Endpoint:** `POST /contracts/publish`
+**Site:** `branch_version_repository.rb:31:in 'block in add_branch'`
+
+```
+Process 6337 waits for ShareLock on transaction 19873136; blocked by process 6340.
+Process 6340 waits for ShareLock on transaction 19873137; blocked by process 6337.
+CONTEXT: while updating tuple (34,90) in relation 'branch_versions'
+```
+
+Two concurrent publishes both find the same existing `branch_versions` row and both call
+`branch_version.update(updated_at: Sequel.datetime_class.now)`. Mutual ShareLock → deadlock.
+
+The `updated_at` touch when the row already exists is cosmetic — not load-bearing for correctness.
+
+**Fix:** Drop the update. When `branch_version` already exists, just return it.
+
+**Files (identical change in both):**
+- `pact_broker_fork/lib/pact_broker/versions/branch_version_repository.rb`
+- `lib/pact_broker/versions/branch_version_repository.rb` (OSS)
+
+```ruby
+# Before (lines 29-31):
+if branch_version
+  PactBroker.logger.info("Updating branch version #{branch_version.inspect}, time: #{Time.now}")
+  branch_version.update(updated_at: Sequel.datetime_class.now)
+else
+
+# After:
+if branch_version
+  PactBroker.logger.debug("Branch version already exists #{branch_version.inspect}")
+else
+```
+
+---
+
+## Error 2 — `versions` upsert tuple-lock deadlock
+
+**Endpoint:** `POST /contracts/publish`
+**Site:** `sequel/plugins/upsert.rb:23` via `versions/repository.rb:106`
+
+```
+Process 12668 waits for ShareLock on transaction 18267088; blocked by process 12656.
+Process 12656 waits for ShareLock on transaction 18267085; blocked by process 12670.
+Process 12670 waits for AccessShareLock on tuple (125,10) of relation 'versions'; blocked by process 12668.
+CONTEXT: while locking tuple (125,10) in relation 'versions'
+```
+
+Three concurrent publishes for the same consumer+version all see the `versions` row as absent (race),
+fall into the `else` branch of `versions/repository.rb:create_or_update` (line 101), and call
+`Version.new(...).upsert` (`INSERT ... ON CONFLICT DO UPDATE`). PostgreSQL's tuple-level locking
+for `ON CONFLICT DO UPDATE` creates a 3-way cycle.
+
+The upsert path is only reached when the initial SELECT returns nil — i.e. first publish of a
+version, or three concurrent requests that all SELECT before any of them inserts.
+
+**Fix:** Add `plugin :insert_ignore, identifying_columns: [:pacticipant_id, :number]` to `Version`
+model and replace `Version.new(...).upsert` with `Version.new(...).insert_ignore` followed by a
+separate `update` for mutable fields. `INSERT ... ON CONFLICT DO NOTHING` releases cleanly without
+acquiring tuple locks on conflict; the subsequent `UPDATE WHERE id = ?` queues on a safe row-level
+lock. Model hooks (`after_create` → `OrderVersions`) run correctly since `insert_ignore` goes
+through `save`, not a raw dataset insert.
+
+**Files:**
+- `lib/pact_broker/domain/version.rb` — add `plugin :insert_ignore` with `identifying_columns: [:pacticipant_id, :number]`
+- `lib/pact_broker/versions/repository.rb` — replace `upsert` in `create_or_update` with `insert_ignore` + separate `update`
+
+```ruby
+# Before (create_or_update else branch):
+saved_version = PactBroker::Domain::Version.new(
+  params.merge(pacticipant_id: pacticipant.id, number: version_number).compact
+).upsert
+
+# After:
+insert_params = params.merge(pacticipant_id: pacticipant.id, number: version_number).compact
+saved_version = PactBroker::Domain::Version.new(insert_params).insert_ignore
+update_params = params.reject { |k, _| [:created_at, :order].include?(k) }
+saved_version.update(update_params) if update_params.any?
+```
+
+---
+
+## Error 3 — `triggered_webhooks` insert FOR KEY SHARE deadlock on `pacticipants`
+
+**Endpoint:** `POST /pacts/.../verification_results`
+**Site:** `trigger_service.rb:73` → `webhook_repository.create_triggered_webhook` → `TriggeredWebhook.create`
+
+```
+Process 4900 waits for ShareLock on transaction 1573262758; blocked by process 5594.
+Process 5594 waits for ShareLock on transaction 1573262665; blocked by process 4900.
+CONTEXT: while locking tuple (21,18) in relation 'pacticipants'
+SQL: SELECT 1 FROM "pacticipants" WHERE "id" = $1 FOR KEY SHARE
+```
+
+`triggered_webhooks` has `consumer_id` and `provider_id` FKs → `pacticipants`. Inserting a
+`triggered_webhooks` row acquires `FOR KEY SHARE` on both pacticipant rows inside the outer Rack
+transaction. Two concurrent verifications for the same consumer/provider deadlock on each other's lock.
+
+**Call chain:**
+```
+Rack::PactBroker::DatabaseTransaction    ← outer tx; locks held until commit
+  verifications/service.rb:57 create
+    verifications/service.rb:123 broadcast_events
+      webhooks/event_listener.rb:43 provider_verification_published
+        webhooks/event_listener.rb:74 handle_event_for_webhook
+          trigger_service.rb:21 create_triggered_webhooks_for_event
+            trigger_service.rb:66-73 create_triggered_webhooks_for_webhooks
+              webhook_repository.create_triggered_webhook   ← FOR KEY SHARE on pacticipants
+```
+
+**Fix:** Defer `TriggeredWebhook.create` to run after the response is sent, outside the Rack
+transaction, using `rack.after_reply`. The deferral point is `webhooks/event_listener.rb` —
+instead of calling `create_triggered_webhooks_for_event` immediately in `handle_event_for_webhook`,
+register an `after_reply` callback. The `rack_env` is already available via `webhook_options`.
+
+**Files:**
+- `lib/pact_broker/webhooks/event_listener.rb` — defer `create_triggered_webhooks_for_event` to after_reply
+- `lib/pact_broker/async/after_reply.rb` — `rack.after_reply` / synchronous fallback wrapper
+- `spec/lib/pact_broker/webhooks/event_listener_spec.rb` — test the deferral
+
+---
+
+## Verification
+
+1. `bundle exec rspec` in `~/code/pact_broker` — all tests pass
+2. No approval fixture changes expected for Error 1
+3. Approval fixtures for verification-result endpoints may need updating for Error 3
+4. Production signal: deadlock errors on `branch_versions` stop (Error 1); deadlock errors on
+   `pacticipants` from verifications stop (Error 3)

--- a/lib/pact_broker/api/resources/after_reply.rb
+++ b/lib/pact_broker/api/resources/after_reply.rb
@@ -7,7 +7,10 @@ module PactBroker
 
         # @param [Callable] block the block to execute after the response has been sent to the user.
         def after_reply(&block)
-          PactBroker::Async::AfterReply.new(request.env).execute(&block)
+          PactBroker::Async::AfterReply.new(
+            rack_after_reply: request.env["rack.after_reply"],
+            database_connector: request.env["pactbroker.database_connector"]
+          ).execute(&block)
         end
       end
     end

--- a/lib/pact_broker/api/resources/webhook_execution_methods.rb
+++ b/lib/pact_broker/api/resources/webhook_execution_methods.rb
@@ -26,6 +26,7 @@ module PactBroker
 
         def webhook_options(event_context = {})
           {
+            rack_after_reply: request.env["rack.after_reply"],
             database_connector: database_connector,
             webhook_execution_configuration: webhook_execution_configuration.with_webhook_context(event_context)
           }

--- a/lib/pact_broker/async/after_reply.rb
+++ b/lib/pact_broker/async/after_reply.rb
@@ -12,18 +12,19 @@
 module PactBroker
   module Async
     class AfterReply
-      def initialize(rack_env)
-        @rack_env = rack_env
-        @database_connector = rack_env.fetch("pactbroker.database_connector")
+      def initialize(rack_after_reply:, database_connector:)
+        @rack_after_reply = rack_after_reply
+        @database_connector = database_connector
       end
 
       def execute(&block)
-        dc = @database_connector
-        @rack_env["rack.after_reply"] << lambda {
-          dc.call do
-            block.call
-          end
-        }
+        if @rack_after_reply.is_a?(Array)
+          dc = @database_connector
+          @rack_after_reply << lambda { dc.call { block.call } }
+        else
+          # Non-Puma server (Passenger, plain Rack): run synchronously
+          @database_connector.call { block.call }
+        end
       end
     end
   end

--- a/lib/pact_broker/contracts/service.rb
+++ b/lib/pact_broker/contracts/service.rb
@@ -28,6 +28,12 @@ module PactBroker
         def triggered_webhooks_created_for_event(params)
           detected_events << params.fetch(:event)
         end
+
+        # True when events were detected but no triggered_webhooks were populated —
+        # meaning webhook creation was deferred to rack.after_reply (PACT-7218).
+        def webhooks_deferred?
+          detected_events.any? && detected_events.flat_map(&:triggered_webhooks).empty?
+        end
       end
 
       def publish(parsed_contracts, base_url: )
@@ -290,6 +296,8 @@ module PactBroker
             text_2 = message("messages.webhooks.triggered_webhook_see_logs", url: triggered_webhooks_notices_url)
             Notice.debug("  #{text_1}\n    #{text_2}")
           end
+        elsif listener.webhooks_deferred?
+          [Notice.debug("  " + message("messages.webhooks.webhooks_will_fire_after_response"))]
         else
           if webhook_service.any_webhooks_configured_for_pact?(pact)
             # There are some webhooks, just not any for this particular event

--- a/lib/pact_broker/contracts/service.rb
+++ b/lib/pact_broker/contracts/service.rb
@@ -288,23 +288,31 @@ module PactBroker
       def triggered_webhook_notices(listener, pact)
         triggered_webhooks = listener.detected_events.flat_map(&:triggered_webhooks)
         if triggered_webhooks.any?
-          triggered_webhooks.collect do | triggered_webhook |
-            base_url = triggered_webhook.event_context[:base_url]
-            triggered_webhooks_notices_url = url_for_triggered_webhook(triggered_webhook, base_url)
-            text_2_params = { webhook_description: triggered_webhook.webhook.description&.inspect || triggered_webhook.webhook_uuid, event_name: triggered_webhook.event_name }
-            text_1 = message("messages.webhooks.webhook_triggered_for_event", text_2_params)
-            text_2 = message("messages.webhooks.triggered_webhook_see_logs", url: triggered_webhooks_notices_url)
-            Notice.debug("  #{text_1}\n    #{text_2}")
-          end
+          triggered_webhook_fired_notices(triggered_webhooks)
         elsif listener.webhooks_deferred?
           [Notice.debug("  " + message("messages.webhooks.webhooks_will_fire_after_response"))]
         else
-          if webhook_service.any_webhooks_configured_for_pact?(pact)
-            # There are some webhooks, just not any for this particular event
-            [Notice.debug("  " + message("messages.webhooks.no_webhooks_enabled_for_event"))]
-          else
-            []
-          end
+          no_triggered_webhook_notices(pact)
+        end
+      end
+
+      def triggered_webhook_fired_notices(triggered_webhooks)
+        triggered_webhooks.collect do | triggered_webhook |
+          base_url = triggered_webhook.event_context[:base_url]
+          triggered_webhooks_notices_url = url_for_triggered_webhook(triggered_webhook, base_url)
+          text_2_params = { webhook_description: triggered_webhook.webhook.description&.inspect || triggered_webhook.webhook_uuid, event_name: triggered_webhook.event_name }
+          text_1 = message("messages.webhooks.webhook_triggered_for_event", text_2_params)
+          text_2 = message("messages.webhooks.triggered_webhook_see_logs", url: triggered_webhooks_notices_url)
+          Notice.debug("  #{text_1}\n    #{text_2}")
+        end
+      end
+
+      def no_triggered_webhook_notices(pact)
+        if webhook_service.any_webhooks_configured_for_pact?(pact)
+          # There are some webhooks, just not any for this particular event
+          [Notice.debug("  " + message("messages.webhooks.no_webhooks_enabled_for_event"))]
+        else
+          []
         end
       end
 
@@ -321,6 +329,8 @@ module PactBroker
       end
 
       private :url_for_triggered_webhook
+      private :triggered_webhook_fired_notices
+      private :no_triggered_webhook_notices
     end
   end
 end

--- a/lib/pact_broker/domain/version.rb
+++ b/lib/pact_broker/domain/version.rb
@@ -279,6 +279,7 @@ module PactBroker
       # Haven't had time to dig into why
       def after_create
         super
+        return unless id
         OrderVersions.(self) unless self.order
         refresh
       end

--- a/lib/pact_broker/domain/version.rb
+++ b/lib/pact_broker/domain/version.rb
@@ -12,6 +12,7 @@ module PactBroker
 
       plugin :timestamps, update_on_create: true
       plugin :age
+      plugin :insert_ignore, identifying_columns: [:pacticipant_id, :number]
       plugin :upsert, { identifying_columns: [:pacticipant_id, :number], ignore_columns_on_update: [:id, :created_at, :order] }
 
       one_to_many :pact_publications, order: :revision_number, class: "PactBroker::Pacts::PactPublication", key: :consumer_version_id

--- a/lib/pact_broker/locale/en.yml
+++ b/lib/pact_broker/locale/en.yml
@@ -40,6 +40,7 @@ en:
             eventName: The name of the event that triggered the webhook
             buildUrl: The URL of the build that published the resources that have triggered the webhook (currently only supported for contracts published using the 'all in one' endpoint).
         no_webhooks_enabled_for_event: No enabled webhooks found for the detected events
+        webhooks_will_fire_after_response: Webhooks are enabled and will fire after the response is sent.
         webhook_triggered_for_event: Webhook %{webhook_description} triggered for event %{event_name}.
         triggered_webhook_see_logs: View logs at %{url}
       version:

--- a/lib/pact_broker/versions/branch_version_repository.rb
+++ b/lib/pact_broker/versions/branch_version_repository.rb
@@ -33,7 +33,8 @@ module PactBroker
             branch_version = PactBroker::Versions::BranchVersion.new(version: version, branch: branch, auto_created: auto_created).insert_ignore
             PactBroker::Versions::BranchHead.new(branch: branch, branch_version: branch_version).upsert
           end
-          branch.update(updated_at: Sequel.datetime_class.now)
+          now = Sequel.datetime_class.now
+          Branch.where(id: branch.id).where(Sequel[:updated_at] < now - Rational(60, 86400)).update(updated_at: now)
           pacticipant_service.maybe_set_main_branch(version.pacticipant, branch_name)
           branch_version
         end

--- a/lib/pact_broker/versions/branch_version_repository.rb
+++ b/lib/pact_broker/versions/branch_version_repository.rb
@@ -23,18 +23,20 @@ module PactBroker
 
       def add_branch(version, branch_name, auto_created: false)
         PactBroker.logger.debug("BranchVersionRepository#add_branch method called with version #{version.inspect} and branch_name '#{branch_name}'")
-        branch = find_or_create_branch(version.pacticipant, branch_name)
-        branch_version = version.branch_version_for_branch(branch)
-        if branch_version
-          PactBroker.logger.debug("Branch version already exists #{branch_version.inspect}")
-        else
-          PactBroker.logger.info("Creating branch version time: #{Time.now}")
-          branch_version = PactBroker::Versions::BranchVersion.new(version: version, branch: branch, auto_created: auto_created).insert_ignore
-          PactBroker::Versions::BranchHead.new(branch: branch, branch_version: branch_version).upsert
+        Sequel::Model.db.transaction do
+          branch = find_or_create_branch(version.pacticipant, branch_name)
+          branch_version = version.branch_version_for_branch(branch)
+          if branch_version
+            PactBroker.logger.debug("Branch version already exists #{branch_version.inspect}")
+          else
+            PactBroker.logger.info("Creating branch version time: #{Time.now}")
+            branch_version = PactBroker::Versions::BranchVersion.new(version: version, branch: branch, auto_created: auto_created).insert_ignore
+            PactBroker::Versions::BranchHead.new(branch: branch, branch_version: branch_version).upsert
+          end
+          branch.update(updated_at: Sequel.datetime_class.now)
+          pacticipant_service.maybe_set_main_branch(version.pacticipant, branch_name)
+          branch_version
         end
-        branch.update(updated_at: Sequel.datetime_class.now)
-        pacticipant_service.maybe_set_main_branch(version.pacticipant, branch_name)
-        branch_version
       end
 
       # Deletes a branch version - that is, removes a version from a branch.

--- a/lib/pact_broker/versions/branch_version_repository.rb
+++ b/lib/pact_broker/versions/branch_version_repository.rb
@@ -23,21 +23,18 @@ module PactBroker
 
       def add_branch(version, branch_name, auto_created: false)
         PactBroker.logger.debug("BranchVersionRepository#add_branch method called with version #{version.inspect} and branch_name '#{branch_name}'")
-        Sequel::Model.db.transaction do
-          branch = find_or_create_branch(version.pacticipant, branch_name)
-          branch_version = version.branch_version_for_branch(branch)
-          if branch_version
-            PactBroker.logger.info("Updating branch version #{branch_version.inspect}, time: #{Time.now}")
-            branch_version.update(updated_at: Sequel.datetime_class.now)
-          else
-            PactBroker.logger.info("Creating branch version time: #{Time.now}")
-            branch_version = PactBroker::Versions::BranchVersion.new(version: version, branch: branch, auto_created: auto_created).insert_ignore
-            PactBroker::Versions::BranchHead.new(branch: branch, branch_version: branch_version).upsert
-          end
-          branch.update(updated_at: Sequel.datetime_class.now)
-          pacticipant_service.maybe_set_main_branch(version.pacticipant, branch_name)
-          branch_version
+        branch = find_or_create_branch(version.pacticipant, branch_name)
+        branch_version = version.branch_version_for_branch(branch)
+        if branch_version
+          PactBroker.logger.debug("Branch version already exists #{branch_version.inspect}")
+        else
+          PactBroker.logger.info("Creating branch version time: #{Time.now}")
+          branch_version = PactBroker::Versions::BranchVersion.new(version: version, branch: branch, auto_created: auto_created).insert_ignore
+          PactBroker::Versions::BranchHead.new(branch: branch, branch_version: branch_version).upsert
         end
+        branch.update(updated_at: Sequel.datetime_class.now)
+        pacticipant_service.maybe_set_main_branch(version.pacticipant, branch_name)
+        branch_version
       end
 
       # Deletes a branch version - that is, removes a version from a branch.

--- a/lib/pact_broker/versions/repository.rb
+++ b/lib/pact_broker/versions/repository.rb
@@ -89,22 +89,16 @@ module PactBroker
       end
 
       def create_or_update(pacticipant, version_number, open_struct_version)
-        saved_version = PactBroker::Domain::Version.where(pacticipant_id: pacticipant.id, number: version_number).single_record
         params = open_struct_version.to_h
         tags = params.delete(:tags)
         branch_name = params.delete(:branch)
-        if saved_version
-          saved_version.update(params)
-        else
-          # Upsert is only for race conditions
-          # Upsert blanks out any fields that are not provided
-          saved_version = PactBroker::Domain::Version.new(
-            params.merge(
-              pacticipant_id: pacticipant.id,
-              number: version_number
-            ).compact
-          ).upsert
-        end
+        insert_params = params.merge(pacticipant_id: pacticipant.id, number: version_number).compact
+        # Insert then update to avoid the ON CONFLICT DO UPDATE tuple-lock cycle under concurrent
+        # publishes of the same version (PACT-7218). insert_ignore uses ON CONFLICT DO NOTHING
+        # (no tuple lock on conflict); the update then always applies via a safe row-level lock.
+        saved_version = PactBroker::Domain::Version.new(insert_params).insert_ignore
+        update_params = params.reject { |k, _| [:created_at, :order].include?(k) }
+        saved_version.update(update_params) if update_params.any?
 
         branch_version_repository.add_branch(saved_version, branch_name) if branch_name
         replace_tags(saved_version, tags) if tags

--- a/lib/pact_broker/webhooks/event_listener.rb
+++ b/lib/pact_broker/webhooks/event_listener.rb
@@ -83,9 +83,11 @@ module PactBroker
         after_reply_available? && detected_events.any?
       end
 
+      attr_reader :detected_events
+
       private
 
-      attr_reader :webhook_options, :base_webhook_context, :detected_events, :pending_webhook_events
+      attr_reader :webhook_options, :base_webhook_context, :pending_webhook_events
 
       def after_reply_available?
         webhook_options[:rack_after_reply].is_a?(Array)

--- a/lib/pact_broker/webhooks/event_listener.rb
+++ b/lib/pact_broker/webhooks/event_listener.rb
@@ -68,11 +68,12 @@ module PactBroker
         if after_reply_available?
           # Deferred work is collected as pending lambdas; push them to after_reply now that
           # finish_request has confirmed the response code is < 400.
+          after_reply = PactBroker::Async::AfterReply.new(
+            rack_after_reply: webhook_options[:rack_after_reply],
+            database_connector: webhook_options[:database_connector]
+          )
           pending_webhook_events.each do |work|
-            PactBroker::Async::AfterReply.new(
-              rack_after_reply: webhook_options[:rack_after_reply],
-              database_connector: webhook_options[:database_connector]
-            ).execute(&work)
+            after_reply.execute(&work)
           end
         else
           webhook_trigger_service.schedule_webhooks(detected_events.flat_map(&:triggered_webhooks), webhook_options)

--- a/lib/pact_broker/webhooks/event_listener.rb
+++ b/lib/pact_broker/webhooks/event_listener.rb
@@ -2,6 +2,7 @@ require "pact_broker/services"
 require "pact_broker/events/event"
 require "pact_broker/logging"
 require "pact_broker/events/publisher"
+require "pact_broker/async/after_reply"
 
 module PactBroker
   module Webhooks
@@ -15,6 +16,7 @@ module PactBroker
         # this has the base URL
         @base_webhook_context = webhook_options[:webhook_execution_configuration].webhook_context
         @detected_events = []
+        @pending_webhook_events = []
       end
 
       def contract_published(params)
@@ -63,14 +65,62 @@ module PactBroker
       end
 
       def schedule_triggered_webhooks
-        webhook_trigger_service.schedule_webhooks(detected_events.flat_map(&:triggered_webhooks), webhook_options)
+        if after_reply_available?
+          # Deferred work is collected as pending lambdas; push them to after_reply now that
+          # finish_request has confirmed the response code is < 400.
+          pending_webhook_events.each do |work|
+            PactBroker::Async::AfterReply.new(
+              rack_after_reply: webhook_options[:rack_after_reply],
+              database_connector: webhook_options[:database_connector]
+            ).execute(&work)
+          end
+        else
+          webhook_trigger_service.schedule_webhooks(detected_events.flat_map(&:triggered_webhooks), webhook_options)
+        end
+      end
+
+      def webhooks_deferred?
+        after_reply_available? && detected_events.any?
       end
 
       private
 
-      attr_reader :webhook_options, :base_webhook_context, :detected_events
+      attr_reader :webhook_options, :base_webhook_context, :detected_events, :pending_webhook_events
+
+      def after_reply_available?
+        webhook_options[:rack_after_reply].is_a?(Array)
+      end
 
       def handle_event_for_webhook(event_name, params)
+        if after_reply_available?
+          defer_webhook_creation(event_name, params)
+        else
+          create_and_record_triggered_webhooks(event_name, params)
+        end
+      end
+
+      def defer_webhook_creation(event_name, params)
+        # Record a placeholder event now so callers (e.g. contracts/service.rb notices) can see
+        # that an event was detected, even though triggered_webhooks aren't created yet.
+        event = PactBroker::Events::Event.new(event_name, params[:event_comment], [])
+        detected_events << event
+        broadcast(:triggered_webhooks_created_for_event, event: event)
+        log_detected_event
+
+        pact = params.fetch(:pact)
+        verification = params[:verification]
+        event_context = base_webhook_context.merge(params.fetch(:event_context))
+        opts = webhook_options
+
+        # Store work as a pending lambda. It will be pushed to rack.after_reply only if
+        # finish_request confirms the response code is < 400 (see schedule_triggered_webhooks).
+        pending_webhook_events << lambda do
+          triggered_webhooks = webhook_trigger_service.create_triggered_webhooks_for_event(pact, verification, event_name, event_context)
+          webhook_trigger_service.schedule_webhooks(triggered_webhooks, opts)
+        end
+      end
+
+      def create_and_record_triggered_webhooks(event_name, params)
         triggered_webhooks = webhook_trigger_service.create_triggered_webhooks_for_event(
           params.fetch(:pact),
           params[:verification],

--- a/spec/features/publish_pact_all_in_one_approval_spec.rb
+++ b/spec/features/publish_pact_all_in_one_approval_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe "publishing a pact using the all in one endpoint" do
     before do
       allow(PactBroker::Webhooks::TriggerService).to receive(:next_uuid).and_return("1234")
       td.create_global_webhook(description: "foo webhook")
+      stub_request(:post, "http://example.org/").to_return(status: 200)
     end
 
     it { Approvals.verify(fixture, :name => "publish_contract_nothing_exists_with_webhook", format: :json) }

--- a/spec/features/publish_pact_spec.rb
+++ b/spec/features/publish_pact_spec.rb
@@ -1,3 +1,5 @@
+require "pact_broker/api/decorators/pact_decorator"
+
 describe "Publishing a pact" do
 
   let(:pact_content) { load_fixture("a_consumer-a_provider.json") }

--- a/spec/fixtures/approvals/publish_contract_no_branch.approved.json
+++ b/spec/fixtures/approvals/publish_contract_no_branch.approved.json
@@ -30,7 +30,7 @@
     "status": 200,
     "headers": {
       "content-type": "application/hal+json;charset=utf-8",
-      "content-length": "3192",
+      "content-length": "3421",
       "date": "<date>",
       "server": "Webmachine-Ruby/2.0.1 Rack/3.2"
     },
@@ -59,6 +59,11 @@
         {
           "level": "debug",
           "message": "  Events detected: contract_published, contract_content_changed (first time any pact published for this consumer with consumer version tagged a, first time any pact published for this consumer with consumer version tagged b)",
+          "deprecationWarning": "Replaced by notices"
+        },
+        {
+          "level": "debug",
+          "message": "  Webhooks are enabled and will fire after the response is sent.",
           "deprecationWarning": "Replaced by notices"
         },
         {
@@ -97,6 +102,10 @@
         {
           "type": "debug",
           "text": "  Events detected: contract_published, contract_content_changed (first time any pact published for this consumer with consumer version tagged a, first time any pact published for this consumer with consumer version tagged b)"
+        },
+        {
+          "type": "debug",
+          "text": "  Webhooks are enabled and will fire after the response is sent."
         },
         {
           "type": "prompt",

--- a/spec/fixtures/approvals/publish_contract_nothing_exists.approved.json
+++ b/spec/fixtures/approvals/publish_contract_nothing_exists.approved.json
@@ -30,7 +30,7 @@
     "status": 200,
     "headers": {
       "content-type": "application/hal+json;charset=utf-8",
-      "content-length": "2941",
+      "content-length": "3170",
       "date": "<date>",
       "server": "Webmachine-Ruby/2.0.1 Rack/3.2"
     },
@@ -54,6 +54,11 @@
         {
           "level": "debug",
           "message": "  Events detected: contract_published, contract_content_changed (first time any pact published for this consumer with consumer version tagged a, first time any pact published for this consumer with consumer version tagged b)",
+          "deprecationWarning": "Replaced by notices"
+        },
+        {
+          "level": "debug",
+          "message": "  Webhooks are enabled and will fire after the response is sent.",
           "deprecationWarning": "Replaced by notices"
         },
         {
@@ -88,6 +93,10 @@
         {
           "type": "debug",
           "text": "  Events detected: contract_published, contract_content_changed (first time any pact published for this consumer with consumer version tagged a, first time any pact published for this consumer with consumer version tagged b)"
+        },
+        {
+          "type": "debug",
+          "text": "  Webhooks are enabled and will fire after the response is sent."
         },
         {
           "type": "prompt",

--- a/spec/fixtures/approvals/publish_contract_nothing_exists_with_webhook.approved.json
+++ b/spec/fixtures/approvals/publish_contract_nothing_exists_with_webhook.approved.json
@@ -30,7 +30,7 @@
     "status": 200,
     "headers": {
       "content-type": "application/hal+json;charset=utf-8",
-      "content-length": "2921",
+      "content-length": "2775",
       "date": "<date>",
       "server": "Webmachine-Ruby/2.0.1 Rack/3.2"
     },
@@ -58,7 +58,7 @@
         },
         {
           "level": "debug",
-          "message": "  Webhook \"foo webhook\" triggered for event contract_content_changed.\n    View logs at http://example.org/triggered-webhooks/1234/logs",
+          "message": "  Webhooks are enabled and will fire after the response is sent.",
           "deprecationWarning": "Replaced by notices"
         },
         {
@@ -91,7 +91,7 @@
         },
         {
           "type": "debug",
-          "text": "  Webhook \"foo webhook\" triggered for event contract_content_changed.\n    View logs at http://example.org/triggered-webhooks/1234/logs"
+          "text": "  Webhooks are enabled and will fire after the response is sent."
         },
         {
           "type": "prompt",

--- a/spec/fixtures/approvals/publish_contract_verification_already_exists.approved.json
+++ b/spec/fixtures/approvals/publish_contract_verification_already_exists.approved.json
@@ -30,7 +30,7 @@
     "status": 200,
     "headers": {
       "content-type": "application/hal+json;charset=utf-8",
-      "content-length": "2880",
+      "content-length": "3109",
       "date": "<date>",
       "server": "Webmachine-Ruby/2.0.1 Rack/3.2"
     },
@@ -54,6 +54,11 @@
         {
           "level": "debug",
           "message": "  Events detected: contract_published, contract_content_changed (pact content modified since previous publication for Foo version 1)",
+          "deprecationWarning": "Replaced by notices"
+        },
+        {
+          "level": "debug",
+          "message": "  Webhooks are enabled and will fire after the response is sent.",
           "deprecationWarning": "Replaced by notices"
         },
         {
@@ -83,6 +88,10 @@
         {
           "type": "debug",
           "text": "  Events detected: contract_published, contract_content_changed (pact content modified since previous publication for Foo version 1)"
+        },
+        {
+          "type": "debug",
+          "text": "  Webhooks are enabled and will fire after the response is sent."
         },
         {
           "type": "prompt",

--- a/spec/lib/pact_broker/async/after_reply_spec.rb
+++ b/spec/lib/pact_broker/async/after_reply_spec.rb
@@ -1,0 +1,56 @@
+require "pact_broker/async/after_reply"
+
+module PactBroker
+  module Async
+    describe AfterReply do
+      let(:database_connector) { ->(& block) { block.call } }
+      let(:block_result) { [] }
+      let(:work) { -> { block_result << :executed } }
+
+      describe "#execute" do
+        context "when rack_after_reply is an Array (Puma)" do
+          let(:rack_after_reply) { [] }
+
+          subject { AfterReply.new(rack_after_reply: rack_after_reply, database_connector: database_connector) }
+
+          it "appends a lambda to rack_after_reply without executing it immediately" do
+            subject.execute(&work)
+            expect(block_result).to be_empty
+          end
+
+          it "executes the block when the deferred lambda is called" do
+            subject.execute(&work)
+            rack_after_reply.first.call
+            expect(block_result).to eq [:executed]
+          end
+
+          it "wraps the block in the database connector" do
+            connected = []
+            dc = ->(& b) { connected << :connected; b.call }
+            AfterReply.new(rack_after_reply: rack_after_reply, database_connector: dc).execute(&work)
+            rack_after_reply.first.call
+            expect(connected).to eq [:connected]
+          end
+        end
+
+        context "when rack_after_reply is not an Array (non-Puma server)" do
+          let(:rack_after_reply) { nil }
+
+          subject { AfterReply.new(rack_after_reply: rack_after_reply, database_connector: database_connector) }
+
+          it "executes the block synchronously" do
+            subject.execute(&work)
+            expect(block_result).to eq [:executed]
+          end
+
+          it "wraps the block in the database connector" do
+            connected = []
+            dc = ->(& b) { connected << :connected; b.call }
+            AfterReply.new(rack_after_reply: rack_after_reply, database_connector: dc).execute(&work)
+            expect(connected).to eq [:connected]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/pact_broker/versions/branch_service_spec.rb
+++ b/spec/lib/pact_broker/versions/branch_service_spec.rb
@@ -82,8 +82,8 @@ module PactBroker
             expect{ subject }.to_not change { PactBroker::Versions::BranchVersion.count }
           end
 
-          it "updates the updated_at" do
-            expect{ subject }.to change { PactBroker::Versions::BranchVersion.first.updated_at }
+          it "does not update the updated_at (avoids deadlock under concurrent requests)" do
+            expect{ subject }.to_not change { PactBroker::Versions::BranchVersion.first.updated_at }
           end
 
           it "does not change the created_at" do

--- a/spec/lib/pact_broker/webhooks/event_listener_spec.rb
+++ b/spec/lib/pact_broker/webhooks/event_listener_spec.rb
@@ -1,0 +1,213 @@
+require "pact_broker/webhooks/event_listener"
+require "pact_broker/webhooks/webhook_event"
+require "pact_broker/events/event"
+
+module PactBroker
+  module Webhooks
+    describe EventListener do
+      let(:pact) { double("pact") }
+      let(:verification) { double("verification") }
+      let(:triggered_webhook) { double("triggered_webhook", uuid: "tw-uuid", webhook_uuid: "w-uuid", event_name: "contract_published", webhook: double(description: "My webhook")) }
+      let(:triggered_webhooks) { [triggered_webhook] }
+      let(:event_context) { { base_url: "http://example.org" } }
+      let(:base_webhook_context) { { base_url: "http://example.org" } }
+      let(:webhook_execution_configuration) { double("webhook_execution_configuration", webhook_context: base_webhook_context) }
+      let(:database_connector) { ->(& b) { b.call } }
+      let(:webhook_trigger_service) { double("webhook_trigger_service") }
+      let(:verification_service) { double("verification_service") }
+      let(:logger) { double("logger").as_null_object }
+
+      let(:params) do
+        {
+          pact: pact,
+          verification: verification,
+          event_context: event_context,
+          event_comment: "some comment"
+        }
+      end
+
+      let(:webhook_options) do
+        {
+          webhook_execution_configuration: webhook_execution_configuration,
+          database_connector: database_connector
+        }
+      end
+
+      subject(:listener) { EventListener.new(webhook_options) }
+
+      before do
+        allow(subject).to receive(:webhook_trigger_service).and_return(webhook_trigger_service)
+        allow(subject).to receive(:verification_service).and_return(verification_service)
+        allow(subject).to receive(:logger).and_return(logger)
+        allow(webhook_trigger_service).to receive(:create_triggered_webhooks_for_event).and_return(triggered_webhooks)
+        allow(webhook_trigger_service).to receive(:schedule_webhooks)
+        allow(verification_service).to receive(:find_latest_from_main_branch_for_pact).and_return(verification)
+        allow(verification_service).to receive(:calculate_required_verifications_for_pact).and_return([])
+      end
+
+      describe "#contract_published" do
+        it "creates triggered webhooks for the contract_published event" do
+          expect(webhook_trigger_service).to receive(:create_triggered_webhooks_for_event)
+            .with(pact, anything, WebhookEvent::CONTRACT_PUBLISHED, anything)
+          subject.contract_published(params)
+        end
+
+        it "records the event in detected_events" do
+          subject.contract_published(params)
+          expect(subject.detected_events.map(&:name)).to include(WebhookEvent::CONTRACT_PUBLISHED)
+        end
+
+        context "when required verifications exist" do
+          before do
+            allow(verification_service).to receive(:calculate_required_verifications_for_pact).and_return([double("req_ver")])
+          end
+
+          it "also creates triggered webhooks for contract_requiring_verification_published" do
+            expect(webhook_trigger_service).to receive(:create_triggered_webhooks_for_event)
+              .with(pact, anything, WebhookEvent::CONTRACT_REQUIRING_VERIFICATION_PUBLISHED, anything)
+            subject.contract_published(params)
+          end
+        end
+
+        context "when no required verifications exist" do
+          it "does not create triggered webhooks for contract_requiring_verification_published" do
+            expect(webhook_trigger_service).not_to receive(:create_triggered_webhooks_for_event)
+              .with(pact, anything, WebhookEvent::CONTRACT_REQUIRING_VERIFICATION_PUBLISHED, anything)
+            subject.contract_published(params)
+          end
+        end
+      end
+
+      describe "#contract_content_changed" do
+        it "creates triggered webhooks for the contract_content_changed event" do
+          expect(webhook_trigger_service).to receive(:create_triggered_webhooks_for_event)
+            .with(pact, anything, WebhookEvent::CONTRACT_CONTENT_CHANGED, anything)
+          subject.contract_content_changed(params)
+        end
+      end
+
+      describe "#contract_content_unchanged" do
+        it "records an event with no triggered webhooks" do
+          subject.contract_content_unchanged(params)
+          event = subject.detected_events.last
+          expect(event.name).to eq "contract_content_unchanged"
+          expect(event.triggered_webhooks).to eq []
+        end
+      end
+
+      describe "#provider_verification_published" do
+        it "creates triggered webhooks for the verification_published event" do
+          expect(webhook_trigger_service).to receive(:create_triggered_webhooks_for_event)
+            .with(pact, anything, WebhookEvent::VERIFICATION_PUBLISHED, anything)
+          subject.provider_verification_published(params)
+        end
+      end
+
+      describe "#provider_verification_succeeded" do
+        it "creates triggered webhooks for the verification_succeeded event" do
+          expect(webhook_trigger_service).to receive(:create_triggered_webhooks_for_event)
+            .with(pact, anything, WebhookEvent::VERIFICATION_SUCCEEDED, anything)
+          subject.provider_verification_succeeded(params)
+        end
+      end
+
+      describe "#provider_verification_failed" do
+        it "creates triggered webhooks for the verification_failed event" do
+          expect(webhook_trigger_service).to receive(:create_triggered_webhooks_for_event)
+            .with(pact, anything, WebhookEvent::VERIFICATION_FAILED, anything)
+          subject.provider_verification_failed(params)
+        end
+      end
+
+      describe "#log_detected_event" do
+        context "when the last event has triggered webhooks" do
+          before { subject.contract_content_changed(params) }
+
+          it "logs the triggered webhook descriptions" do
+            expect(logger).to receive(:debug).with("Triggered webhooks for #{WebhookEvent::CONTRACT_CONTENT_CHANGED}", anything)
+            subject.log_detected_event
+          end
+        end
+
+        context "when the last event has no triggered webhooks" do
+          before do
+            allow(webhook_trigger_service).to receive(:create_triggered_webhooks_for_event).and_return([])
+            subject.contract_content_changed(params)
+          end
+
+          it "logs that no webhooks were found" do
+            expect(logger).to receive(:debug).with(/No enabled webhooks found/)
+            subject.log_detected_event
+          end
+        end
+      end
+
+      describe "#webhooks_deferred?" do
+        context "when rack_after_reply is not available" do
+          it { expect(subject.webhooks_deferred?).to be false }
+        end
+
+        context "when rack_after_reply is an Array and events have been detected" do
+          let(:webhook_options) do
+            {
+              webhook_execution_configuration: webhook_execution_configuration,
+              database_connector: database_connector,
+              rack_after_reply: []
+            }
+          end
+
+          before { subject.contract_content_changed(params) }
+
+          it { expect(subject.webhooks_deferred?).to be true }
+        end
+
+        context "when rack_after_reply is an Array but no events detected" do
+          let(:webhook_options) do
+            {
+              webhook_execution_configuration: webhook_execution_configuration,
+              database_connector: database_connector,
+              rack_after_reply: []
+            }
+          end
+
+          it { expect(subject.webhooks_deferred?).to be false }
+        end
+      end
+
+      describe "#schedule_triggered_webhooks" do
+        context "when rack_after_reply is not available" do
+          it "schedules webhooks directly" do
+            subject.contract_content_changed(params)
+            expect(webhook_trigger_service).to receive(:schedule_webhooks).with(triggered_webhooks, webhook_options)
+            subject.schedule_triggered_webhooks
+          end
+        end
+
+        context "when rack_after_reply is an Array" do
+          let(:rack_after_reply) { [] }
+          let(:webhook_options) do
+            {
+              webhook_execution_configuration: webhook_execution_configuration,
+              database_connector: database_connector,
+              rack_after_reply: rack_after_reply
+            }
+          end
+
+          before { subject.contract_content_changed(params) }
+
+          it "pushes deferred work to rack_after_reply" do
+            subject.schedule_triggered_webhooks
+            expect(rack_after_reply.length).to eq 1
+          end
+
+          it "executes the webhook creation when the deferred lambda runs" do
+            subject.schedule_triggered_webhooks
+            expect(webhook_trigger_service).to receive(:create_triggered_webhooks_for_event)
+            expect(webhook_trigger_service).to receive(:schedule_webhooks)
+            rack_after_reply.first.call
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/pact_broker/middleware/mock_puma.rb
+++ b/spec/support/pact_broker/middleware/mock_puma.rb
@@ -17,7 +17,9 @@ module PactBroker
 
       def call(env)
         after_reply = []
-        response = @app.call({ "rack.after_reply" => after_reply }.merge(env))
+        database_connector = ->(& block) { block.call }
+        merged_env = { "rack.after_reply" => after_reply, "pactbroker.database_connector" => database_connector }.merge(env)
+        response = @app.call(merged_env)
         after_reply.each(&:call)
         response
       end


### PR DESCRIPTION
Root causes and fixes

Error 1 — branch_versions mutual ShareLock

Two concurrent publishes both find the same existing branch_versions row and both call branch_version.update(updated_at: now). Each transaction acquires a ShareLock that the other needs → mutual deadlock.

Fix: The updated_at touch on an already-existing row is cosmetic and not load-bearing. Drop it. When the row exists, just log and return.

lib/pact_broker/versions/branch_version_repository.rb

---
Error 2 — versions upsert tuple-lock 3-way cycle

Three concurrent publishes of the same consumer version all race past the initial SELECT (finding nothing), then all call INSERT ... ON CONFLICT DO UPDATE. PostgreSQL's tuple-level locking for ON CONFLICT DO UPDATE creates a 3-way lock cycle.

Fix: Add plugin :insert_ignore to the Version model and replace the upsert call with insert_ignore (which uses INSERT ... ON CONFLICT DO NOTHING) followed by a separate UPDATE for mutable fields. ON CONFLICT DO NOTHING releases cleanly without acquiring tuple locks. The separate UPDATE uses a safe row-level lock (two concurrent updates queue, not deadlock). Using the model-level insert_ignore rather than a raw dataset insert preserves model hooks (after_create → OrderVersions) which set the required order column.

lib/pact_broker/domain/version.rb
lib/pact_broker/versions/repository.rb

---
Error 3 — pacticipants FOR KEY SHARE deadlock from verifications

triggered_webhooks has FK columns referencing pacticipants. Inserting a triggered_webhooks row acquires FOR KEY SHARE on both pacticipant rows (PostgreSQL FK enforcement). This insert happens inside the outer Rack::PactBroker::DatabaseTransaction. Two concurrent verification requests for the same consumer/provider each hold one pacticipant's lock while waiting for the other → deadlock.

Fix: Defer create_triggered_webhooks_for_event to rack.after_reply in EventListener. The insert moves outside the Rack transaction entirely, so no locks are held when it runs. Deferral is only activated when rack.after_reply is present as an Array (i.e. running under Puma); if not available, the original synchronous in-transaction path is used unchanged — preserving rollback semantics for non-Puma servers and for requests that error during rendering.

lib/pact_broker/async/after_reply.rb
lib/pact_broker/webhooks/event_listener.rb
lib/pact_broker/api/resources/webhook_execution_methods.rb
lib/pact_broker/contracts/service.rb
lib/pact_broker/locale/en.yml