### PR TITLE
feat: add endpoint to get versions released or deployed

### DIFF
--- a/lib/pact_broker/api.rb
+++ b/lib/pact_broker/api.rb
@@ -104,6 +104,7 @@ module PactBroker
 
         # Versions
         add ["pacticipants", :pacticipant_name, "versions"], Api::Resources::Versions, {resource_name: "pacticipant_versions"}
+        add ["pacticipants", :pacticipant_name, "deployed-or-released", "versions"], Api::Resources::DeployedOrReleasedVersions, {resource_name: "pacticipant_deployed_or_released_versions"}
         add ["pacticipants", :pacticipant_name, "branches", :branch_name, "versions"], Api::Resources::BranchVersions, {resource_name: "pacticipant_branch_versions"}
         add ["pacticipants", :pacticipant_name, "environments", :environment_uuid, "versions"], Api::Resources::EnvironmentVersions, {resource_name: "pacticipant_environment_versions"}
         add ["pacticipants", :pacticipant_name, "versions", :pacticipant_version_number], Api::Resources::Version, {resource_name: "pacticipant_version"}

--- a/lib/pact_broker/api/decorators/provider_states_decorator.rb
+++ b/lib/pact_broker/api/decorators/provider_states_decorator.rb
@@ -26,7 +26,7 @@ module PactBroker
             end
 
             consumers_map.map do |(name, params), consumers|
-              { name: name, params: params, consumers: consumers.uniq }.transform_keys(&:to_sym)
+              { name: name, params: params, consumers: consumers.uniq.sort }.transform_keys(&:to_sym)
             end
           .sort_by { |provider_state| provider_state[:name] }
         }, :extend => PactBroker::Api::Decorators::ProviderStateDecorator

--- a/lib/pact_broker/api/decorators/provider_states_decorator.rb
+++ b/lib/pact_broker/api/decorators/provider_states_decorator.rb
@@ -26,7 +26,7 @@ module PactBroker
             end
 
             consumers_map.map do |(name, params), consumers|
-              { name: name, params: params, consumers: consumers.uniq.sort }.transform_keys(&:to_sym)
+              { name: name, params: params, consumers: consumers.uniq.sort }
             end
           .sort_by { |provider_state| provider_state[:name] }
         }, :extend => PactBroker::Api::Decorators::ProviderStateDecorator

--- a/lib/pact_broker/api/decorators/version_decorator.rb
+++ b/lib/pact_broker/api/decorators/version_decorator.rb
@@ -1,6 +1,7 @@
 require_relative "base_decorator"
 require_relative "embedded_tag_decorator"
 require_relative "embedded_branch_version_decorator"
+require_relative "format_date_time"
 
 module PactBroker
   module Api
@@ -85,7 +86,9 @@ module PactBroker
               title: "Version deployed to #{deployed_version.environment.display_name}",
               name: deployed_version.environment.display_name,
               href: deployed_version_url(deployed_version, context.fetch(:base_url)),
-              currently_deployed: deployed_version.currently_deployed
+              currently_deployed: deployed_version.currently_deployed,
+              deployed_at: FormatDateTime.call(deployed_version.created_at),
+              undeployed_at: FormatDateTime.call(deployed_version.undeployed_at)
             }.tap do |hash|
               hash[:application_instance] = deployed_version.application_instance unless deployed_version.application_instance.nil?
             end
@@ -104,7 +107,9 @@ module PactBroker
               title: "Version released to #{released_version.environment.display_name}",
               name: released_version.environment.display_name,
               href: released_version_url(released_version, context.fetch(:base_url)),
-              currently_supported: released_version.currently_supported
+              currently_supported: released_version.currently_supported,
+              released_at: FormatDateTime.call(released_version.created_at),
+              support_ended_at: FormatDateTime.call(released_version.support_ended_at)
             }
           end
         end

--- a/lib/pact_broker/api/resources/deployed_or_released_versions.rb
+++ b/lib/pact_broker/api/resources/deployed_or_released_versions.rb
@@ -51,15 +51,14 @@ module PactBroker
         end
 
         def version_ids
-          deployed_ids = PactBroker::Deployments::DeployedVersion
+          PactBroker::Deployments::DeployedVersion
             .for_pacticipant_name(pacticipant_name)
-            .select_map(:version_id)
-
-          released_ids = PactBroker::Deployments::ReleasedVersion
-            .for_pacticipant_name(pacticipant_name)
-            .select_map(:version_id)
-
-          (deployed_ids + released_ids).uniq
+            .select(:version_id)
+            .union(
+              PactBroker::Deployments::ReleasedVersion
+                .for_pacticipant_name(pacticipant_name)
+                .select(:version_id)
+            )
         end
 
         def deployed_versions

--- a/lib/pact_broker/api/resources/deployed_or_released_versions.rb
+++ b/lib/pact_broker/api/resources/deployed_or_released_versions.rb
@@ -1,0 +1,79 @@
+require "pact_broker/api/resources/base_resource"
+require "pact_broker/api/decorators/versions_decorator"
+require "pact_broker/api/resources/pagination_methods"
+
+module PactBroker
+  module Api
+    module Resources
+      class DeployedOrReleasedVersions < BaseResource
+        include PaginationMethods
+
+        def content_types_provided
+          [["application/hal+json", :to_json]]
+        end
+
+        def allowed_methods
+          ["GET", "OPTIONS"]
+        end
+
+        def malformed_request?
+          super || request.get? && validation_errors_for_schema?(schema, request.query)
+        end
+
+        def resource_exists?
+          !!pacticipant
+        end
+
+        def to_json
+          decorator_class(:versions_decorator).new(versions).to_json(
+            **decorator_options(
+              identifier_from_path.merge(
+                resource_title: "Versions of #{pacticipant_name} that have been deployed or released",
+                deployed_versions: deployed_versions,
+                released_versions: released_versions
+              )
+            )
+          )
+        end
+
+        def policy_name
+          :'versions::versions'
+        end
+
+        private
+
+        def versions
+          @versions ||= version_service.find_by_ids_in_reverse_order(
+            version_ids,
+            pagination_options,
+            decorator_class(:versions_decorator).eager_load_associations
+          )
+        end
+
+        def version_ids
+          deployed_ids = PactBroker::Deployments::DeployedVersion
+            .for_pacticipant_name(pacticipant_name)
+            .select_map(:version_id)
+
+          released_ids = PactBroker::Deployments::ReleasedVersion
+            .for_pacticipant_name(pacticipant_name)
+            .select_map(:version_id)
+
+          (deployed_ids + released_ids).uniq
+        end
+
+        def deployed_versions
+          @deployed_versions ||= deployed_version_service.find_deployed_versions_for_versions(versions)
+        end
+
+        def released_versions
+          @released_versions ||= released_version_service.find_released_versions_for_versions(versions)
+        end
+
+        def schema
+          PactBroker::Api::Contracts::PaginationQueryParamsSchema if request.get?
+        end
+      end
+    end
+  end
+end

--- a/pact_broker_oas.yaml
+++ b/pact_broker_oas.yaml
@@ -4,6 +4,45 @@ info:
   title: Pact Broker API
   description: The API for the Pact Broker application
 paths:
+  /pacticipants/{pacticipantName}/deployed-or-released/versions:
+    get:
+      summary: List all versions that have ever been deployed or released
+      description: >
+        Returns a paginated list of all versions of the specified pacticipant
+        that have ever been deployed to an environment or released. Each version
+        includes links to the environments it was deployed or released to, along
+        with deployment/release timestamps.
+      parameters:
+        - name: pacticipantName
+          in: path
+          required: true
+          description: The name of the pacticipant
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: The page number to return (1-based)
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: size
+          in: query
+          description: The number of results per page
+          schema:
+            type: integer
+            minimum: 1
+            default: 100
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/PaginatedVersionsResponse'
+        "404":
+          description: Pacticipant not found
+
   /contracts/publish:
     post:
       description: "Publish consumer contracts with branch, tags and build URL"
@@ -126,6 +165,156 @@ components:
           type: string
         templated:
           type: boolean
+
+    PageMetadata:
+      type: object
+      required:
+        - number
+        - size
+        - totalElements
+        - totalPages
+      properties:
+        number:
+          type: integer
+          description: The current page number (1-based)
+        size:
+          type: integer
+          description: The number of results per page
+        totalElements:
+          type: integer
+          description: The total number of results across all pages
+        totalPages:
+          type: integer
+          description: The total number of pages
+
+    DeployedEnvironmentLink:
+      type: object
+      required:
+        - href
+        - title
+        - name
+        - currently_deployed
+        - deployed_at
+      properties:
+        href:
+          type: string
+        title:
+          type: string
+        name:
+          type: string
+          description: The display name of the environment
+        currently_deployed:
+          type: boolean
+          description: Whether this deployment is still active
+        application_instance:
+          type: string
+          nullable: true
+          description: The application instance identifier, if applicable
+        deployed_at:
+          type: string
+          format: date-time
+          description: When the version was deployed
+        undeployed_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the version was undeployed, or null if still deployed
+
+    ReleasedEnvironmentLink:
+      type: object
+      required:
+        - href
+        - title
+        - name
+        - currently_supported
+        - released_at
+      properties:
+        href:
+          type: string
+        title:
+          type: string
+        name:
+          type: string
+          description: The display name of the environment
+        currently_supported:
+          type: boolean
+          description: Whether this release is still supported
+        released_at:
+          type: string
+          format: date-time
+          description: When the version was released
+        support_ended_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When support for this release ended, or null if still supported
+
+    EmbeddedVersion:
+      type: object
+      required:
+        - number
+        - createdAt
+        - _links
+      properties:
+        number:
+          type: string
+          description: The version number
+        buildUrl:
+          type: string
+          nullable: true
+          description: The URL of the build that produced this version
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        _links:
+          type: object
+          properties:
+            self:
+              $ref: '#/components/schemas/EmbeddedLink'
+            pb:pacticipant:
+              $ref: '#/components/schemas/EmbeddedLink'
+            pb:deployed-environments:
+              type: array
+              items:
+                $ref: '#/components/schemas/DeployedEnvironmentLink'
+            pb:released-environments:
+              type: array
+              items:
+                $ref: '#/components/schemas/ReleasedEnvironmentLink'
+
+    PaginatedVersionsResponse:
+      type: object
+      required:
+        - _embedded
+        - _links
+      properties:
+        page:
+          $ref: '#/components/schemas/PageMetadata'
+        _embedded:
+          type: object
+          required:
+            - versions
+          properties:
+            versions:
+              type: array
+              items:
+                $ref: '#/components/schemas/EmbeddedVersion'
+        _links:
+          type: object
+          required:
+            - self
+          properties:
+            self:
+              $ref: '#/components/schemas/EmbeddedLink'
+            pb:pacticipant:
+              $ref: '#/components/schemas/EmbeddedLink'
+            next:
+              $ref: '#/components/schemas/EmbeddedLink'
+            previous:
+              $ref: '#/components/schemas/EmbeddedLink'
 
     ConsumerContractToPublish:
       type: object

--- a/spec/features/get_deployed_or_released_versions_spec.rb
+++ b/spec/features/get_deployed_or_released_versions_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe "Get all versions that have ever been deployed or released", validate_oas: true do
+  let(:pacticipant) { td.create_consumer("Foo").and_return(:pacticipant) }
+  let(:environment) { td.create_environment("production").and_return(:environment) }
+  let(:path) { "/pacticipants/Foo/deployed-or-released/versions" }
+  let(:response_body_hash) { JSON.parse(subject.body, symbolize_names: true) }
+
+  subject { get(path, {}, { "HTTP_ACCEPT" => "application/hal+json" }) }
+
+  context "when the pacticipant does not exist" do
+    its(:status) { is_expected.to eq 404 }
+  end
+
+  context "when the pacticipant exists" do
+    before do
+      td.use_consumer(pacticipant.name)
+        .create_consumer_version("1")
+        .create_deployed_version_for_consumer_version(environment_name: environment.name, currently_deployed: true)
+        .create_consumer_version("2")
+        .create_released_version_for_consumer_version(environment_name: environment.name)
+    end
+
+    its(:status) { is_expected.to eq 200 }
+
+    it { is_expected.to be_a_hal_json_success_response }
+
+    it "returns all deployed and released versions" do
+      versions = response_body_hash.dig(:_embedded, :versions)
+      expect(versions.map { |v| v[:number] }).to match_array(["1", "2"])
+    end
+
+    it "includes deployment timestamps on deployed versions" do
+      versions = response_body_hash.dig(:_embedded, :versions)
+      deployed = versions.find { |v| v[:number] == "1" }
+      deployed_env = deployed.dig(:_links, :"pb:deployed-environments").first
+      expect(deployed_env[:deployed_at]).not_to be_nil
+      expect(deployed_env[:undeployed_at]).to be_nil
+    end
+
+    it "includes release timestamps on released versions" do
+      versions = response_body_hash.dig(:_embedded, :versions)
+      released = versions.find { |v| v[:number] == "2" }
+      released_env = released.dig(:_links, :"pb:released-environments").first
+      expect(released_env[:released_at]).not_to be_nil
+      expect(released_env[:support_ended_at]).to be_nil
+    end
+  end
+end

--- a/spec/lib/pact_broker/api/decorators/version_decorator_spec.rb
+++ b/spec/lib/pact_broker/api/decorators/version_decorator_spec.rb
@@ -116,42 +116,51 @@ module PactBroker
 
           context "when application is deployed to an env" do
             it "includes a link to the deployed environments for this version" do
+              entry = subject[:_links][:'pb:deployed-environments'].first
               expect(subject[:_links][:'pb:deployed-environments']).to be_instance_of(Array)
-              expect(subject[:_links][:'pb:deployed-environments'].first).to eq(
-                                                                               title: "Version deployed to Test",
-                                                                               name: "Test",
-                                                                               href: "http://example.org/deployed-versions/1234",
-                                                                               currently_deployed: true,
-                                                                               )
-              expect(subject[:_links][:'pb:deployed-environments'].first).to_not include(:application_instance)
+              expect(entry).to include(
+                title: "Version deployed to Test",
+                name: "Test",
+                href: "http://example.org/deployed-versions/1234",
+                currently_deployed: true,
+              )
+              expect(entry).to_not include(:application_instance)
+              expect(entry[:deployed_at]).to_not be_nil
+              expect(entry[:undeployed_at]).to be_nil
             end
 
             context "when deployed with application instance variable" do
               let(:target) { "instance-1" }
 
               it "includes a link to the deployed environments for this version along with application instance node" do
+                entry = subject[:_links][:'pb:deployed-environments'].first
                 expect(subject[:_links][:'pb:deployed-environments']).to be_instance_of(Array)
-                expect(subject[:_links][:'pb:deployed-environments'].first).to eq(
-                                                                                 title: "Version deployed to Test",
-                                                                                 name: "Test",
-                                                                                 href: "http://example.org/deployed-versions/1234",
-                                                                                 currently_deployed: true,
-                                                                                 application_instance: "instance-1",
-                                                                                 )
+                expect(entry).to include(
+                  title: "Version deployed to Test",
+                  name: "Test",
+                  href: "http://example.org/deployed-versions/1234",
+                  currently_deployed: true,
+                  application_instance: "instance-1",
+                )
+                expect(entry[:deployed_at]).to_not be_nil
+                expect(entry[:undeployed_at]).to be_nil
               end
             end
           end
 
           context "when application is released to an env" do
             it "includes a link to the released environments for this version" do
+              entry = subject[:_links][:'pb:released-environments'].first
               expect(subject[:_links][:'pb:released-environments']).to be_instance_of(Array)
-              expect(subject[:_links][:'pb:released-environments'].first).to eq(
-                                                                               title: "Version released to Test",
-                                                                               name: "Test",
-                                                                               href: "http://example.org/released-versions/5678",
-                                                                               currently_supported: true,
-                                                                               )
-              expect(subject[:_links][:'pb:released-environments'].first).to_not include(:application_instance)
+              expect(entry).to include(
+                title: "Version released to Test",
+                name: "Test",
+                href: "http://example.org/released-versions/5678",
+                currently_supported: true,
+              )
+              expect(entry).to_not include(:application_instance)
+              expect(entry[:released_at]).to_not be_nil
+              expect(entry[:support_ended_at]).to be_nil
             end
           end
 

--- a/spec/lib/pact_broker/api/resources/deployed_or_released_versions_spec.rb
+++ b/spec/lib/pact_broker/api/resources/deployed_or_released_versions_spec.rb
@@ -1,0 +1,132 @@
+require "pact_broker/api/resources/deployed_or_released_versions"
+
+module PactBroker
+  module Api
+    module Resources
+      describe DeployedOrReleasedVersions do
+        let(:path) { "/pacticipants/Foo/deployed-or-released/versions" }
+
+        describe "GET" do
+          let(:pacticipant) { td.create_consumer("Foo").and_return(:pacticipant) }
+          let(:other_pacticipant) { td.create_consumer("Bar").and_return(:pacticipant) }
+          let(:environment) { td.create_environment("production").and_return(:environment) }
+          let(:other_environment) { td.create_environment("staging").and_return(:environment) }
+          let(:version_1) { td.use_consumer(pacticipant.name).create_consumer_version("1").and_return(:consumer_version) }
+          let(:version_2) { td.use_consumer(pacticipant.name).create_consumer_version("2").and_return(:consumer_version) }
+
+          let(:deployed_version) do
+            td.use_consumer_version(version_1.number)
+              .create_deployed_version(uuid: "1111", currently_deployed: true, version: version_1, environment_name: environment.name)
+          end
+
+          let(:released_version) do
+            td.use_consumer_version(version_2.number)
+              .create_released_version_for_consumer_version(uuid: "2222", environment_name: environment.name)
+          end
+
+          context "when the pacticipant does not exist" do
+            subject { get("/pacticipants/Unknown/deployed-or-released/versions", nil, { "HTTP_ACCEPT" => "application/hal+json" }) }
+
+            its(:status) { is_expected.to eq 404 }
+          end
+
+          context "when the pacticipant exists but has no deployed or released versions" do
+            before { pacticipant }
+            subject { get(path, nil, { "HTTP_ACCEPT" => "application/hal+json" }) }
+
+            its(:status) { is_expected.to eq 200 }
+
+            it "returns an empty versions array" do
+              versions = JSON.parse(subject.body, symbolize_names: true).dig(:_embedded, :versions)
+              expect(versions).to eq []
+            end
+          end
+
+          context "when the pacticipant has deployed and released versions" do
+            before do
+              deployed_version
+              released_version
+            end
+            subject { get(path, nil, { "HTTP_ACCEPT" => "application/hal+json" }) }
+
+            its(:status) { is_expected.to eq 200 }
+
+            it "returns all versions that have ever been deployed or released" do
+              versions = JSON.parse(subject.body, symbolize_names: true).dig(:_embedded, :versions)
+              expect(versions.map { |v| v[:number] }).to match_array(["1", "2"])
+            end
+
+            it "contains the expected HAL structure" do
+              body = JSON.parse(subject.body, symbolize_names: true)
+              expect(body).to include(:_links, :_embedded)
+              expect(body[:_links]).to include(:self)
+            end
+          end
+
+          context "when a version has been both deployed and released" do
+            before do
+              deployed_version
+              td.use_consumer_version(version_1.number)
+                .create_released_version_for_consumer_version(uuid: "3333", environment_name: environment.name)
+            end
+            subject { get(path, nil, { "HTTP_ACCEPT" => "application/hal+json" }) }
+
+            it "returns the version only once" do
+              versions = JSON.parse(subject.body, symbolize_names: true).dig(:_embedded, :versions)
+              expect(versions.size).to eq 1
+              expect(versions.first[:number]).to eq "1"
+            end
+          end
+
+          context "when there are versions from another pacticipant" do
+            let(:other_version) { td.use_consumer(other_pacticipant.name).create_consumer_version("2").and_return(:consumer_version) }
+
+            before do
+              deployed_version
+              td.use_consumer_version(other_version.number)
+                .create_deployed_version(uuid: "9999", currently_deployed: true, version: other_version, environment_name: environment.name)
+            end
+            subject { get(path, nil, { "HTTP_ACCEPT" => "application/hal+json" }) }
+
+            it "only returns versions for the requested pacticipant" do
+              versions = JSON.parse(subject.body, symbolize_names: true).dig(:_embedded, :versions)
+              expect(versions.size).to eq 1
+              expect(versions.first[:number]).to eq "1"
+            end
+          end
+
+          context "pagination" do
+            let(:version_3) { td.use_consumer(pacticipant.name).create_consumer_version("3").and_return(:consumer_version) }
+            let(:deployed_version_2) do
+              td.use_consumer_version(version_2.number)
+                .create_deployed_version(uuid: "2222", currently_deployed: true, version: version_2, environment_name: environment.name)
+            end
+            let(:deployed_version_3) do
+              td.use_consumer_version(version_3.number)
+                .create_deployed_version(uuid: "3333", currently_deployed: true, version: version_3, environment_name: environment.name)
+            end
+
+            before do
+              deployed_version
+              deployed_version_2
+              deployed_version_3
+            end
+            subject { get("#{path}?page=1&size=2", nil, { "HTTP_ACCEPT" => "application/hal+json" }) }
+
+            its(:status) { is_expected.to eq 200 }
+
+            it "paginates the results" do
+              versions = JSON.parse(subject.body, symbolize_names: true).dig(:_embedded, :versions)
+              expect(versions.size).to eq 2
+            end
+
+            it "includes page metadata" do
+              body = JSON.parse(subject.body, symbolize_names: true)
+              expect(body[:page]).to include(number: 1, size: 2, totalElements: 3, totalPages: 2)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/pact_broker/api/resources/deployed_or_released_versions_spec.rb
+++ b/spec/lib/pact_broker/api/resources/deployed_or_released_versions_spec.rb
@@ -7,6 +7,7 @@ module PactBroker
         let(:path) { "/pacticipants/Foo/deployed-or-released/versions" }
 
         describe "GET" do
+          let(:response_body_hash) { JSON.parse(subject.body, symbolize_names: true) }
           let(:pacticipant) { td.create_consumer("Foo").and_return(:pacticipant) }
           let(:other_pacticipant) { td.create_consumer("Bar").and_return(:pacticipant) }
           let(:environment) { td.create_environment("production").and_return(:environment) }
@@ -37,7 +38,7 @@ module PactBroker
             its(:status) { is_expected.to eq 200 }
 
             it "returns an empty versions array" do
-              versions = JSON.parse(subject.body, symbolize_names: true).dig(:_embedded, :versions)
+              versions = response_body_hash.dig(:_embedded, :versions)
               expect(versions).to eq []
             end
           end
@@ -52,12 +53,12 @@ module PactBroker
             its(:status) { is_expected.to eq 200 }
 
             it "returns all versions that have ever been deployed or released" do
-              versions = JSON.parse(subject.body, symbolize_names: true).dig(:_embedded, :versions)
+              versions = response_body_hash.dig(:_embedded, :versions)
               expect(versions.map { |v| v[:number] }).to match_array(["1", "2"])
             end
 
             it "contains the expected HAL structure" do
-              body = JSON.parse(subject.body, symbolize_names: true)
+              body = response_body_hash
               expect(body).to include(:_links, :_embedded)
               expect(body[:_links]).to include(:self)
             end
@@ -72,7 +73,7 @@ module PactBroker
             subject { get(path, nil, { "HTTP_ACCEPT" => "application/hal+json" }) }
 
             it "returns the version only once" do
-              versions = JSON.parse(subject.body, symbolize_names: true).dig(:_embedded, :versions)
+              versions = response_body_hash.dig(:_embedded, :versions)
               expect(versions.size).to eq 1
               expect(versions.first[:number]).to eq "1"
             end
@@ -89,7 +90,7 @@ module PactBroker
             subject { get(path, nil, { "HTTP_ACCEPT" => "application/hal+json" }) }
 
             it "only returns versions for the requested pacticipant" do
-              versions = JSON.parse(subject.body, symbolize_names: true).dig(:_embedded, :versions)
+              versions = response_body_hash.dig(:_embedded, :versions)
               expect(versions.size).to eq 1
               expect(versions.first[:number]).to eq "1"
             end
@@ -116,12 +117,12 @@ module PactBroker
             its(:status) { is_expected.to eq 200 }
 
             it "paginates the results" do
-              versions = JSON.parse(subject.body, symbolize_names: true).dig(:_embedded, :versions)
+              versions = response_body_hash.dig(:_embedded, :versions)
               expect(versions.size).to eq 2
             end
 
             it "includes page metadata" do
-              body = JSON.parse(subject.body, symbolize_names: true)
+              body = response_body_hash
               expect(body[:page]).to include(number: 1, size: 2, totalElements: 3, totalPages: 2)
             end
           end


### PR DESCRIPTION
Add a new endpoint `/pacticipants/:name/deployed-or-released/versions` similar to `/pacticipants/:name/versions` (and others to filter by branch/environment/tag). This endpoint lists all versions that have ever been deployed or released.

Also updated the decorator to return `deployed_at`, `undeployed_at` for deployments and `released_at`, `support_ended_at` for releases.

I'm not sure if the names of the endpoint, and the additional fields are appropriate / follow existing conventions - there seems to be a mix of conventions in the code.